### PR TITLE
Expose get address header

### DIFF
--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -349,9 +349,12 @@ declare export var StakeCredKind: {|
 |};
 
 /**
+ * Careful: this enum doesn't include the network ID part of the header
+ * ex: base address isn't 0b0000_0000 but instead 0b0000
+ * Use `header_matches_kind` if you don't want to implement the bitwise operators yourself
  */
 
-declare export var AddressHeader: {|
+declare export var AddressHeaderKind: {|
   +BasePaymentKeyStakeKey: 0, // 0
   +BasePaymentScriptStakeKey: 1, // 1
   +BasePaymentKeyStakeScript: 2, // 2
@@ -456,6 +459,13 @@ declare export class Address {
    * @returns {number}
    */
   header(): number;
+
+  /**
+   * @param {number} header
+   * @param {number} kind
+   * @returns {boolean}
+   */
+  static header_matches_kind(header: number, kind: number): boolean;
 
   /**
    * @returns {Uint8Array}

--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -409,6 +409,11 @@ declare export class Address {
   static from_json(json: string): Address;
 
   /**
+   * @returns {number}
+   */
+  header(): number;
+
+  /**
    * @returns {Uint8Array}
    */
   to_bytes(): Uint8Array;

--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -351,6 +351,23 @@ declare export var StakeCredKind: {|
 /**
  */
 
+declare export var AddressHeader: {|
+  +BasePaymentKeyStakeKey: 0, // 0
+  +BasePaymentScriptStakeKey: 1, // 1
+  +BasePaymentKeyStakeScript: 2, // 2
+  +BasePaymentScriptStakeScript: 3, // 3
+  +PointerKey: 4, // 4
+  +PointerScript: 5, // 5
+  +EnterpriseKey: 6, // 6
+  +EnterpriseScript: 7, // 7
+  +Byron: 8, // 8
+  +RewardKey: 9, // 9
+  +RewardScript: 10, // 10
+|};
+
+/**
+ */
+
 declare export var CoinSelectionStrategyCIP2: {|
   +LargestFirst: 0, // 0
   +RandomImprove: 1, // 1
@@ -409,6 +426,33 @@ declare export class Address {
   static from_json(json: string): Address;
 
   /**
+   * header has 4 bits addr type discrim then 4 bits network discrim.
+   * Copied from shelley.cddl:
+   *
+   * base address
+   * bits 7-6: 00
+   * bit 5: stake cred is keyhash/scripthash
+   * bit 4: payment cred is keyhash/scripthash
+   * bits 3-0: network id
+   *
+   * pointer address
+   * bits 7-5: 010
+   * bit 4: payment cred is keyhash/scripthash
+   * bits 3-0: network id
+   *
+   * enterprise address
+   * bits 7-5: 010
+   * bit 4: payment cred is keyhash/scripthash
+   * bits 3-0: network id
+   *
+   * reward addresses:
+   * bits 7-5: 111
+   * bit 4: credential is keyhash/scripthash
+   * bits 3-0: network id
+   *
+   * byron addresses:
+   * bits 7-4: 1000
+   * bits 3-0: unrelated data (recall: no network ID in Byron addresses)
    * @returns {number}
    */
   header(): number;


### PR DESCRIPTION
We used to treat the header as an internal implementation detail, but this would be useful to export for indexers