### PR TITLE
Add more builder types

### DIFF
--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -513,6 +513,18 @@ declare export class Address {
    * @returns {BaseAddress | void}
    */
   as_base(): BaseAddress | void;
+
+  /**
+   * Note: by convention, the key inside reward addresses are considered payment credentials
+   * @returns {StakeCredential | void}
+   */
+  payment_cred(): StakeCredential | void;
+
+  /**
+   * Note: by convention, the key inside reward addresses are NOT considered staking credentials
+   * @returns {StakeCredential | void}
+   */
+  staking_cred(): StakeCredential | void;
 }
 /**
  */
@@ -2420,6 +2432,11 @@ declare export class HeaderBody {
 }
 /**
  */
+declare export class InputBuilderResult {
+  free(): void;
+}
+/**
+ */
 declare export class Int {
   free(): void;
 
@@ -3058,6 +3075,11 @@ declare export class MintAssets {
 }
 /**
  */
+declare export class MintBuilderResult {
+  free(): void;
+}
+/**
+ */
 declare export class MoveInstantaneousReward {
   free(): void;
 
@@ -3424,6 +3446,11 @@ declare export class NativeScript {
    * @returns {Ed25519KeyHashes}
    */
   get_required_signers(): Ed25519KeyHashes;
+}
+/**
+ */
+declare export class NativeScriptWitnessInfo {
+  free(): void;
 }
 /**
  */
@@ -3853,6 +3880,11 @@ declare export class PlutusScript {
    * @returns {Uint8Array}
    */
   bytes(): Uint8Array;
+}
+/**
+ */
+declare export class PlutusScriptWitnessInfo {
+  free(): void;
 }
 /**
  */
@@ -5073,19 +5105,14 @@ declare export class RequiredWitnessSet {
   add_native_script(native_script: NativeScript): void;
 
   /**
-   * @param {ScriptHash} native_script
+   * @param {ScriptHash} script_hash
    */
-  add_native_script_hash(native_script: ScriptHash): void;
+  add_script_hash(script_hash: ScriptHash): void;
 
   /**
    * @param {PlutusScript} plutus_script
    */
   add_plutus_script(plutus_script: PlutusScript): void;
-
-  /**
-   * @param {ScriptHash} plutus_script
-   */
-  add_plutus_hash(plutus_script: ScriptHash): void;
 
   /**
    * @param {PlutusData} plutus_datum
@@ -5521,20 +5548,39 @@ declare export class SingleCertificateBuilder {
   /**
    * @returns {CertificateBuilderResult}
    */
-  no_script(): CertificateBuilderResult;
+  skip_witness(): CertificateBuilderResult;
 
   /**
-   * @param {NativeScript} native_script
+   * @param {Vkeys} vkeys
    * @returns {CertificateBuilderResult}
    */
-  native_script(native_script: NativeScript): CertificateBuilderResult;
+  vkeys(vkeys: Vkeys): CertificateBuilderResult;
+
+  /**
+   * @param {Vkey} vkey
+   * @returns {CertificateBuilderResult}
+   */
+  vkey(vkey: Vkey): CertificateBuilderResult;
+
+  /**
+   * Signer keys don't have to be set. You can leave it empty and then add the required witnesses later
+   * @param {NativeScript} native_script
+   * @param {NativeScriptWitnessInfo} witness_info
+   * @returns {CertificateBuilderResult}
+   */
+  native_script(
+    native_script: NativeScript,
+    witness_info: NativeScriptWitnessInfo
+  ): CertificateBuilderResult;
 
   /**
    * @param {PartialPlutusWitness} partial_witness
+   * @param {PlutusScriptWitnessInfo} witness_info
    * @returns {CertificateBuilderResult}
    */
   plutus_script(
-    partial_witness: PartialPlutusWitness
+    partial_witness: PartialPlutusWitness,
+    witness_info: PlutusScriptWitnessInfo
   ): CertificateBuilderResult;
 }
 /**
@@ -5640,6 +5686,146 @@ declare export class SingleHostName {
    * @returns {SingleHostName}
    */
   static new(port: number | void, dns_name: DNSRecordAorAAAA): SingleHostName;
+}
+/**
+ */
+declare export class SingleInputBuilder {
+  free(): void;
+
+  /**
+   * @param {TransactionInput} input
+   * @param {TransactionOutput} utxo_info
+   * @returns {SingleInputBuilder}
+   */
+  static new(
+    input: TransactionInput,
+    utxo_info: TransactionOutput
+  ): SingleInputBuilder;
+
+  /**
+   * @returns {InputBuilderResult}
+   */
+  skip_witness(): InputBuilderResult;
+
+  /**
+   * @param {Vkey} vkey
+   * @returns {InputBuilderResult}
+   */
+  vkey(vkey: Vkey): InputBuilderResult;
+
+  /**
+   * @param {BootstrapWitness} bootstrap
+   * @returns {InputBuilderResult}
+   */
+  bootstrap(bootstrap: BootstrapWitness): InputBuilderResult;
+
+  /**
+   * @param {NativeScript} native_script
+   * @param {NativeScriptWitnessInfo} witness_info
+   * @returns {InputBuilderResult}
+   */
+  native_script(
+    native_script: NativeScript,
+    witness_info: NativeScriptWitnessInfo
+  ): InputBuilderResult;
+
+  /**
+   * @param {PartialPlutusWitness} partial_witness
+   * @param {PlutusScriptWitnessInfo} witness_info
+   * @param {PlutusData} datum
+   * @returns {InputBuilderResult}
+   */
+  plutus_script(
+    partial_witness: PartialPlutusWitness,
+    witness_info: PlutusScriptWitnessInfo,
+    datum: PlutusData
+  ): InputBuilderResult;
+}
+/**
+ */
+declare export class SingleMintBuilder {
+  free(): void;
+
+  /**
+   * @param {MintAssets} assets
+   * @returns {SingleMintBuilder}
+   */
+  static new(assets: MintAssets): SingleMintBuilder;
+
+  /**
+   * @param {ScriptHash} policy_id
+   * @returns {MintBuilderResult}
+   */
+  skip_witness(policy_id: ScriptHash): MintBuilderResult;
+
+  /**
+   * @param {NativeScript} native_script
+   * @param {NativeScriptWitnessInfo} witness_info
+   * @returns {MintBuilderResult}
+   */
+  native_script(
+    native_script: NativeScript,
+    witness_info: NativeScriptWitnessInfo
+  ): MintBuilderResult;
+
+  /**
+   * @param {PartialPlutusWitness} partial_witness
+   * @param {PlutusScriptWitnessInfo} witness_info
+   * @returns {MintBuilderResult}
+   */
+  plutus_script(
+    partial_witness: PartialPlutusWitness,
+    witness_info: PlutusScriptWitnessInfo
+  ): MintBuilderResult;
+}
+/**
+ */
+declare export class SingleWithdrawalBuilder {
+  free(): void;
+
+  /**
+   * @param {RewardAddress} address
+   * @param {BigNum} amount
+   * @returns {SingleWithdrawalBuilder}
+   */
+  static new(address: RewardAddress, amount: BigNum): SingleWithdrawalBuilder;
+
+  /**
+   * @returns {WithdrawalBuilderResult}
+   */
+  skip_witness(): WithdrawalBuilderResult;
+
+  /**
+   * @param {Vkeys} vkeys
+   * @returns {WithdrawalBuilderResult}
+   */
+  vkeys(vkeys: Vkeys): WithdrawalBuilderResult;
+
+  /**
+   * @param {Vkey} vkey
+   * @returns {WithdrawalBuilderResult}
+   */
+  vkey(vkey: Vkey): WithdrawalBuilderResult;
+
+  /**
+   * @param {NativeScript} native_script
+   * @param {NativeScriptWitnessInfo} witness_info
+   * @returns {WithdrawalBuilderResult}
+   */
+  native_script(
+    native_script: NativeScript,
+    witness_info: NativeScriptWitnessInfo
+  ): WithdrawalBuilderResult;
+
+  /**
+   * @param {PartialPlutusWitness} partial_witness
+   * @param {PlutusScriptWitnessInfo} witness_info
+   * @returns {WithdrawalBuilderResult}
+   */
+  plutus_script(
+    partial_witness: PartialPlutusWitness,
+    witness_info: PlutusScriptWitnessInfo
+  ): WithdrawalBuilderResult;
 }
 /**
  */
@@ -8022,6 +8208,11 @@ declare export class Vkeywitnesses {
    * @param {Vkeywitness} elem
    */
   add(elem: Vkeywitness): void;
+}
+/**
+ */
+declare export class WithdrawalBuilderResult {
+  free(): void;
 }
 /**
  */

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -575,6 +575,28 @@ impl Address {
             _ => None
         }
     }
+
+    /// Note: by convention, the key inside reward addresses are considered payment credentials
+    pub fn payment_cred(&self) -> Option<StakeCredential> {
+        match &self.0 {
+            AddrType::Base(a) => Some(a.payment.clone()),
+            AddrType::Enterprise(a) => Some(a.payment.clone()),
+            AddrType::Ptr(a) => Some(a.payment.clone()),
+            AddrType::Reward(a) => Some(a.payment.clone()),
+            AddrType::Byron(_) => None,
+        }
+    }
+
+    /// Note: by convention, the key inside reward addresses are NOT considered staking credentials
+    pub fn staking_cred(&self) -> Option<StakeCredential> {
+        match &self.0 {
+            AddrType::Base(a) => Some(a.stake.clone()),
+            AddrType::Enterprise(_) => None,
+            AddrType::Ptr(_) => None,
+            AddrType::Reward(_) => None,
+            AddrType::Byron(_) => None,
+        }
+    }
 }
 
 impl cbor_event::se::Serialize for Address {

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -588,6 +588,7 @@ impl Address {
     }
 
     /// Note: by convention, the key inside reward addresses are NOT considered staking credentials
+    /// Note: None is returned pointer addresses as the chain history is required to resolve its associated cred
     pub fn staking_cred(&self) -> Option<StakeCredential> {
         match &self.0 {
             AddrType::Base(a) => Some(a.stake.clone()),

--- a/rust/src/builders/certificate_builder.rs
+++ b/rust/src/builders/certificate_builder.rs
@@ -2,6 +2,48 @@ use crate::*;
 use crate::builders::witness_builder::{InputAggregateWitnessData, PartialPlutusWitness};
 use std::collections::{HashSet};
 
+use super::witness_builder::RequiredWitnessSet;
+
+// comes from witsVKeyNeeded in the Ledger spec
+pub fn cert_required_wits(cert_enum: &Certificate, required_witnesses: &mut RequiredWitnessSet) -> () {
+    match &cert_enum.0 {
+        // stake key registrations do not require a witness
+        CertificateEnum::StakeRegistration(_cert) => (),
+        CertificateEnum::StakeDeregistration(cert) => match cert.stake_credential().kind() {
+            StakeCredKind::Script => {
+                required_witnesses.add_script_hash(&cert.stake_credential().to_scripthash().unwrap());
+            }
+            StakeCredKind::Key => {
+                required_witnesses.add_vkey_key_hash(&cert.stake_credential().to_keyhash().unwrap());
+            }
+        },
+        CertificateEnum::StakeDelegation(cert) => match cert.stake_credential().kind() {
+            StakeCredKind::Script => {
+                required_witnesses.add_script_hash(&cert.stake_credential().to_scripthash().unwrap());
+            }
+            StakeCredKind::Key => {
+                required_witnesses.add_vkey_key_hash(&cert.stake_credential().to_keyhash().unwrap());
+            }
+        },
+        CertificateEnum::PoolRegistration(cert) => {
+            for owner in &cert.pool_params().pool_owners().0 {
+                required_witnesses.add_vkey_key_hash(&owner.clone());
+            }
+            required_witnesses.add_vkey_key_hash(&cert.pool_params().operator());
+        },
+        CertificateEnum::PoolRetirement(cert) => {
+            required_witnesses.add_vkey_key_hash(&cert.pool_keyhash());
+        },
+        CertificateEnum::GenesisKeyDelegation(cert) => {
+            required_witnesses.add_vkey_key_hash(
+                &Ed25519KeyHash::from_bytes(cert.genesis_delegate_hash().to_bytes()).unwrap()
+            );
+        },
+        // no witness as there is no single core node or genesis key that posts the certificate
+        CertificateEnum::MoveInstantaneousRewardsCert(_cert) => {},
+    };
+}
+
 // comes from witsVKeyNeeded in the Ledger spec
 pub fn add_cert_vkeys(cert_enum: &Certificate, vkeys: &mut HashSet<Ed25519KeyHash>) -> Result<(), JsError> {
     match &cert_enum.0 {
@@ -39,45 +81,12 @@ pub fn add_cert_vkeys(cert_enum: &Certificate, vkeys: &mut HashSet<Ed25519KeyHas
     Ok(())
 }
 
-/// Check if the script hash matches the one in the certificate
-/// If the certificate does not require the script to sign the transaction, Ok(false) is returned
-fn check_cert_script_hash(cert_enum: &Certificate, expected_hash: &ScriptHash) -> Result<bool, JsError> {
-    match &cert_enum.0 {
-        // stake key registrations do not require a witness
-        CertificateEnum::StakeRegistration(_cert) => Ok(false),
-        CertificateEnum::StakeDeregistration(cert) => match cert.stake_credential().to_scripthash() {
-            Some(script_hash) => {
-                match *expected_hash == script_hash {
-                    true => Ok(true),
-                    false => return Err(JsError::from_str(&format!("Deregistration certificate contains wrong script hash. Expected {}, got {}.\n{:#?}", expected_hash, script_hash, cert.to_json()))),
-                }
-            },
-            None => return Err(JsError::from_str(&format!("Deregistration certificate contains public key hash. Expected script.\n{:#?}", cert.to_json()))),
-        },
-        CertificateEnum::StakeDelegation(cert) => match cert.stake_credential().to_scripthash() {
-            Some(script_hash) => {
-                match *expected_hash == script_hash {
-                    true => Ok(true),
-                    false => return Err(JsError::from_str(&format!("Delegation certificate contains wrong script hash. Expected {}, got {}.\n{:#?}", expected_hash, script_hash, cert.to_json()))),
-                }
-            },
-            None => return Err(JsError::from_str(&format!("Delegation certificate contains public key hash. Expected script.\n{:#?}", cert.to_json()))),
-        },
-        // can't register pools with scripts
-        CertificateEnum::PoolRegistration(_cert) => Ok(false),
-        CertificateEnum::PoolRetirement(_cert) => Ok(false),
-        // genesis keys are not scripts
-        CertificateEnum::GenesisKeyDelegation(_cert) => Ok(false),
-        // no witness as there is no single core node or genesis key that posts the certificate
-        CertificateEnum::MoveInstantaneousRewardsCert(_cert) => Ok(false),
-    }
-}
-
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct CertificateBuilderResult {
     cert: Certificate,
     aggregate_witness: Option<InputAggregateWitnessData>,
+    required_wits: RequiredWitnessSet,
 }
 
 #[wasm_bindgen]
@@ -94,41 +103,90 @@ impl SingleCertificateBuilder {
         }
     }
 
-    pub fn no_script(&self) -> Result<CertificateBuilderResult, JsError> {
-        let mut vkey_set = HashSet::<Ed25519KeyHash>::new();
-        add_cert_vkeys(&self.cert, &mut vkey_set)?;
+    pub fn skip_witness(&self) -> CertificateBuilderResult {
+        let mut required_wits = RequiredWitnessSet::default();
+        cert_required_wits(&self.cert, &mut required_wits);
+
+        CertificateBuilderResult {
+            cert: self.cert.clone(),
+            aggregate_witness: None,
+            required_wits: required_wits.clone(),
+        }
+    }
+
+    pub fn vkeys(&self, vkeys: &Vkeys) -> Result<CertificateBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        cert_required_wits(&self.cert, &mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let provided_wit_subset: Vec<&Vkey> = vkeys.0.iter().filter(|vkey| required_wits_left.vkeys.contains(&vkey.public_key().hash())).collect();
+        
+        // check the user provided all the required witnesses
+        provided_wit_subset.iter().for_each(|wit| { required_wits_left.vkeys.remove(&wit.public_key().hash()); });
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
         Ok(CertificateBuilderResult {
             cert: self.cert.clone(),
-            aggregate_witness: if vkey_set.len() > 0 { Some(InputAggregateWitnessData::Vkeys(vkey_set.clone())) } else { None },
+            aggregate_witness: if provided_wit_subset.len() > 0 { Some(InputAggregateWitnessData::Vkeys(provided_wit_subset.into_iter().cloned().collect())) } else { None },
+            required_wits: required_wits.clone(),
         })
     }
 
+    pub fn vkey(&self, vkey: &Vkey) -> Result<CertificateBuilderResult, JsError> {
+        self.vkeys(&Vkeys(vec![vkey.clone()]))
+    }
+
     pub fn native_script(&self, native_script: &NativeScript) -> Result<CertificateBuilderResult, JsError> {
-        let expected_hash = native_script.hash(ScriptHashNamespace::NativeScript);
-        match check_cert_script_hash(&self.cert, &expected_hash)? {
-            true => Ok(CertificateBuilderResult {
-                cert: self.cert.clone(),
-                aggregate_witness: Some(InputAggregateWitnessData::NativeScript(native_script.clone())),
-            }),
-            false => Ok(CertificateBuilderResult {
-                cert: self.cert.clone(),
-                aggregate_witness: None,
-            })
+        let mut required_wits = RequiredWitnessSet::default();
+        cert_required_wits(&self.cert, &mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.scripts.contains(&native_script.hash(ScriptHashNamespace::NativeScript));
+        
+        // check the user provided all the required witnesses
+        required_wits_left.scripts.remove(&native_script.hash(ScriptHashNamespace::NativeScript));
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
         }
+
+        let mut required_wits = RequiredWitnessSet::default();
+        cert_required_wits(&self.cert, &mut required_wits);
+
+        Ok(CertificateBuilderResult {
+            cert: self.cert.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::NativeScript(native_script.clone())) } else { None },
+            required_wits: required_wits.clone(),
+        })
     }
 
     pub fn plutus_script(&self, partial_witness: &PartialPlutusWitness) -> Result<CertificateBuilderResult, JsError> {
-        // TODO: support PlutusV2
-        let expected_hash = partial_witness.script().hash(ScriptHashNamespace::PlutusV1);
-        match check_cert_script_hash(&self.cert, &expected_hash)? {
-            true => Ok(CertificateBuilderResult {
-                cert: self.cert.clone(),
-                aggregate_witness: Some(InputAggregateWitnessData::PlutusScriptNoDatum(partial_witness.clone())),
-            }),
-            false => Ok(CertificateBuilderResult {
-                cert: self.cert.clone(),
-                aggregate_witness: None,
-            })
+        let mut required_wits = RequiredWitnessSet::default();
+        cert_required_wits(&self.cert, &mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        // TODO: Plutus V2
+        let script_hash = partial_witness.script().hash(ScriptHashNamespace::PlutusV1);
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.scripts.contains(&script_hash);
+        
+        // check the user provided all the required witnesses
+        required_wits_left.scripts.remove(&script_hash);
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
         }
+
+        Ok(CertificateBuilderResult {
+            cert: self.cert.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::PlutusScriptNoDatum(partial_witness.clone())) } else { None },
+            required_wits: required_wits.clone(),
+        })
     }
 }

--- a/rust/src/builders/certificate_builder.rs
+++ b/rust/src/builders/certificate_builder.rs
@@ -155,9 +155,6 @@ impl SingleCertificateBuilder {
             return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
         }
 
-        let mut required_wits = RequiredWitnessSet::default();
-        cert_required_wits(&self.cert, &mut required_wits);
-
         Ok(CertificateBuilderResult {
             cert: self.cert.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::NativeScript(native_script.clone())) } else { None },

--- a/rust/src/builders/certificate_builder.rs
+++ b/rust/src/builders/certificate_builder.rs
@@ -5,7 +5,7 @@ use std::collections::{HashSet};
 use super::witness_builder::{RequiredWitnessSet, NativeScriptWitnessInfo, PlutusScriptWitnessInfo};
 
 // comes from witsVKeyNeeded in the Ledger spec
-pub fn cert_required_wits(cert_enum: &Certificate, required_witnesses: &mut RequiredWitnessSet) -> () {
+pub fn cert_required_wits(cert_enum: &Certificate, required_witnesses: &mut RequiredWitnessSet) {
     match &cert_enum.0 {
         // stake key registrations do not require a witness
         CertificateEnum::StakeRegistration(_cert) => (),
@@ -110,7 +110,7 @@ impl SingleCertificateBuilder {
         CertificateBuilderResult {
             cert: self.cert.clone(),
             aggregate_witness: None,
-            required_wits: required_wits.clone(),
+            required_wits,
         }
     }
 
@@ -132,7 +132,7 @@ impl SingleCertificateBuilder {
         Ok(CertificateBuilderResult {
             cert: self.cert.clone(),
             aggregate_witness: if provided_wit_subset.len() > 0 { Some(InputAggregateWitnessData::Vkeys(provided_wit_subset.into_iter().cloned().collect())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -159,7 +159,7 @@ impl SingleCertificateBuilder {
         Ok(CertificateBuilderResult {
             cert: self.cert.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::NativeScript(native_script.clone(), witness_info.clone())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -185,7 +185,7 @@ impl SingleCertificateBuilder {
         Ok(CertificateBuilderResult {
             cert: self.cert.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::PlutusScriptNoDatum(partial_witness.clone(), witness_info.clone())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 }

--- a/rust/src/builders/input_builder.rs
+++ b/rust/src/builders/input_builder.rs
@@ -1,0 +1,162 @@
+use crate::*;
+use crate::builders::witness_builder::{InputAggregateWitnessData, PartialPlutusWitness};
+
+use super::witness_builder::RequiredWitnessSet;
+
+// comes from witsVKeyNeeded in the Ledger spec
+pub fn input_required_wits(utxo_info: &TransactionOutput, required_witnesses: &mut RequiredWitnessSet) -> () {
+    // TODO: script hash, plutus script, plutus data
+    if let Some(cred) = &utxo_info.address().payment_cred() {
+        if let Some(keyhash) = &cred.to_keyhash() {
+            required_witnesses.add_vkey_key_hash(&keyhash);
+        }
+        if let Some(script_hash) = &cred.to_scripthash() {
+            required_witnesses.add_script_hash(&script_hash);
+            if let Some(data_hash) = utxo_info.data_hash() {
+                required_witnesses.add_plutus_datum_hash(&data_hash);
+                // note: redeemer is required as well
+                // but we can't know the index, so we rely on the tx builder to satisfy this requirement
+            }
+        }
+    };
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct InputBuilderResult {
+    input: TransactionInput,
+    utxo_info: TransactionOutput,
+    aggregate_witness: Option<InputAggregateWitnessData>,
+    required_wits: RequiredWitnessSet,
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct SingleInputBuilder {
+    input: TransactionInput,
+    utxo_info: TransactionOutput,
+}
+
+#[wasm_bindgen]
+impl SingleInputBuilder {
+    pub fn new(input: &TransactionInput, utxo_info: &TransactionOutput,) -> Self {
+        Self {
+            input: input.clone(),
+            utxo_info: utxo_info.clone(),
+        }
+    }
+
+    pub fn skip_witness(&self) -> Result<InputBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        input_required_wits(&self.utxo_info, &mut required_wits);
+
+        Ok(InputBuilderResult {
+            input: self.input.clone(),
+            utxo_info: self.utxo_info.clone(),
+            aggregate_witness: None,
+            required_wits: required_wits.clone(),
+        })
+    }
+
+    pub fn vkey(&self, vkey: &Vkey) -> Result<InputBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        input_required_wits(&self.utxo_info,&mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        let keyhash = &vkey.public_key().hash();
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.vkeys.contains(&keyhash);
+        
+        // check the user provided all the required witnesses
+        required_wits_left.vkeys.remove(&keyhash);
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
+        Ok(InputBuilderResult {
+            input: self.input.clone(),
+            utxo_info: self.utxo_info.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::Vkeys(vec![vkey.clone()])) } else { None },
+            required_wits: required_wits.clone(),
+        })
+    }
+
+    pub fn bootstrap(&self, bootstrap: &BootstrapWitness) -> Result<InputBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        input_required_wits(&self.utxo_info,&mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        let keyhash = &bootstrap.vkey().public_key().hash();
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.bootstraps.contains(&keyhash);
+        
+        // check the user provided all the required witnesses
+        required_wits_left.bootstraps.remove(&keyhash);
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
+        Ok(InputBuilderResult {
+            input: self.input.clone(),
+            utxo_info: self.utxo_info.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::Bootstraps(vec![bootstrap.clone()])) } else { None },
+            required_wits: required_wits.clone(),
+        })
+    }
+
+    pub fn native_script(&self, native_script: &NativeScript) -> Result<InputBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        input_required_wits(&self.utxo_info,&mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        let script_hash = &native_script.hash(ScriptHashNamespace::NativeScript);
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.scripts.contains(script_hash);
+        
+        // check the user provided all the required witnesses
+        required_wits_left.scripts.remove(script_hash);
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
+        Ok(InputBuilderResult {
+            input: self.input.clone(),
+            utxo_info: self.utxo_info.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::NativeScript(native_script.clone())) } else { None },
+            required_wits: required_wits.clone(),
+        })
+    }
+
+    pub fn plutus_script(&self, partial_witness: &PartialPlutusWitness, datum: &PlutusData) -> Result<InputBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        input_required_wits(&self.utxo_info,&mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        // TODO: Plutus V2
+        let script_hash = &partial_witness.script().hash(ScriptHashNamespace::PlutusV1);
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.scripts.contains(script_hash);
+        
+        // check the user provided all the required witnesses
+        required_wits_left.scripts.remove(script_hash);
+        required_wits_left.plutus_data.remove(&hash_plutus_data(datum));
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the certificate: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
+        Ok(InputBuilderResult {
+            input: self.input.clone(),
+            utxo_info: self.utxo_info.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::PlutusScriptWithDatum(partial_witness.clone(), datum.clone())) } else { None },
+            required_wits: required_wits.clone(),
+        })
+    }
+}

--- a/rust/src/builders/input_builder.rs
+++ b/rust/src/builders/input_builder.rs
@@ -3,7 +3,7 @@ use crate::builders::witness_builder::{InputAggregateWitnessData, PartialPlutusW
 
 use super::witness_builder::{RequiredWitnessSet, NativeScriptWitnessInfo, PlutusScriptWitnessInfo};
 
-pub fn input_required_wits(utxo_info: &TransactionOutput, required_witnesses: &mut RequiredWitnessSet) -> () {
+pub fn input_required_wits(utxo_info: &TransactionOutput, required_witnesses: &mut RequiredWitnessSet) {
     if let Some(cred) = &utxo_info.address().payment_cred() {
         if let Some(keyhash) = &cred.to_keyhash() {
             required_witnesses.add_vkey_key_hash(&keyhash);
@@ -52,7 +52,7 @@ impl SingleInputBuilder {
             input: self.input.clone(),
             utxo_info: self.utxo_info.clone(),
             aggregate_witness: None,
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -61,7 +61,7 @@ impl SingleInputBuilder {
         input_required_wits(&self.utxo_info,&mut required_wits);
         let mut required_wits_left = required_wits.clone();
 
-        let keyhash = &vkey.public_key().hash();
+        let keyhash = vkey.public_key().hash();
 
         // the user may have provided more witnesses than required. Strip it down to just the required wits
         let contains = required_wits_left.vkeys.contains(&keyhash);
@@ -77,7 +77,7 @@ impl SingleInputBuilder {
             input: self.input.clone(),
             utxo_info: self.utxo_info.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::Vkeys(vec![vkey.clone()])) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -102,7 +102,7 @@ impl SingleInputBuilder {
             input: self.input.clone(),
             utxo_info: self.utxo_info.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::Bootstraps(vec![bootstrap.clone()])) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -127,7 +127,7 @@ impl SingleInputBuilder {
             input: self.input.clone(),
             utxo_info: self.utxo_info.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::NativeScript(native_script.clone(), witness_info.clone())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -155,7 +155,7 @@ impl SingleInputBuilder {
             input: self.input.clone(),
             utxo_info: self.utxo_info.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::PlutusScriptWithDatum(partial_witness.clone(), witness_info.clone(), datum.clone())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 }

--- a/rust/src/builders/mint_builder.rs
+++ b/rust/src/builders/mint_builder.rs
@@ -1,0 +1,58 @@
+use crate::*;
+use crate::builders::witness_builder::{InputAggregateWitnessData, PartialPlutusWitness};
+
+use super::witness_builder::{RequiredWitnessSet, NativeScriptWitnessInfo, PlutusScriptWitnessInfo};
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct MintBuilderResult {
+    policy_id: PolicyID,
+    assets: MintAssets,
+    aggregate_witness: Option<InputAggregateWitnessData>,
+    required_wits: RequiredWitnessSet,
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct SingleMintBuilder {
+    assets: MintAssets,
+}
+
+#[wasm_bindgen]
+impl SingleMintBuilder {
+    pub fn new(assets: &MintAssets,) -> Self {
+        Self {
+            assets: assets.clone(),
+        }
+    }
+
+    pub fn skip_witness(&self, policy_id: &PolicyID) -> MintBuilderResult {
+        MintBuilderResult {
+            assets: self.assets.clone(),
+            policy_id: policy_id.clone(),
+            aggregate_witness: None,
+            required_wits: RequiredWitnessSet::default(),
+        }
+    }
+
+    pub fn native_script(&self, native_script: &NativeScript, witness_info: &NativeScriptWitnessInfo) -> Result<MintBuilderResult, JsError> {
+        Ok(MintBuilderResult {
+            assets: self.assets.clone(),
+            policy_id: native_script.hash(ScriptHashNamespace::NativeScript),
+            aggregate_witness: Some(InputAggregateWitnessData::NativeScript(native_script.clone(), witness_info.clone())),
+            required_wits: RequiredWitnessSet::default(),
+        })
+    }
+
+    pub fn plutus_script(&self, partial_witness: &PartialPlutusWitness, witness_info: &PlutusScriptWitnessInfo) -> Result<MintBuilderResult, JsError> {
+        // TODO: Plutus V2
+        let script_hash = partial_witness.script().hash(ScriptHashNamespace::PlutusV1);
+        
+        Ok(MintBuilderResult {
+            assets: self.assets.clone(),
+            policy_id: script_hash,
+            aggregate_witness: Some(InputAggregateWitnessData::PlutusScriptNoDatum(partial_witness.clone(), witness_info.clone())),
+            required_wits: RequiredWitnessSet::default(),
+        })
+    }
+}

--- a/rust/src/builders/mod.rs
+++ b/rust/src/builders/mod.rs
@@ -1,4 +1,5 @@
 pub mod certificate_builder;
+pub mod input_builder;
 pub mod output_builder;
 pub mod tx_builder;
 pub mod witness_builder;

--- a/rust/src/builders/mod.rs
+++ b/rust/src/builders/mod.rs
@@ -3,3 +3,5 @@ pub mod input_builder;
 pub mod output_builder;
 pub mod tx_builder;
 pub mod witness_builder;
+pub mod withdrawal_builder;
+pub mod mint_builder;

--- a/rust/src/builders/withdrawal_builder.rs
+++ b/rust/src/builders/withdrawal_builder.rs
@@ -1,0 +1,131 @@
+use crate::*;
+use crate::builders::witness_builder::{InputAggregateWitnessData, PartialPlutusWitness};
+
+use super::witness_builder::{RequiredWitnessSet, NativeScriptWitnessInfo, PlutusScriptWitnessInfo};
+
+// comes from witsVKeyNeeded in the Ledger spec
+pub fn withdrawal_required_wits(address: &RewardAddress, required_witnesses: &mut RequiredWitnessSet) -> () {
+    let cred = &address.payment_cred();
+    if let Some(keyhash) = &cred.to_keyhash() {
+        required_witnesses.add_vkey_key_hash(&keyhash);
+    }
+    if let Some(script_hash) = &cred.to_scripthash() {
+        required_witnesses.add_script_hash(&script_hash);
+        // recall: no datum hash for reward withdrawals
+    };
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct WithdrawalBuilderResult {
+    address: RewardAddress,
+    amount: Coin,
+    aggregate_witness: Option<InputAggregateWitnessData>,
+    required_wits: RequiredWitnessSet,
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct SingleWithdrawalBuilder {
+    address: RewardAddress,
+    amount: Coin,
+}
+
+#[wasm_bindgen]
+impl SingleWithdrawalBuilder {
+    pub fn new(address: &RewardAddress, amount: &Coin) -> Self {
+        Self {
+            address: address.clone(),
+            amount: amount.clone(),
+        }
+    }
+
+    pub fn skip_witness(&self) -> WithdrawalBuilderResult {
+        let mut required_wits = RequiredWitnessSet::default();
+        withdrawal_required_wits(&self.address, &mut required_wits);
+
+        WithdrawalBuilderResult {
+            address: self.address.clone(),
+            amount: self.amount.clone(),
+            aggregate_witness: None,
+            required_wits: required_wits.clone(),
+        }
+    }
+
+    pub fn vkeys(&self, vkeys: &Vkeys) -> Result<WithdrawalBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        withdrawal_required_wits(&self.address, &mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let provided_wit_subset: Vec<&Vkey> = vkeys.0.iter().filter(|vkey| required_wits_left.vkeys.contains(&vkey.public_key().hash())).collect();
+        
+        // check the user provided all the required witnesses
+        provided_wit_subset.iter().for_each(|wit| { required_wits_left.vkeys.remove(&wit.public_key().hash()); });
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the withdrawal: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
+        Ok(WithdrawalBuilderResult {
+            address: self.address.clone(),
+            amount: self.amount.clone(),
+            aggregate_witness: if provided_wit_subset.len() > 0 { Some(InputAggregateWitnessData::Vkeys(provided_wit_subset.into_iter().cloned().collect())) } else { None },
+            required_wits: required_wits.clone(),
+        })
+    }
+
+    pub fn vkey(&self, vkey: &Vkey) -> Result<WithdrawalBuilderResult, JsError> {
+        self.vkeys(&Vkeys(vec![vkey.clone()]))
+    }
+
+    pub fn native_script(&self, native_script: &NativeScript, witness_info: &NativeScriptWitnessInfo) -> Result<WithdrawalBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        withdrawal_required_wits(&self.address, &mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.scripts.contains(&native_script.hash(ScriptHashNamespace::NativeScript));
+        
+        // check the user provided all the required witnesses
+        required_wits_left.scripts.remove(&native_script.hash(ScriptHashNamespace::NativeScript));
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the withdrawal: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
+        Ok(WithdrawalBuilderResult {
+            address: self.address.clone(),
+            amount: self.amount.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::NativeScript(native_script.clone(), witness_info.clone())) } else { None },
+            required_wits: required_wits.clone(),
+        })
+    }
+
+    pub fn plutus_script(&self, partial_witness: &PartialPlutusWitness, witness_info: &PlutusScriptWitnessInfo) -> Result<WithdrawalBuilderResult, JsError> {
+        let mut required_wits = RequiredWitnessSet::default();
+        witness_info.missing_signers.0.iter().for_each(|required_signer| required_wits.add_vkey_key_hash(&required_signer));
+        withdrawal_required_wits(&self.address, &mut required_wits);
+        let mut required_wits_left = required_wits.clone();
+
+        // TODO: Plutus V2
+        let script_hash = partial_witness.script().hash(ScriptHashNamespace::PlutusV1);
+
+        // the user may have provided more witnesses than required. Strip it down to just the required wits
+        let contains = required_wits_left.scripts.contains(&script_hash);
+        
+        // check the user provided all the required witnesses
+        required_wits_left.scripts.remove(&script_hash);
+
+        if required_wits_left.len() > 0 {
+            return Err(JsError::from_str(&format!("Missing the following witnesses for the withdrawal: \n{:#?}", required_wits_left.to_str()))); 
+        }
+
+        Ok(WithdrawalBuilderResult {
+            address: self.address.clone(),
+            amount: self.amount.clone(),
+            aggregate_witness: if contains { Some(InputAggregateWitnessData::PlutusScriptNoDatum(partial_witness.clone(), witness_info.clone())) } else { None },
+            required_wits: required_wits.clone(),
+        })
+    }
+}

--- a/rust/src/builders/withdrawal_builder.rs
+++ b/rust/src/builders/withdrawal_builder.rs
@@ -4,7 +4,7 @@ use crate::builders::witness_builder::{InputAggregateWitnessData, PartialPlutusW
 use super::witness_builder::{RequiredWitnessSet, NativeScriptWitnessInfo, PlutusScriptWitnessInfo};
 
 // comes from witsVKeyNeeded in the Ledger spec
-pub fn withdrawal_required_wits(address: &RewardAddress, required_witnesses: &mut RequiredWitnessSet) -> () {
+pub fn withdrawal_required_wits(address: &RewardAddress, required_witnesses: &mut RequiredWitnessSet) {
     let cred = &address.payment_cred();
     if let Some(keyhash) = &cred.to_keyhash() {
         required_witnesses.add_vkey_key_hash(&keyhash);
@@ -48,7 +48,7 @@ impl SingleWithdrawalBuilder {
             address: self.address.clone(),
             amount: self.amount.clone(),
             aggregate_witness: None,
-            required_wits: required_wits.clone(),
+            required_wits,
         }
     }
 
@@ -71,7 +71,7 @@ impl SingleWithdrawalBuilder {
             address: self.address.clone(),
             amount: self.amount.clone(),
             aggregate_witness: if provided_wit_subset.len() > 0 { Some(InputAggregateWitnessData::Vkeys(provided_wit_subset.into_iter().cloned().collect())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -98,7 +98,7 @@ impl SingleWithdrawalBuilder {
             address: self.address.clone(),
             amount: self.amount.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::NativeScript(native_script.clone(), witness_info.clone())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 
@@ -125,7 +125,7 @@ impl SingleWithdrawalBuilder {
             address: self.address.clone(),
             amount: self.amount.clone(),
             aggregate_witness: if contains { Some(InputAggregateWitnessData::PlutusScriptNoDatum(partial_witness.clone(), witness_info.clone())) } else { None },
-            required_wits: required_wits.clone(),
+            required_wits,
         })
     }
 }

--- a/rust/src/builders/witness_builder.rs
+++ b/rust/src/builders/witness_builder.rs
@@ -90,13 +90,14 @@ impl PartialPlutusWitness {
 }
 
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone)]
 pub enum InputAggregateWitnessData {
     // note: this struct may contains duplicates, but it will be de-duped later
     Vkeys(Vec<Vkey>),
+    Bootstraps(Vec<BootstrapWitness>),
     NativeScript(NativeScript),
     PlutusScriptNoDatum(PartialPlutusWitness),
-    PlutusScriptWithDatum((PartialPlutusWitness, PlutusData))
+    PlutusScriptWithDatum(PartialPlutusWitness, PlutusData)
 }
 
 

--- a/rust/src/builders/witness_builder.rs
+++ b/rust/src/builders/witness_builder.rs
@@ -90,9 +90,10 @@ impl PartialPlutusWitness {
 }
 
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum InputAggregateWitnessData {
-    Vkeys(HashSet<Ed25519KeyHash>),
+    // note: this struct may contains duplicates, but it will be de-duped later
+    Vkeys(Vec<Vkey>),
     NativeScript(NativeScript),
     PlutusScriptNoDatum(PartialPlutusWitness),
     PlutusScriptWithDatum((PartialPlutusWitness, PlutusData))
@@ -104,13 +105,12 @@ pub enum InputAggregateWitnessData {
 pub struct RequiredWitnessSet {
     // note: the real key type for these is Vkey
     // but cryptographically these should be equivalent and Ed25519KeyHash is more flexible
-    vkeys: HashSet<Ed25519KeyHash>,
-    bootstraps: HashSet<Ed25519KeyHash>,
-
-    native_scripts: HashSet<ScriptHash>,
-    plutus_scripts: HashSet<ScriptHash>,
-    plutus_data: HashSet<DataHash>,
-    redeemers: HashSet<RedeemerWitnessKey>,
+    pub(crate) vkeys: HashSet<Ed25519KeyHash>,
+    pub(crate) bootstraps: HashSet<Ed25519KeyHash>,
+    // note: no way to differentiate Plutus script from native script
+    pub(crate) scripts: HashSet<ScriptHash>,
+    pub(crate) plutus_data: HashSet<DataHash>,
+    pub(crate) redeemers: HashSet<RedeemerWitnessKey>,
 }
 
 #[wasm_bindgen]
@@ -136,17 +136,14 @@ impl RequiredWitnessSet {
     }
 
     pub fn add_native_script(&mut self, native_script: &NativeScript) {
-        self.add_native_script_hash(&native_script.hash(ScriptHashNamespace::NativeScript));
+        self.add_script_hash(&native_script.hash(ScriptHashNamespace::NativeScript));
     }
-    pub fn add_native_script_hash(&mut self, native_script: &ScriptHash) {
-        self.native_scripts.insert(native_script.clone());
+    pub fn add_script_hash(&mut self, script_hash: &ScriptHash) {
+        self.scripts.insert(script_hash.clone());
     }
 
     pub fn add_plutus_script(&mut self, plutus_script: &PlutusScript) {
-        self.add_plutus_hash(&plutus_script.hash(ScriptHashNamespace::PlutusV1));
-    }
-    pub fn add_plutus_hash(&mut self, plutus_script: &ScriptHash) {
-        self.plutus_scripts.insert(plutus_script.clone());
+        self.add_script_hash(&plutus_script.hash(ScriptHashNamespace::PlutusV1));
     }
 
     pub fn add_plutus_datum(&mut self, plutus_datum: &PlutusData) {
@@ -166,8 +163,7 @@ impl RequiredWitnessSet {
     pub fn add_all(&mut self, requirements: &RequiredWitnessSet) {
         self.vkeys.extend(requirements.vkeys.iter().cloned());
         self.bootstraps.extend(requirements.bootstraps.iter().cloned());
-        self.native_scripts.extend(requirements.native_scripts.iter().cloned());
-        self.plutus_scripts.extend(requirements.plutus_scripts.iter().cloned());
+        self.scripts.extend(requirements.scripts.iter().cloned());
         self.plutus_data.extend(requirements.plutus_data.iter().cloned());
         self.redeemers.extend(requirements.redeemers.iter().cloned());
     }
@@ -175,19 +171,17 @@ impl RequiredWitnessSet {
     pub (crate) fn to_str(&self) -> String {
         let vkeys = self.vkeys.iter().map(|key| format!("Vkey:{}", hex::encode(key.to_bytes()))).collect::<Vec<String>>().join(",");
         let bootstraps = self.bootstraps.iter().map(|key| format!("Legacy Bootstraps:{}", hex::encode(key.to_bytes()))).collect::<Vec<String>>().join(",");
-        let native_scripts = self.native_scripts.iter().map(|hash| format!("Native script hash:{}", hex::encode(hash.to_bytes()))).collect::<Vec<String>>().join(",");
-        let plutus_scripts = self.plutus_scripts.iter().map(|hash| format!("Plutus script hash:{}", hex::encode(hash.to_bytes()))).collect::<Vec<String>>().join(",");
+        let scripts = self.scripts.iter().map(|hash| format!("Script hash:{}", hex::encode(hash.to_bytes()))).collect::<Vec<String>>().join(",");
         let plutus_data = self.plutus_data.iter().map(|hash| format!("Plutus data hash:{}", hex::encode(hash.to_bytes()))).collect::<Vec<String>>().join(",");
         let redeemers = self.redeemers.iter().map(|key| format!("Redeemer:{}-{}", hex::encode(key.tag().to_bytes()), key.index().to_str())).collect::<Vec<String>>().join(",");
 
-        [vkeys, bootstraps, native_scripts, plutus_scripts, plutus_data, redeemers].iter().filter(|msg| !msg.is_empty()).cloned().collect::<Vec<String>>().join("\n")
+        [vkeys, bootstraps, scripts, plutus_data, redeemers].iter().filter(|msg| !msg.is_empty()).cloned().collect::<Vec<String>>().join("\n")
     }
 
     pub (crate) fn len(&self) -> usize {
         self.vkeys.len() +
             self.bootstraps.len() +
-            self.native_scripts.len() +
-            self.plutus_scripts.len() +
+            self.scripts.len() +
             self.plutus_data.len() +
             self.redeemers.len()
     }
@@ -322,11 +316,11 @@ impl TransactionWitnessSetBuilder {
         }
         if !self.native_scripts.is_empty() {
             result.set_native_scripts(&NativeScripts(self.native_scripts.values().cloned().collect()));
-            self.native_scripts.keys().for_each(|hash| { remaining_wits.native_scripts.remove(hash); });
+            self.native_scripts.keys().for_each(|hash| { remaining_wits.scripts.remove(hash); });
         }
         if !self.plutus_scripts.is_empty() {
             result.set_plutus_scripts(&PlutusScripts(self.plutus_scripts.values().cloned().collect()));
-            self.plutus_scripts.keys().for_each(|hash| { remaining_wits.plutus_scripts.remove(hash); });
+            self.plutus_scripts.keys().for_each(|hash| { remaining_wits.scripts.remove(hash); });
         }
         if !self.plutus_data.is_empty() {
             result.set_plutus_data(&PlutusList {


### PR DESCRIPTION
This adds all the component builders I think we will need

The next step after this will be changing the tx builder to have functions like `add_cert` that takes in a builder result instead of a single "add_certs" function. The reason for this change is that having a single add_certs function that deals with all the witness structure of native scripts & plutus would be really ugly, and so things are instead isolated into their own builders.

These builders support inlining witnesses as you build them up, or allow just doing `skip_witness` if, for example, you're building wallet software where the signature comes later. Native scripts & Plutus allow partially filling in the witness as well while keeping track of the # of witnesses requires so we can calculate the tx fee accurately