### PR TITLE
Add as_ conversions to the Address struct

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -376,6 +376,31 @@ declare export class Address {
    * @returns {number}
    */
   network_id(): number;
+
+  /**
+   * @returns {ByronAddress | void}
+   */
+  as_byron(): ByronAddress | void;
+
+  /**
+   * @returns {RewardAddress | void}
+   */
+  as_reward(): RewardAddress | void;
+
+  /**
+   * @returns {PointerAddress | void}
+   */
+  as_pointer(): PointerAddress | void;
+
+  /**
+   * @returns {EnterpriseAddress | void}
+   */
+  as_enterprise(): EnterpriseAddress | void;
+
+  /**
+   * @returns {BaseAddress | void}
+   */
+  as_base(): BaseAddress | void;
 }
 /**
  */

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -469,6 +469,41 @@ impl Address {
             AddrType::Byron(a) => a.network_id(),
         }
     }
+
+    pub fn as_byron(&self) -> Option<ByronAddress> {
+        match &self.0 {
+            AddrType::Byron(a) => Some(a.clone()),
+            _ => None
+        }
+    }
+
+    pub fn as_reward(&self) -> Option<RewardAddress> {
+        match &self.0 {
+            AddrType::Reward(a) => Some(a.clone()),
+            _ => None
+        }
+    }
+
+    pub fn as_pointer(&self) -> Option<PointerAddress> {
+        match &self.0 {
+            AddrType::Ptr(a) => Some(a.clone()),
+            _ => None
+        }
+    }
+
+    pub fn as_enterprise(&self) -> Option<EnterpriseAddress> {
+        match &self.0 {
+            AddrType::Enterprise(a) => Some(a.clone()),
+            _ => None
+        }
+    }
+
+    pub fn as_base(&self) -> Option<BaseAddress> {
+        match &self.0 {
+            AddrType::Base(a) => Some(a.clone()),
+            _ => None
+        }
+    }
 }
 
 impl cbor_event::se::Serialize for Address {


### PR DESCRIPTION
Currently you can convert between address types doing, for example, `RewardAddress.from_address(...)`

A design philosophy during the CSL days was there should only be one way to do this. This was to avoid duplication of work when converting Yoroi code to Yoroi Mobile code which required native bindings.

However, this limitation is no longer required so we should add useful helper functions like this