### PR TITLE
Clippy fixes part 1

### DIFF
--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -815,10 +815,10 @@ declare export class BigInt {
   as_int(): Int | void;
 
   /**
-   * @param {string} text
+   * @param {string} string
    * @returns {BigInt}
    */
-  static from_str(text: string): BigInt;
+  static from_str(string: string): BigInt;
 
   /**
    * @returns {string}
@@ -7134,6 +7134,11 @@ declare export class TransactionUnspentOutputs {
    * @returns {TransactionUnspentOutputs}
    */
   static new(): TransactionUnspentOutputs;
+
+  /**
+   * @returns {boolean}
+   */
+  is_empty(): boolean;
 
   /**
    * @returns {number}

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -377,12 +377,11 @@ impl Address {
             // checks the /bit/ bit of the header for key vs scripthash then reads the credential starting at byte position /pos/
             let read_addr_cred = |bit: u8, pos: usize| {
                 let hash_bytes: [u8; HASH_LEN] = data[pos..pos+HASH_LEN].try_into().unwrap();
-                let x = if header & (1 << bit)  == 0 {
+                if header & (1 << bit)  == 0 {
                     StakeCredential::from_keyhash(&Ed25519KeyHash::from(hash_bytes))
                 } else {
                     StakeCredential::from_scripthash(&ScriptHash::from(hash_bytes))
-                };
-                x
+                }
             };
             let addr = match (header & 0xF0) >> 4 {
                 // base
@@ -408,13 +407,13 @@ impl Address {
                     let payment_cred = read_addr_cred(4, 1);
                     byte_index += HASH_LEN;
                     let (slot, slot_bytes) = variable_nat_decode(&data[byte_index..])
-                        .ok_or(DeserializeError::new("Address.Pointer.slot", DeserializeFailure::VariableLenNatDecodeFailed))?;
+                        .ok_or_else(|| DeserializeError::new("Address.Pointer.slot", DeserializeFailure::VariableLenNatDecodeFailed))?;
                     byte_index += slot_bytes;
                     let (tx_index, tx_bytes) = variable_nat_decode(&data[byte_index..])
-                        .ok_or(DeserializeError::new("Address.Pointer.tx_index", DeserializeFailure::VariableLenNatDecodeFailed))?;
+                        .ok_or_else(|| DeserializeError::new("Address.Pointer.tx_index", DeserializeFailure::VariableLenNatDecodeFailed))?;
                     byte_index += tx_bytes;
                     let (cert_index, cert_bytes) = variable_nat_decode(&data[byte_index..])
-                        .ok_or(DeserializeError::new("Address.Pointer.cert_index", DeserializeFailure::VariableLenNatDecodeFailed))?;
+                        .ok_or_else(|| DeserializeError::new("Address.Pointer.cert_index", DeserializeFailure::VariableLenNatDecodeFailed))?;
                     byte_index += cert_bytes;
                     if byte_index < data.len() {
                         return Err(cbor_event::Error::TrailingData.into());

--- a/rust/src/chain_crypto/algorithms/ed25519_derive.rs
+++ b/rust/src/chain_crypto/algorithms/ed25519_derive.rs
@@ -69,7 +69,7 @@ impl From<i::SignatureError> for SignatureError {
         match v {
             i::SignatureError::InvalidLength(got) => SignatureError::SizeInvalid {
                 expected: ed25519_bip32::SIGNATURE_SIZE,
-                got: got,
+                got,
             },
         }
     }

--- a/rust/src/chain_crypto/algorithms/legacy_daedalus.rs
+++ b/rust/src/chain_crypto/algorithms/legacy_daedalus.rs
@@ -86,7 +86,7 @@ impl AsymmetricKey for LegacyDaedalus {
                 out[64..96].clone_from_slice(&block[32..64]);
                 break;
             }
-            iter = iter + 1;
+            iter += 1;
         }
 
         LegacyPriv(out)

--- a/rust/src/chain_crypto/derive.rs
+++ b/rust/src/chain_crypto/derive.rs
@@ -32,7 +32,7 @@ pub fn from_bip39_entropy(entropy: &[u8], password: &[u8]) -> SecretKey<Ed25519B
 
     const ITER: u32 = 4096;
     let mut mac = Hmac::new(Sha512::new(), password);
-    pbkdf2(&mut mac, entropy.as_ref(), ITER, &mut pbkdf2_result);
+    pbkdf2(&mut mac, entropy, ITER, &mut pbkdf2_result);
 
     SecretKey(XPrv::normalize_bytes_force3rd(pbkdf2_result))
 }

--- a/rust/src/chain_crypto/digest.rs
+++ b/rust/src/chain_crypto/digest.rs
@@ -301,7 +301,7 @@ impl<H: DigestAlg, T> Clone for DigestOf<H, T> {
     fn clone(&self) -> Self {
         DigestOf {
             inner: self.inner.clone(),
-            marker: self.marker.clone(),
+            marker: self.marker,
         }
     }
 }
@@ -323,7 +323,7 @@ impl<H: DigestAlg, T> From<Digest<H>> for DigestOf<H, T> {
 
 impl<H: DigestAlg, T> PartialEq for DigestOf<H, T> {
     fn eq(&self, other: &Self) -> bool {
-        &self.inner == &other.inner
+        self.inner == other.inner
     }
 }
 

--- a/rust/src/chain_crypto/sign.rs
+++ b/rust/src/chain_crypto/sign.rs
@@ -241,6 +241,6 @@ pub(crate) mod test {
         }
 
         let signature = sk.sign(&data);
-        signature.verify(&pk_random, &data) == Verification::Failed
+        signature.verify(pk_random, &data) == Verification::Failed
     }
 }

--- a/rust/src/emip3.rs
+++ b/rust/src/emip3.rs
@@ -50,7 +50,7 @@ pub fn encrypt_with_password(
     if nonce.len() != NONCE_SIZE {
         return Err(JsError::from_str(&format!("nonce len must be {}, found {} bytes", NONCE_SIZE, nonce.len())));
     }
-    if password.len() == 0 {
+    if password.is_empty() {
       return Err(JsError::from_str("Password len cannot be 0"));
     }
 
@@ -98,13 +98,13 @@ pub fn decrypt_with_password(
     let key = {
         let mut mac = Hmac::new(Sha512::new(), &password);
         let mut key: Vec<u8> = repeat(0).take(KEY_SIZE).collect();
-        pbkdf2(&mut mac, &salt[..], ITER, &mut key);
+        pbkdf2(&mut mac, salt, ITER, &mut key);
         key
     };
 
     let mut decrypted: Vec<u8> = repeat(0).take(encrypted.len()).collect();
     let decryption_succeed =
-        { ChaCha20Poly1305::new(&key, &nonce, &[]).decrypt(&encrypted, &mut decrypted, &tag) };
+        { ChaCha20Poly1305::new(&key, nonce, &[]).decrypt(encrypted, &mut decrypted, tag) };
 
     if decryption_succeed {
         Ok(decrypted.encode_hex::<String>())

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2893,7 +2893,7 @@ impl MultiAsset {
 impl PartialOrd for MultiAsset {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         fn amount_or_zero(ma: &MultiAsset, pid: &PolicyID, aname: &AssetName) -> Coin {
-            ma.get(&pid).and_then(|assets| assets.get(aname))
+            ma.get(pid).and_then(|assets| assets.get(aname))
                 .unwrap_or(to_bignum(0u64)) // assume 0 if asset not present
         }
 
@@ -2902,7 +2902,7 @@ impl PartialOrd for MultiAsset {
             for (pid, assets) in lhs.0.iter() {
                 for (aname, amount) in assets.0.iter() {
                     match amount
-                            .clamped_sub(&amount_or_zero(&rhs, pid, aname))
+                            .clamped_sub(&amount_or_zero(rhs, pid, aname))
                             .cmp(&to_bignum(0))
                     {
                         std::cmp::Ordering::Equal => (),

--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -572,7 +572,7 @@ pub enum RedeemerTagKind {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash, serde::Serialize, serde::Deserialize, JsonSchema)]
 pub struct RedeemerTag(RedeemerTagKind);
 
 to_from_bytes!(RedeemerTag);


### PR DESCRIPTION
Once we do the regeneration, we want to make sure the code generated conforms to both `clippy` and `cargo fmt` so that we don't have to disable these tools for the repo.

However, that means we also have to fix clippy errors on the non-generated part of the codebase as well. This PR makes progress towards this, but definitely doesn't fix all issues (I decided to stop here because otherwise the PR would get too big and it's probably already a bit too big)