### PR TITLE
Slot/TransactionIndex/CertificateIndex changes

### DIFF
--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -605,22 +605,22 @@ declare export class AuxiliaryDataSet {
   len(): number;
 
   /**
-   * @param {number} tx_index
+   * @param {BigNum} tx_index
    * @param {AuxiliaryData} data
    * @returns {AuxiliaryData | void}
    */
-  insert(tx_index: number, data: AuxiliaryData): AuxiliaryData | void;
+  insert(tx_index: BigNum, data: AuxiliaryData): AuxiliaryData | void;
 
   /**
-   * @param {number} tx_index
+   * @param {BigNum} tx_index
    * @returns {AuxiliaryData | void}
    */
-  get(tx_index: number): AuxiliaryData | void;
+  get(tx_index: BigNum): AuxiliaryData | void;
 
   /**
-   * @returns {Uint32Array}
+   * @returns {TransactionIndexes}
    */
-  indices(): Uint32Array;
+  indices(): TransactionIndexes;
 }
 /**
  */
@@ -964,16 +964,16 @@ declare export class Block {
   auxiliary_data_set(): AuxiliaryDataSet;
 
   /**
-   * @returns {Uint32Array}
+   * @returns {TransactionIndexes}
    */
-  invalid_transactions(): Uint32Array;
+  invalid_transactions(): TransactionIndexes;
 
   /**
    * @param {Header} header
    * @param {TransactionBodies} transaction_bodies
    * @param {TransactionWitnessSets} transaction_witness_sets
    * @param {AuxiliaryDataSet} auxiliary_data_set
-   * @param {Uint32Array} invalid_transactions
+   * @param {TransactionIndexes} invalid_transactions
    * @returns {Block}
    */
   static new(
@@ -981,7 +981,7 @@ declare export class Block {
     transaction_bodies: TransactionBodies,
     transaction_witness_sets: TransactionWitnessSets,
     auxiliary_data_set: AuxiliaryDataSet,
-    invalid_transactions: Uint32Array
+    invalid_transactions: TransactionIndexes
   ): Block;
 }
 /**
@@ -3253,11 +3253,11 @@ declare export class Pointer {
 
   /**
    * @param {BigNum} slot
-   * @param {number} tx_index
-   * @param {number} cert_index
+   * @param {BigNum} tx_index
+   * @param {BigNum} cert_index
    * @returns {Pointer}
    */
-  static new(slot: BigNum, tx_index: number, cert_index: number): Pointer;
+  static new(slot: BigNum, tx_index: BigNum, cert_index: BigNum): Pointer;
 
   /**
    * @returns {BigNum}
@@ -3265,14 +3265,14 @@ declare export class Pointer {
   slot(): BigNum;
 
   /**
-   * @returns {number}
+   * @returns {BigNum}
    */
-  tx_index(): number;
+  tx_index(): BigNum;
 
   /**
-   * @returns {number}
+   * @returns {BigNum}
    */
-  cert_index(): number;
+  cert_index(): BigNum;
 }
 /**
  */
@@ -5585,6 +5585,43 @@ declare export class TransactionHash {
 }
 /**
  */
+declare export class TransactionIndexes {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {TransactionIndexes}
+   */
+  static from_bytes(bytes: Uint8Array): TransactionIndexes;
+
+  /**
+   * @returns {TransactionIndexes}
+   */
+  static new(): TransactionIndexes;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {number} index
+   * @returns {BigNum}
+   */
+  get(index: number): BigNum;
+
+  /**
+   * @param {BigNum} elem
+   */
+  add(elem: BigNum): void;
+}
+/**
+ */
 declare export class TransactionInput {
   free(): void;
 
@@ -5605,16 +5642,16 @@ declare export class TransactionInput {
   transaction_id(): TransactionHash;
 
   /**
-   * @returns {number}
+   * @returns {BigNum}
    */
-  index(): number;
+  index(): BigNum;
 
   /**
    * @param {TransactionHash} transaction_id
-   * @param {number} index
+   * @param {BigNum} index
    * @returns {TransactionInput}
    */
-  static new(transaction_id: TransactionHash, index: number): TransactionInput;
+  static new(transaction_id: TransactionHash, index: BigNum): TransactionInput;
 }
 /**
  */

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -646,14 +646,14 @@ impl Deserialize for RewardAddress {
 #[wasm_bindgen]
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Pointer {
-    slot: BigNum,
-    tx_index: BigNum,
-    cert_index: BigNum,
+    slot: Slot,
+    tx_index: TransactionIndex,
+    cert_index: CertificateIndex,
 }
 
 #[wasm_bindgen]
 impl Pointer {
-    pub fn new(slot: &BigNum, tx_index: &BigNum, cert_index: &BigNum) -> Self {
+    pub fn new(slot: &Slot, tx_index: &TransactionIndex, cert_index: &CertificateIndex) -> Self {
         Self {
             slot: slot.clone(),
             tx_index: tx_index.clone(),
@@ -661,15 +661,15 @@ impl Pointer {
         }
     }
 
-    pub fn slot(&self) -> BigNum {
+    pub fn slot(&self) -> Slot {
         self.slot.clone()
     }
 
-    pub fn tx_index(&self) -> BigNum {
+    pub fn tx_index(&self) -> TransactionIndex {
         self.tx_index.clone()
     }
 
-    pub fn cert_index(&self) -> BigNum {
+    pub fn cert_index(&self) -> CertificateIndex {
         self.cert_index.clone()
     }
 }

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -51,7 +51,7 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(
             &TransactionHash::from_bytes(hex::decode("3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7").unwrap()).unwrap(),
-            0
+            &0.into()
         ));
         let mut outputs = TransactionOutputs::new();
 
@@ -99,7 +99,7 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(
             &TransactionHash::from_bytes(hex::decode("3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7").unwrap()).unwrap(),
-            0
+            &0.into()
         ));
         let mut outputs = TransactionOutputs::new();
 
@@ -153,7 +153,7 @@ mod tests {
                     .unwrap(),
             )
             .unwrap(),
-            42,
+            &42.into(),
         ));
         inputs.add(&TransactionInput::new(
             &TransactionHash::from_bytes(
@@ -161,7 +161,7 @@ mod tests {
                     .unwrap(),
             )
             .unwrap(),
-            7,
+            &7.into(),
         ));
         let mut outputs = TransactionOutputs::new();
 
@@ -226,7 +226,7 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(
             &TransactionHash::from_bytes(hex::decode("3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7").unwrap()).unwrap(),
-            0
+            &0.into()
         ));
         let mut outputs = TransactionOutputs::new();
 
@@ -459,7 +459,7 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(
             &TransactionHash::from_bytes(hex::decode("3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7").unwrap()).unwrap(),
-            0
+            &0.into()
         ));
         let mut outputs = TransactionOutputs::new();
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -146,9 +146,9 @@ impl Transaction {
 }
 
 // index of a tx within a block
-type TransactionIndex = u32;
+type TransactionIndex = BigNum;
 // index of a cert within a tx
-type CertificateIndex = u32;
+type CertificateIndex = BigNum;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -299,8 +299,8 @@ impl TransactionBody {
         self.auxiliary_data_hash.clone()
     }
 
-    pub fn set_validity_start_interval(&mut self, validity_start_interval: Slot) {
-        self.validity_start_interval = Some(validity_start_interval)
+    pub fn set_validity_start_interval(&mut self, validity_start_interval: &Slot) {
+        self.validity_start_interval = Some(validity_start_interval.clone())
     }
 
     pub fn validity_start_interval(&self) -> Option<Slot> {
@@ -400,10 +400,10 @@ impl TransactionInput {
         self.index.clone()
     }
 
-    pub fn new(transaction_id: &TransactionHash, index: TransactionIndex) -> Self {
+    pub fn new(transaction_id: &TransactionHash, index: &TransactionIndex) -> Self {
         Self {
             transaction_id: transaction_id.clone(),
-            index: index,
+            index: index.clone(),
         }
     }
 }
@@ -1574,9 +1574,9 @@ impl TimelockStart {
         self.slot
     }
 
-    pub fn new(slot: Slot) -> Self {
+    pub fn new(slot: &Slot) -> Self {
         Self {
-            slot,
+            slot: slot.clone(),
         }
     }
 }
@@ -1595,9 +1595,9 @@ impl TimelockExpiry {
         self.slot
     }
 
-    pub fn new(slot: Slot) -> Self {
+    pub fn new(slot: &Slot) -> Self {
         Self {
-            slot,
+            slot: slot.clone(),
         }
     }
 }
@@ -2211,7 +2211,30 @@ impl TransactionWitnessSets {
     }
 }
 
-pub type TransactionIndexes = Vec<TransactionIndex>;
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct TransactionIndexes(Vec<TransactionIndex>);
+
+to_from_bytes!(TransactionIndexes);
+
+#[wasm_bindgen]
+impl TransactionIndexes {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionIndex {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &TransactionIndex) {
+        self.0.push(elem.clone());
+    }
+}
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -2227,16 +2250,16 @@ impl AuxiliaryDataSet {
         self.0.len()
     }
 
-    pub fn insert(&mut self, tx_index: TransactionIndex, data: &AuxiliaryData) -> Option<AuxiliaryData> {
-        self.0.insert(tx_index, data.clone())
+    pub fn insert(&mut self, tx_index: &TransactionIndex, data: &AuxiliaryData) -> Option<AuxiliaryData> {
+        self.0.insert(tx_index.clone(), data.clone())
     }
 
-    pub fn get(&self, tx_index: TransactionIndex) -> Option<AuxiliaryData> {
-        self.0.get(&tx_index).map(|v| v.clone())
+    pub fn get(&self, tx_index: &TransactionIndex) -> Option<AuxiliaryData> {
+        self.0.get(tx_index).map(|v| v.clone())
     }
 
     pub fn indices(&self) -> TransactionIndexes {
-        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<TransactionIndex>>()
+        TransactionIndexes(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<TransactionIndex>>())
     }
 }
 
@@ -2274,13 +2297,13 @@ impl Block {
         self.invalid_transactions.clone()
     }
 
-    pub fn new(header: &Header, transaction_bodies: &TransactionBodies, transaction_witness_sets: &TransactionWitnessSets, auxiliary_data_set: &AuxiliaryDataSet, invalid_transactions: TransactionIndexes) -> Self {
+    pub fn new(header: &Header, transaction_bodies: &TransactionBodies, transaction_witness_sets: &TransactionWitnessSets, auxiliary_data_set: &AuxiliaryDataSet, invalid_transactions: &TransactionIndexes) -> Self {
         Self {
             header: header.clone(),
             transaction_bodies: transaction_bodies.clone(),
             transaction_witness_sets: transaction_witness_sets.clone(),
             auxiliary_data_set: auxiliary_data_set.clone(),
-            invalid_transactions: invalid_transactions,
+            invalid_transactions: invalid_transactions.clone(),
         }
     }
 }
@@ -2415,10 +2438,10 @@ impl HeaderBody {
         self.protocol_version.clone()
     }
 
-    pub fn new(block_number: u32, slot: Slot, prev_hash: Option<BlockHash>, issuer_vkey: &Vkey, vrf_vkey: &VRFVKey, nonce_vrf: &VRFCert, leader_vrf: &VRFCert, block_body_size: u32, block_body_hash: &BlockHash, operational_cert: &OperationalCert, protocol_version: &ProtocolVersion) -> Self {
+    pub fn new(block_number: u32, slot: &Slot, prev_hash: Option<BlockHash>, issuer_vkey: &Vkey, vrf_vkey: &VRFVKey, nonce_vrf: &VRFCert, leader_vrf: &VRFCert, block_body_size: u32, block_body_hash: &BlockHash, operational_cert: &OperationalCert, protocol_version: &ProtocolVersion) -> Self {
         Self {
             block_number: block_number,
-            slot: slot,
+            slot: slot.clone(),
             prev_hash: prev_hash.clone(),
             issuer_vkey: issuer_vkey.clone(),
             vrf_vkey: vrf_vkey.clone(),
@@ -3029,7 +3052,7 @@ mod tests {
 
         let pks2 = RequiredSignersSet::from(
             &NativeScript::new_timelock_start(
-                &TimelockStart::new(123.into()),
+                &TimelockStart::new(&123.into()),
             ),
         );
         assert_eq!(pks2.len(), 0);
@@ -3052,13 +3075,13 @@ mod tests {
                     &NativeScript::new_script_n_of_k(&ScriptNOfK::new(
                         1,
                         &scripts_vec(vec![
-                            &NativeScript::new_timelock_start(&TimelockStart::new(132.into())),
+                            &NativeScript::new_timelock_start(&TimelockStart::new(&132.into())),
                             &pkscript(&keyhash3),
                         ]),
                     )),
                     &NativeScript::new_script_all(&ScriptAll::new(
                         &scripts_vec(vec![
-                            &NativeScript::new_timelock_expiry(&TimelockExpiry::new(132.into())),
+                            &NativeScript::new_timelock_expiry(&TimelockExpiry::new(&132.into())),
                             &pkscript(&keyhash1),
                         ]),
                     )),

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -1060,7 +1060,7 @@ mod tests {
         assert_eq!(aux_data.to_bytes(), ad1_deser.to_bytes());
         // mary shelley
         let mut native_scripts = NativeScripts::new();
-        native_scripts.add(&NativeScript::new_timelock_start(&TimelockStart::new(20.into())));
+        native_scripts.add(&NativeScript::new_timelock_start(&TimelockStart::new(&20.into())));
         aux_data.set_native_scripts(&native_scripts);
         let ad2_deser = AuxiliaryData::from_bytes(aux_data.to_bytes()).unwrap();
         assert_eq!(aux_data.to_bytes(), ad2_deser.to_bytes());

--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -1256,13 +1256,13 @@ mod tests {
         );
         let constr_0_hash = hex::encode(hash_plutus_data(&constr_0).to_bytes());
         assert_eq!(constr_0_hash, "923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec");
-        let constr_0_roundtrip = PlutusData::from_bytes(constr_0.to_bytes()).unwrap();
+        let _constr_0_roundtrip = PlutusData::from_bytes(constr_0.to_bytes()).unwrap();
         // TODO: do we want semantic equality or bytewise equality?
         //assert_eq!(constr_0, constr_0_roundtrip);
         let constr_1854 = PlutusData::new_constr_plutus_data(
             &ConstrPlutusData::new(&to_bignum(1854), &PlutusList::new())
         );
-        let constr_1854_roundtrip = PlutusData::from_bytes(constr_1854.to_bytes()).unwrap();
+        let _constr_1854_roundtrip = PlutusData::from_bytes(constr_1854.to_bytes()).unwrap();
         //assert_eq!(constr_1854, constr_1854_roundtrip);
     }
 
@@ -1318,7 +1318,7 @@ mod tests {
             32, 150000, 32, 3345831, 1, 1,
         ];
         let cm = arr.iter().fold((CostModel::new(), 0), |(mut cm, i), x| {
-            cm.set(i, &Int::new_i32(x.clone()));
+            cm.set(i, &Int::new_i32(x.clone())).unwrap();
             (cm, i + 1)
         }).0;
         let mut cms = Costmdls::new();

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -690,12 +690,12 @@ impl TransactionBuilder {
         self.fee = Some(fee.clone())
     }
 
-    pub fn set_ttl(&mut self, ttl: Slot) {
-        self.ttl = Some(ttl)
+    pub fn set_ttl(&mut self, ttl: &Slot) {
+        self.ttl = Some(ttl.clone())
     }
 
-    pub fn set_validity_start_interval(&mut self, validity_start_interval: Slot) {
-        self.validity_start_interval = Some(validity_start_interval)
+    pub fn set_validity_start_interval(&mut self, validity_start_interval: &Slot) {
+        self.validity_start_interval = Some(validity_start_interval.clone())
     }
 
     pub fn set_certs(&mut self, certs: &Certificates) {
@@ -1459,7 +1459,7 @@ mod tests {
         let addr_net_0 = BaseAddress::new(NetworkInfo::testnet().network_id(), &spend_cred, &stake_cred).to_address();
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_output(
@@ -1469,7 +1469,7 @@ mod tests {
                 .with_coin(&to_bignum(29))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(1000.into());
+        tx_builder.set_ttl(&1000.into());
 
         let change_cred = StakeCredential::from_keyhash(&change_key.to_raw_key().hash());
         let change_addr = BaseAddress::new(NetworkInfo::testnet().network_id(), &change_cred, &stake_cred).to_address();
@@ -1517,7 +1517,7 @@ mod tests {
         let addr_net_0 = BaseAddress::new(NetworkInfo::testnet().network_id(), &spend_cred, &stake_cred).to_address();
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_output(
@@ -1527,7 +1527,7 @@ mod tests {
                 .with_coin(&to_bignum(880_000))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(1000.into());
+        tx_builder.set_ttl(&1000.into());
 
         let change_cred = StakeCredential::from_keyhash(&change_key.to_raw_key().hash());
         let change_addr = BaseAddress::new(NetworkInfo::testnet().network_id(), &change_cred, &stake_cred).to_address();
@@ -1571,10 +1571,10 @@ mod tests {
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(5_000_000))
         );
-        tx_builder.set_ttl(1000.into());
+        tx_builder.set_ttl(&1000.into());
 
         let mut certs = Certificates::new();
         certs.add(&Certificate::new_stake_registration(&StakeRegistration::new(&stake_cred)));
@@ -1630,7 +1630,7 @@ mod tests {
             .to_public();
         tx_builder.add_key_input(
             &&spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(100))
         );
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
@@ -1643,7 +1643,7 @@ mod tests {
                 .with_coin(&to_bignum(100))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(0.into());
+        tx_builder.set_ttl(&0.into());
 
         let change_cred = StakeCredential::from_keyhash(&change_key.to_raw_key().hash());
         let change_addr = BaseAddress::new(NetworkInfo::testnet().network_id(), &change_cred, &stake_cred).to_address();
@@ -1682,7 +1682,7 @@ mod tests {
             .to_public();
         tx_builder.add_key_input(
             &&spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(58))
         );
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
@@ -1700,7 +1700,7 @@ mod tests {
                 .with_coin(&to_bignum(29))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(0.into());
+        tx_builder.set_ttl(&0.into());
 
         let change_cred = StakeCredential::from_keyhash(&change_key.to_raw_key().hash());
         let change_addr = BaseAddress::new(NetworkInfo::testnet().network_id(), &change_cred, &stake_cred).to_address();
@@ -1741,7 +1741,7 @@ mod tests {
             .to_public();
         tx_builder.add_key_input(
             &&spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(5)),
         );
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
@@ -1759,7 +1759,7 @@ mod tests {
                 .with_coin(&to_bignum(5))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(0.into());
+        tx_builder.set_ttl(&0.into());
 
         // add a cert which requires a deposit
         let mut certs = Certificates::new();
@@ -1806,7 +1806,7 @@ mod tests {
                     NetworkInfo::testnet().network_id(),
                     &spend_cred
                 ).to_address(),
-                &TransactionInput::new(&genesis_id(), 0),
+                &TransactionInput::new(&genesis_id(), &0.into()),
                 &Value::new(&to_bignum(1_000_000))
             ).unwrap().to_str(), "69500");
             tx_builder.add_input(
@@ -1814,7 +1814,7 @@ mod tests {
                     NetworkInfo::testnet().network_id(),
                     &spend_cred
                 ).to_address(),
-                &TransactionInput::new(&genesis_id(), 0),
+                &TransactionInput::new(&genesis_id(), &0.into()),
                 &Value::new(&to_bignum(1_000_000))
             );
         }
@@ -1824,7 +1824,7 @@ mod tests {
                 &spend_cred,
                 &stake_cred
             ).to_address(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_input(
@@ -1837,14 +1837,14 @@ mod tests {
                     &to_bignum(0)
                 )
             ).to_address(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_input(
             &ByronAddress::icarus_from_key(
                 &spend, NetworkInfo::testnet().protocol_magic()
             ).to_address(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
 
@@ -1885,7 +1885,7 @@ mod tests {
                 NetworkInfo::testnet().network_id(),
                 &spend_cred
             ).to_address(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(150))
         );
 
@@ -1972,7 +1972,7 @@ mod tests {
                 NetworkInfo::testnet().network_id(),
                 &spend_cred
             ).to_address(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(150))
         );
 
@@ -2088,7 +2088,7 @@ mod tests {
 
             tx_builder.add_key_input(
                 &&spend.to_raw_key().hash(),
-                &TransactionInput::new(&genesis_id(), 0),
+                &TransactionInput::new(&genesis_id(), &0.into()),
                 &input_amount,
             );
         }
@@ -2201,7 +2201,7 @@ mod tests {
 
             tx_builder.add_key_input(
                 &&spend.to_raw_key().hash(),
-                &TransactionInput::new(&genesis_id(), 0),
+                &TransactionInput::new(&genesis_id(), &0.into()),
                 &input_amount,
             );
         }
@@ -2331,7 +2331,7 @@ mod tests {
 
             tx_builder.add_key_input(
                 &&spend.to_raw_key().hash(),
-                &TransactionInput::new(&genesis_id(), 0),
+                &TransactionInput::new(&genesis_id(), &0.into()),
                 &input_amount,
             );
         }
@@ -2437,7 +2437,7 @@ mod tests {
         input_amount.set_multiasset(&input_multiasset);
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &input_amount
         );
 
@@ -2448,7 +2448,7 @@ mod tests {
                 .with_coin(&to_bignum(880_000))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(1000.into());
+        tx_builder.set_ttl(&1000.into());
 
         let change_cred = StakeCredential::from_keyhash(&change_key.to_raw_key().hash());
         let change_addr = BaseAddress::new(NetworkInfo::testnet().network_id(), &change_cred, &stake_cred).to_address();
@@ -2482,12 +2482,12 @@ mod tests {
             &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
             &TransactionInput::new(
                 &genesis_id(),
-                0
+                &0.into()
             ),
             &Value::new(&to_bignum(2_400_000))
         );
 
-        tx_builder.set_ttl(1.into());
+        tx_builder.set_ttl(&1.into());
 
         let change_addr = ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap();
         let added_change = tx_builder.add_change_if_needed(
@@ -2521,12 +2521,12 @@ mod tests {
             &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
             &TransactionInput::new(
                 &genesis_id(),
-                0
+                &0.into()
             ),
             &input_value
         );
 
-        tx_builder.set_ttl(1.into());
+        tx_builder.set_ttl(&1.into());
 
         let change_addr = ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap();
         let added_change = tx_builder.add_change_if_needed(
@@ -2562,7 +2562,7 @@ mod tests {
             &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
             &TransactionInput::new(
                 &genesis_id(),
-                0
+                &0.into()
             ),
             &input_amount
         );
@@ -2586,7 +2586,7 @@ mod tests {
                 .build().unwrap()
             ).unwrap();
 
-        tx_builder.set_ttl(1.into());
+        tx_builder.set_ttl(&1.into());
 
         let change_addr = ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap();
         let added_change = tx_builder.add_change_if_needed(
@@ -2645,7 +2645,7 @@ mod tests {
             &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
             &TransactionInput::new(
                 &genesis_id(),
-                0
+                &0.into()
             ),
             &input_value
         );
@@ -2695,7 +2695,7 @@ mod tests {
             &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
             &TransactionInput::new(
                 &genesis_id(),
-                0
+                &0.into()
             ),
             &Value::new(&to_bignum(500))
         );
@@ -2750,7 +2750,7 @@ mod tests {
             &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
             &TransactionInput::new(
                 &genesis_id(),
-                0
+                &0.into()
             ),
             &input_value
         );
@@ -2773,7 +2773,7 @@ mod tests {
 
     fn make_input(input_hash_byte: u8, value: Value) -> TransactionUnspentOutput {
         TransactionUnspentOutput::new(
-            &TransactionInput::new(&TransactionHash::from([input_hash_byte; 32]), 0),
+            &TransactionInput::new(&TransactionHash::from([input_hash_byte; 32]), &0.into()),
             &TransactionOutputBuilder::new()
                 .with_address(&Address::from_bech32("addr1vyy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqs6l44z").unwrap())
                 .next().unwrap()
@@ -2848,7 +2848,6 @@ mod tests {
     #[test]
     fn tx_builder_cip2_largest_first_multiasset() {
         // we have a = 0 so we know adding inputs/outputs doesn't change the fee so we can analyze more
-        let linear_fee = LinearFee::new(&to_bignum(0), &to_bignum(0));
         let mut tx_builder = create_tx_builder_with_fee(&create_linear_fee(0, 0));
         let pid1 = PolicyID::from([1u8; 28]);
         let pid2 = PolicyID::from([2u8; 28]);
@@ -3179,7 +3178,7 @@ mod tests {
 
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_output(
@@ -3189,7 +3188,7 @@ mod tests {
                 .with_coin(&to_bignum(999_000))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(1000.into());
+        tx_builder.set_ttl(&1000.into());
         tx_builder.set_fee(&to_bignum(1_000));
 
         assert_eq!(tx_builder.outputs.len(),1);
@@ -3250,7 +3249,7 @@ mod tests {
 
         tx_builder.add_input(
             &addr_multisig,
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
 
@@ -3261,7 +3260,7 @@ mod tests {
                 .with_coin(&to_bignum(999_000))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(1000.into());
+        tx_builder.set_ttl(&1000.into());
         tx_builder.set_fee(&to_bignum(1_000));
 
         let mut auxiliary_data = AuxiliaryData::new();
@@ -3312,7 +3311,7 @@ mod tests {
         let addr_net_0 = BaseAddress::new(NetworkInfo::testnet().network_id(), &spend_cred, &stake_cred).to_address();
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_output(
@@ -3322,7 +3321,7 @@ mod tests {
                 .with_coin(&to_bignum(999_000))
                 .build().unwrap()
             ).unwrap();
-        tx_builder.set_ttl(1000.into());
+        tx_builder.set_ttl(&1000.into());
         tx_builder.set_fee(&to_bignum(1_000));
 
         let mut auxiliary_data = AuxiliaryData::new();
@@ -3401,7 +3400,7 @@ mod tests {
             &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
             &TransactionInput::new(
                 &genesis_id(),
-                0
+                &0.into()
             ),
             &input_value
         );
@@ -3479,7 +3478,7 @@ mod tests {
         let mut nats = NativeScripts::new();
         nats.add(
             &NativeScript::new_timelock_start(
-                &TimelockStart::new(123.into()),
+                &TimelockStart::new(&123.into()),
             ),
         );
         aux.set_native_scripts(&nats);
@@ -3994,14 +3993,14 @@ mod tests {
         // One input from unrelated address
         tx_builder.add_key_input(
             &hash0,
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(10_000_000)),
         );
 
         // One input from same address as mint
         tx_builder.add_key_input(
             &hash1,
-            &TransactionInput::new(&genesis_id(), 0),
+            &TransactionInput::new(&genesis_id(), &0.into()),
             &Value::new(&to_bignum(10_000_000)),
         );
 
@@ -4168,7 +4167,7 @@ mod tests {
 
             tx_builder.add_key_input(
                 &&spend.to_raw_key().hash(),
-                &TransactionInput::new(&genesis_id(), 0),
+                &TransactionInput::new(&genesis_id(), &0.into()),
                 &input_amount,
             );
         }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1279,7 +1279,7 @@ fn encode_template_to_native_script(
         serde_json::Value::Object(map) if map.contains_key("active_from") => {
             if let serde_json::Value::Number(active_from) = map.get("active_from").unwrap() {
                 if let Some(slot) = active_from.as_u64() {
-                    let time_lock_start = TimelockStart::new(slot.into());
+                    let time_lock_start = TimelockStart::new(&slot.into());
 
                     Ok(NativeScript::new_timelock_start(&time_lock_start))
                 } else {
@@ -1294,7 +1294,7 @@ fn encode_template_to_native_script(
         serde_json::Value::Object(map) if map.contains_key("active_until") => {
             if let serde_json::Value::Number(active_until) = map.get("active_until").unwrap() {
                 if let Some(slot) = active_until.as_u64() {
-                    let time_lock_expiry = TimelockExpiry::new(slot.into());
+                    let time_lock_expiry = TimelockExpiry::new(&slot.into());
 
                     Ok(NativeScript::new_timelock_expiry(&time_lock_expiry))
                 } else {

--- a/rust/src/witness_builder.rs
+++ b/rust/src/witness_builder.rs
@@ -358,14 +358,14 @@ mod tests {
 
         // add the same element twice
         let wit1 = NativeScript::new_timelock_start(
-            &TimelockStart::new(BigNum::from(1)),
+            &TimelockStart::new(&1.into()),
         );
         builder.add_native_script(&wit1);
         builder.add_native_script(&wit1);
 
         // add a different element
         builder.add_native_script(&NativeScript::new_timelock_start(
-            &TimelockStart::new(BigNum::from(2)),
+            &TimelockStart::new(&2.into()),
         ));
 
         let wit_set = builder.build().unwrap();
@@ -384,7 +384,7 @@ mod tests {
         let mut required_wits = RequiredWitnessSet::new();
         required_wits.add_vkey_key(&Vkey::new(&fake_raw_key_public(0)));
         required_wits.add_native_script(&NativeScript::new_timelock_start(
-            &TimelockStart::new(BigNum::from(2)),
+            &TimelockStart::new(&2.into()),
         ));
         builder.add_required_wits(&required_wits);
 


### PR DESCRIPTION
When `Slot` was changed to `BigNum`, it wasn't updated for wasm-suitable
API in every location (still taken by value in some spots), so this
includes fixes for that.

Also updates the changes in #33 to work with the global `Slot` change
that was done prior.

`TransactionIndex` and `CertificateIndex` were globablly changed to
`BigNum` for consistency and because we'll likely run into those
on-chain if they are already there inside of pointer addresses.

There still remains other uses of `u32`, especially in lower priority
structures like block headers and updates. Those should be fine for now
as we might end up removing `BigNum` soon anyway, and those are not as
succeptible to random users posting them on-chain.

Warning in tests were fixed as well.