### PR TITLE
TxBuilder rewrite: certificates (partial)

### DIFF
--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -1461,6 +1461,11 @@ declare export class Certificate {
 }
 /**
  */
+declare export class CertificateBuilderResult {
+  free(): void;
+}
+/**
+ */
 declare export class Certificates {
   free(): void;
 
@@ -3565,6 +3570,41 @@ declare export class OperationalCert {
   ): OperationalCert;
 }
 /**
+ * A partial Plutus witness
+ * It contains all the information needed to witness the Plutus script execution
+ * except for the redeemer tag and index
+ */
+declare export class PartialPlutusWitness {
+  free(): void;
+
+  /**
+   * @returns {PlutusScript}
+   */
+  script(): PlutusScript;
+
+  /**
+   * @returns {PlutusData}
+   */
+  datum(): PlutusData;
+
+  /**
+   * @returns {UntaggedRedeemer}
+   */
+  untagged_redeemer(): UntaggedRedeemer;
+
+  /**
+   * @param {PlutusScript} script
+   * @param {PlutusData} datum
+   * @param {UntaggedRedeemer} untagged_redeemer
+   * @returns {PartialPlutusWitness}
+   */
+  static new(
+    script: PlutusScript,
+    datum: PlutusData,
+    untagged_redeemer: UntaggedRedeemer
+  ): PartialPlutusWitness;
+}
+/**
  */
 declare export class PlutusData {
   free(): void;
@@ -5416,6 +5456,36 @@ declare export class ScriptPubkey {
 }
 /**
  */
+declare export class SingleCertificateBuilder {
+  free(): void;
+
+  /**
+   * @param {Certificate} cert
+   * @returns {SingleCertificateBuilder}
+   */
+  static new(cert: Certificate): SingleCertificateBuilder;
+
+  /**
+   * @returns {CertificateBuilderResult}
+   */
+  no_script(): CertificateBuilderResult;
+
+  /**
+   * @param {NativeScript} native_script
+   * @returns {CertificateBuilderResult}
+   */
+  native_script(native_script: NativeScript): CertificateBuilderResult;
+
+  /**
+   * @param {PartialPlutusWitness} partial_witness
+   * @returns {CertificateBuilderResult}
+   */
+  plutus_script(
+    partial_witness: PartialPlutusWitness
+  ): CertificateBuilderResult;
+}
+/**
+ */
 declare export class SingleHostAddr {
   free(): void;
 
@@ -6278,6 +6348,7 @@ declare export class TransactionBuilder {
   set_validity_start_interval(validity_start_interval: BigNum): void;
 
   /**
+   * TODO: replace with add_cert that takes in a CertificateBuilderResult
    * @param {Certificates} certs
    */
   set_certs(certs: Certificates): void;
@@ -7437,6 +7508,31 @@ declare export class UnitInterval {
    * @returns {UnitInterval}
    */
   static new(numerator: BigNum, denominator: BigNum): UnitInterval;
+}
+/**
+ * Redeemer without the tag of index
+ * This allows builder code to return partial redeemers
+ * and then later have them placed in the right context
+ */
+declare export class UntaggedRedeemer {
+  free(): void;
+
+  /**
+   * @returns {PlutusData}
+   */
+  datum(): PlutusData;
+
+  /**
+   * @returns {ExUnits}
+   */
+  ex_units(): ExUnits;
+
+  /**
+   * @param {PlutusData} data
+   * @param {ExUnits} ex_units
+   * @returns {UntaggedRedeemer}
+   */
+  static new(data: PlutusData, ex_units: ExUnits): UntaggedRedeemer;
 }
 /**
  */

--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -3573,6 +3573,7 @@ declare export class OperationalCert {
  * A partial Plutus witness
  * It contains all the information needed to witness the Plutus script execution
  * except for the redeemer tag and index
+ * Note: no datum is attached because only input script types have datums
  */
 declare export class PartialPlutusWitness {
   free(): void;
@@ -3583,24 +3584,17 @@ declare export class PartialPlutusWitness {
   script(): PlutusScript;
 
   /**
-   * @returns {PlutusData}
-   */
-  datum(): PlutusData;
-
-  /**
    * @returns {UntaggedRedeemer}
    */
   untagged_redeemer(): UntaggedRedeemer;
 
   /**
    * @param {PlutusScript} script
-   * @param {PlutusData} datum
    * @param {UntaggedRedeemer} untagged_redeemer
    * @returns {PartialPlutusWitness}
    */
   static new(
     script: PlutusScript,
-    datum: PlutusData,
     untagged_redeemer: UntaggedRedeemer
   ): PartialPlutusWitness;
 }

--- a/rust/src/builders/certificate_builder.rs
+++ b/rust/src/builders/certificate_builder.rs
@@ -1,0 +1,122 @@
+use crate::*;
+use crate::witness_builder::{InputAggregateWitnessData, PartialPlutusWitness};
+use std::collections::{HashSet};
+
+// comes from witsVKeyNeeded in the Ledger spec
+pub fn add_cert_vkeys(cert_enum: &Certificate, vkeys: &mut HashSet<Ed25519KeyHash>) -> Result<(), JsError> {
+    match &cert_enum.0 {
+        // stake key registrations do not require a witness
+        CertificateEnum::StakeRegistration(_cert) => {},
+        CertificateEnum::StakeDeregistration(cert) => match cert.stake_credential().kind() {
+            StakeCredKind::Script => return Err(JsError::from_str(&format!("Deregistration certificate contains script. Expected public key hash.\n{:#?}", cert.to_json()))),
+            StakeCredKind::Key => {
+                vkeys.insert(cert.stake_credential().to_keyhash().unwrap());
+            }
+        },
+        CertificateEnum::StakeDelegation(cert) => match cert.stake_credential().kind() {
+            StakeCredKind::Script => return Err(JsError::from_str(&format!("Delegation certificate contains script. Expected public key hash.\n{:#?}", cert.to_json()))),
+            StakeCredKind::Key => {
+                vkeys.insert(cert.stake_credential().to_keyhash().unwrap());
+            }
+        },
+        CertificateEnum::PoolRegistration(cert) => {
+            for owner in &cert.pool_params().pool_owners().0 {
+                vkeys.insert(owner.clone());
+            }
+            vkeys.insert(cert.pool_params().operator());
+        },
+        CertificateEnum::PoolRetirement(cert) => {
+            vkeys.insert(cert.pool_keyhash());
+        },
+        CertificateEnum::GenesisKeyDelegation(cert) => {
+            vkeys.insert(
+                Ed25519KeyHash::from_bytes(cert.genesis_delegate_hash().to_bytes()).unwrap()
+            );
+        },
+        // no witness as there is no single core node or genesis key that posts the certificate
+        CertificateEnum::MoveInstantaneousRewardsCert(_cert) => {},
+    };
+    Ok(())
+}
+
+fn check_cert_script_hash(cert_enum: &Certificate, expected_hash: &ScriptHash) -> Result<bool, JsError> {
+    match &cert_enum.0 {
+        // stake key registrations do not require a witness
+        CertificateEnum::StakeRegistration(_cert) => Ok(false),
+        CertificateEnum::StakeDeregistration(cert) => match cert.stake_credential().to_scripthash() {
+            Some(script_hash) => {
+                match *expected_hash == script_hash {
+                    true => Ok(true),
+                    false => return Err(JsError::from_str(&format!("Deregistration certificate contains wrong script hash. Expected {}, got {}.\n{:#?}", expected_hash, script_hash, cert.to_json()))),
+                }
+            },
+            None => return Err(JsError::from_str(&format!("Deregistration certificate contains public key hash. Expected script.\n{:#?}", cert.to_json()))),
+        },
+        CertificateEnum::StakeDelegation(cert) => match cert.stake_credential().to_scripthash() {
+            Some(script_hash) => {
+                match *expected_hash == script_hash {
+                    true => Ok(true),
+                    false => return Err(JsError::from_str(&format!("Delegation certificate contains wrong script hash. Expected {}, got {}.\n{:#?}", expected_hash, script_hash, cert.to_json()))),
+                }
+            },
+            None => return Err(JsError::from_str(&format!("Delegation certificate contains public key hash. Expected script.\n{:#?}", cert.to_json()))),
+        },
+        // can't register pools with scripts
+        CertificateEnum::PoolRegistration(_cert) => Ok(false),
+        CertificateEnum::PoolRetirement(_cert) => Ok(false),
+        // genesis keys are not scripts
+        CertificateEnum::GenesisKeyDelegation(_cert) => Ok(false),
+        // no witness as there is no single core node or genesis key that posts the certificate
+        CertificateEnum::MoveInstantaneousRewardsCert(_cert) => Ok(false),
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct CertificateBuilderResult {
+    cert: Certificate,
+    aggregate_witness: InputAggregateWitnessData,
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct SingleCertificateBuilder {
+    cert: Certificate,
+}
+
+#[wasm_bindgen]
+impl SingleCertificateBuilder {
+    pub fn new(cert: &Certificate) -> Self {
+        Self {
+            cert: cert.clone(),
+        }
+    }
+
+    pub fn no_script(&self) -> Result<CertificateBuilderResult, JsError> {
+        let mut vkey_set = HashSet::<Ed25519KeyHash>::new();
+        add_cert_vkeys(&self.cert, &mut vkey_set)?;
+        Ok(CertificateBuilderResult {
+            cert: self.cert.clone(),
+            aggregate_witness: InputAggregateWitnessData::Vkeys(vkey_set.clone()),
+        })
+    }
+
+    pub fn native_script(&self, native_script: &NativeScript) -> Result<CertificateBuilderResult, JsError> {
+        let expected_hash = native_script.hash(ScriptHashNamespace::NativeScript);
+        check_cert_script_hash(&self.cert, &expected_hash)?;
+        Ok(CertificateBuilderResult {
+            cert: self.cert.clone(),
+            aggregate_witness: InputAggregateWitnessData::NativeScript(native_script.clone()),
+        })
+    }
+
+    pub fn plutus_script(&self, partial_witness: &PartialPlutusWitness) -> Result<CertificateBuilderResult, JsError> {
+        // TODO: support PlutusV2
+        let expected_hash = partial_witness.script().hash(ScriptHashNamespace::PlutusV1);
+        check_cert_script_hash(&self.cert, &expected_hash)?;
+        Ok(CertificateBuilderResult {
+            cert: self.cert.clone(),
+            aggregate_witness: InputAggregateWitnessData::PlutusScript(partial_witness.clone()),
+        })
+    }
+}

--- a/rust/src/builders/certificate_builder.rs
+++ b/rust/src/builders/certificate_builder.rs
@@ -116,7 +116,7 @@ impl SingleCertificateBuilder {
         check_cert_script_hash(&self.cert, &expected_hash)?;
         Ok(CertificateBuilderResult {
             cert: self.cert.clone(),
-            aggregate_witness: InputAggregateWitnessData::PlutusScript(partial_witness.clone()),
+            aggregate_witness: InputAggregateWitnessData::PlutusScriptNoDatum(partial_witness.clone()),
         })
     }
 }

--- a/rust/src/builders/mod.rs
+++ b/rust/src/builders/mod.rs
@@ -1,0 +1,1 @@
+pub mod certificate_builder;

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -838,6 +838,12 @@ macro_rules! impl_hash_type {
             pub const BYTE_COUNT: usize = $byte_count;
         }
 
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.to_hex())
+            }
+        }
+
         // can't expose [T; N] to wasm for new() but it's useful internally so we implement From trait
         impl From<[u8; $byte_count]> for $name {
             fn from(bytes: [u8; $byte_count]) -> Self {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -48,6 +48,7 @@ pub mod output_builder;
 pub mod plutus;
 pub mod serialization;
 pub mod tx_builder;
+pub mod builders;
 pub mod typed_bytes;
 pub mod emip3;
 #[macro_use]

--- a/rust/src/witness_builder.rs
+++ b/rust/src/witness_builder.rs
@@ -2,7 +2,7 @@ use std::collections::{HashSet, HashMap};
 use super::*;
 
 #[wasm_bindgen]
-#[derive(Clone, PartialEq, Eq,  Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RedeemerWitnessKey {
     tag: RedeemerTag,
     index: BigNum,
@@ -25,8 +25,84 @@ impl RedeemerWitnessKey {
             index: *index,
         }
     }
-
 }
+
+/// Redeemer without the tag of index
+/// This allows builder code to return partial redeemers
+/// and then later have them placed in the right context
+#[wasm_bindgen]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct UntaggedRedeemer {
+    data: PlutusData,
+    ex_units: ExUnits,
+}
+
+#[wasm_bindgen]
+impl UntaggedRedeemer {
+
+    pub fn datum(&self) -> PlutusData {
+        self.data.clone()
+    }
+
+    pub fn ex_units(&self) -> ExUnits {
+        self.ex_units.clone()
+    }
+
+    pub fn new(data: &PlutusData, ex_units: &ExUnits) -> Self {
+        Self {
+            data: data.clone(),
+            ex_units: ex_units.clone(),
+        }
+    }
+}
+
+/// A partial Plutus witness
+/// It contains all the information needed to witness the Plutus script execution
+/// except for the redeemer tag and index
+#[wasm_bindgen]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct PartialPlutusWitness {
+    script: PlutusScript,
+    datum: PlutusData,
+    untagged_redeemer: UntaggedRedeemer,
+}
+
+#[wasm_bindgen]
+impl PartialPlutusWitness {
+
+    pub fn script(&self) -> PlutusScript {
+        self.script.clone()
+    }
+
+    pub fn datum(&self) -> PlutusData {
+        self.datum.clone()
+    }
+
+    pub fn untagged_redeemer(&self) -> UntaggedRedeemer {
+        self.untagged_redeemer.clone()
+    }
+
+    pub fn new(
+        script: &PlutusScript,
+        datum: &PlutusData,
+        untagged_redeemer: &UntaggedRedeemer
+    ) -> Self {
+        Self {
+            script: script.clone(),
+            datum: datum.clone(),
+            untagged_redeemer: untagged_redeemer.clone(),
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum InputAggregateWitnessData {
+    Vkeys(HashSet<Ed25519KeyHash>),
+    NativeScript(NativeScript),
+    PlutusScript(PartialPlutusWitness)
+}
+
 
 #[wasm_bindgen]
 #[derive(Clone, Default)]

--- a/rust/src/witness_builder.rs
+++ b/rust/src/witness_builder.rs
@@ -59,11 +59,11 @@ impl UntaggedRedeemer {
 /// A partial Plutus witness
 /// It contains all the information needed to witness the Plutus script execution
 /// except for the redeemer tag and index
+/// Note: no datum is attached because only input script types have datums
 #[wasm_bindgen]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PartialPlutusWitness {
     script: PlutusScript,
-    datum: PlutusData,
     untagged_redeemer: UntaggedRedeemer,
 }
 
@@ -74,22 +74,16 @@ impl PartialPlutusWitness {
         self.script.clone()
     }
 
-    pub fn datum(&self) -> PlutusData {
-        self.datum.clone()
-    }
-
     pub fn untagged_redeemer(&self) -> UntaggedRedeemer {
         self.untagged_redeemer.clone()
     }
 
     pub fn new(
         script: &PlutusScript,
-        datum: &PlutusData,
         untagged_redeemer: &UntaggedRedeemer
     ) -> Self {
         Self {
             script: script.clone(),
-            datum: datum.clone(),
             untagged_redeemer: untagged_redeemer.clone(),
         }
     }
@@ -100,7 +94,8 @@ impl PartialPlutusWitness {
 pub enum InputAggregateWitnessData {
     Vkeys(HashSet<Ed25519KeyHash>),
     NativeScript(NativeScript),
-    PlutusScript(PartialPlutusWitness)
+    PlutusScriptNoDatum(PartialPlutusWitness),
+    PlutusScriptWithDatum((PartialPlutusWitness, PlutusData))
 }
 
 


### PR DESCRIPTION
The current tx builder doesn't support Plutus at all and barely supports native scripts (only through a hacky solution)

We need to annotate every step of the tx builder with information about scripts to properly build the transaction and estimate the fee. We could do this in the same style as we've done historically (just add a bunch of `set_` functions), but this is already near-unusable levels of uglyness so I'm thinking of rewriting all the set functions as builders so that we can isolate complexity of individual parts of a transaction (such as certificates) into their own builds and the main builder is just there to aggregate the data

In this PR, I wrote the CertificateBuilder, but I didn't connect it to the main tx builder. This is because if I did that, I would be stuck refactoring a huge amount of code and this PR is already big enough. Probably the best path forward is to rewrite all the chunks into these kinds of builders, then do a PR that connects them all together.