### PR TITLE
Deser fix for Update + pre-Alonzo blocks support

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -1900,9 +1900,9 @@ declare export class HeaderBody {
   block_number(): number;
 
   /**
-   * @returns {number}
+   * @returns {BigNum}
    */
-  slot(): number;
+  slot(): BigNum;
 
   /**
    * @returns {BlockHash | void}
@@ -1951,7 +1951,7 @@ declare export class HeaderBody {
 
   /**
    * @param {number} block_number
-   * @param {number} slot
+   * @param {BigNum} slot
    * @param {BlockHash | void} prev_hash
    * @param {Vkey} issuer_vkey
    * @param {VRFVKey} vrf_vkey
@@ -1965,7 +1965,7 @@ declare export class HeaderBody {
    */
   static new(
     block_number: number,
-    slot: number,
+    slot: BigNum,
     prev_hash: BlockHash | void,
     issuer_vkey: Vkey,
     vrf_vkey: VRFVKey,
@@ -3212,17 +3212,17 @@ declare export class Pointer {
   free(): void;
 
   /**
-   * @param {number} slot
+   * @param {BigNum} slot
    * @param {number} tx_index
    * @param {number} cert_index
    * @returns {Pointer}
    */
-  static new(slot: number, tx_index: number, cert_index: number): Pointer;
+  static new(slot: BigNum, tx_index: number, cert_index: number): Pointer;
 
   /**
-   * @returns {number}
+   * @returns {BigNum}
    */
-  slot(): number;
+  slot(): BigNum;
 
   /**
    * @returns {number}
@@ -3744,14 +3744,14 @@ declare export class ProtocolParamUpdate {
   extra_entropy(): Nonce | void;
 
   /**
-   * @param {ProtocolVersions} protocol_version
+   * @param {ProtocolVersion} protocol_version
    */
-  set_protocol_version(protocol_version: ProtocolVersions): void;
+  set_protocol_version(protocol_version: ProtocolVersion): void;
 
   /**
-   * @returns {ProtocolVersions | void}
+   * @returns {ProtocolVersion | void}
    */
-  protocol_version(): ProtocolVersions | void;
+  protocol_version(): ProtocolVersion | void;
 
   /**
    * @param {BigNum} min_pool_cost
@@ -3880,43 +3880,6 @@ declare export class ProtocolVersion {
    * @returns {ProtocolVersion}
    */
   static new(major: number, minor: number): ProtocolVersion;
-}
-/**
- */
-declare export class ProtocolVersions {
-  free(): void;
-
-  /**
-   * @returns {Uint8Array}
-   */
-  to_bytes(): Uint8Array;
-
-  /**
-   * @param {Uint8Array} bytes
-   * @returns {ProtocolVersions}
-   */
-  static from_bytes(bytes: Uint8Array): ProtocolVersions;
-
-  /**
-   * @returns {ProtocolVersions}
-   */
-  static new(): ProtocolVersions;
-
-  /**
-   * @returns {number}
-   */
-  len(): number;
-
-  /**
-   * @param {number} index
-   * @returns {ProtocolVersion}
-   */
-  get(index: number): ProtocolVersion;
-
-  /**
-   * @param {ProtocolVersion} elem
-   */
-  add(elem: ProtocolVersion): void;
 }
 /**
  * ED25519 key used as public key
@@ -4764,15 +4727,15 @@ declare export class TimelockExpiry {
   static from_bytes(bytes: Uint8Array): TimelockExpiry;
 
   /**
-   * @returns {number}
+   * @returns {BigNum}
    */
-  slot(): number;
+  slot(): BigNum;
 
   /**
-   * @param {number} slot
+   * @param {BigNum} slot
    * @returns {TimelockExpiry}
    */
-  static new(slot: number): TimelockExpiry;
+  static new(slot: BigNum): TimelockExpiry;
 }
 /**
  */
@@ -4791,15 +4754,15 @@ declare export class TimelockStart {
   static from_bytes(bytes: Uint8Array): TimelockStart;
 
   /**
-   * @returns {number}
+   * @returns {BigNum}
    */
-  slot(): number;
+  slot(): BigNum;
 
   /**
-   * @param {number} slot
+   * @param {BigNum} slot
    * @returns {TimelockStart}
    */
-  static new(slot: number): TimelockStart;
+  static new(slot: BigNum): TimelockStart;
 }
 /**
  */
@@ -4923,9 +4886,9 @@ declare export class TransactionBody {
   fee(): BigNum;
 
   /**
-   * @returns {number | void}
+   * @returns {BigNum | void}
    */
-  ttl(): number | void;
+  ttl(): BigNum | void;
 
   /**
    * @param {Certificates} certs
@@ -4968,14 +4931,14 @@ declare export class TransactionBody {
   auxiliary_data_hash(): AuxiliaryDataHash | void;
 
   /**
-   * @param {number} validity_start_interval
+   * @param {BigNum} validity_start_interval
    */
-  set_validity_start_interval(validity_start_interval: number): void;
+  set_validity_start_interval(validity_start_interval: BigNum): void;
 
   /**
-   * @returns {number | void}
+   * @returns {BigNum | void}
    */
-  validity_start_interval(): number | void;
+  validity_start_interval(): BigNum | void;
 
   /**
    * @param {Mint} mint
@@ -5038,14 +5001,14 @@ declare export class TransactionBody {
    * @param {TransactionInputs} inputs
    * @param {TransactionOutputs} outputs
    * @param {BigNum} fee
-   * @param {number | void} ttl
+   * @param {BigNum | void} ttl
    * @returns {TransactionBody}
    */
   static new(
     inputs: TransactionInputs,
     outputs: TransactionOutputs,
     fee: BigNum,
-    ttl?: number
+    ttl?: BigNum
   ): TransactionBody;
 }
 /**
@@ -5141,14 +5104,14 @@ declare export class TransactionBuilder {
   set_fee(fee: BigNum): void;
 
   /**
-   * @param {number} ttl
+   * @param {BigNum} ttl
    */
-  set_ttl(ttl: number): void;
+  set_ttl(ttl: BigNum): void;
 
   /**
-   * @param {number} validity_start_interval
+   * @param {BigNum} validity_start_interval
    */
-  set_validity_start_interval(validity_start_interval: number): void;
+  set_validity_start_interval(validity_start_interval: BigNum): void;
 
   /**
    * @param {Certificates} certs

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1920,32 +1920,6 @@ impl ProtocolVersion {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct ProtocolVersions(Vec<ProtocolVersion>);
-
-to_from_bytes!(ProtocolVersions);
-
-#[wasm_bindgen]
-impl ProtocolVersions {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn get(&self, index: usize) -> ProtocolVersion {
-        self.0[index].clone()
-    }
-
-    pub fn add(&mut self, elem: &ProtocolVersion) {
-        self.0.push(elem.clone());
-    }
-}
-
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ProtocolParamUpdate {
     minfee_a: Option<Coin>,
     minfee_b: Option<Coin>,
@@ -1963,7 +1937,7 @@ pub struct ProtocolParamUpdate {
     // decentralization constant
     d: Option<UnitInterval>,
     extra_entropy: Option<Nonce>,
-    protocol_version: Option<ProtocolVersions>,
+    protocol_version: Option<ProtocolVersion>,
     min_pool_cost: Option<Coin>,
     ada_per_utxo_byte: Option<Coin>,
     cost_models: Option<Costmdls>,
@@ -2091,11 +2065,11 @@ impl ProtocolParamUpdate {
         self.extra_entropy.clone()
     }
 
-    pub fn set_protocol_version(&mut self, protocol_version: &ProtocolVersions) {
+    pub fn set_protocol_version(&mut self, protocol_version: &ProtocolVersion) {
         self.protocol_version = Some(protocol_version.clone())
     }
 
-    pub fn protocol_version(&self) -> Option<ProtocolVersions> {
+    pub fn protocol_version(&self) -> Option<ProtocolVersion> {
         self.protocol_version.clone()
     }
 


### PR DESCRIPTION
Update's ProtocolVersion was generated as an array due to cddl-codegen
not supporting occurencies so it treated [protocol_version] as an array
rather than a single one as all other occurences of an array with a
single element were * occurences in the cddl.

As of Alozno, Blocks have a mandatory invalid_transactions field which
makes it one of the 2 non-backwards-compatible (the other being
transaction which we already support deserializing both) era changes to
the CDDL. This includes a fix for this by ignoring it if it's not
present.