### PR TITLE
Add a test on real data

### DIFF
--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -3160,6 +3160,8 @@ mod tests {
             &mut output_total,
             |value| Some(value.coin),
             &mut rng).unwrap();
+        assert!(!available_indices.contains(&0));
+        assert!(available_indices.contains(&1));
         assert!(available_indices.len() < 2);
     }
 

--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -3087,6 +3087,47 @@ mod tests {
     }
 
     #[test]
+    fn tx_builder_cip2_random_improve_on_real_data() {
+        let mut tx_builder = create_tx_builder_with_fee(&create_linear_fee(44, 155381));
+        const COST: u64 = 1000000;
+        tx_builder.add_output(
+            &TransactionOutputBuilder::new()
+                .with_address(&Address::from_bech32("addr1vyy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqs6l44z").unwrap())
+                .next().unwrap()
+                .with_coin(&to_bignum(COST))
+                .build().unwrap()
+            ).unwrap();
+        let mut available_inputs = TransactionUnspentOutputs::new();
+        available_inputs.add(&make_input(0u8, Value::new(&to_bignum(1000000))));
+        available_inputs.add(&make_input(1u8, Value::new(&to_bignum(10000000))));
+        let add_inputs_res =
+            tx_builder.add_inputs_from(&available_inputs, CoinSelectionStrategyCIP2::RandomImprove);
+        assert!(add_inputs_res.is_ok(), "{:?}", add_inputs_res.err());
+        let change_addr = ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap().to_address();
+        let add_change_res = tx_builder.add_change_if_needed(&change_addr);
+        assert!(add_change_res.is_ok(), "{:?}", add_change_res.err());
+        let tx_build_res = tx_builder.build();
+        assert!(tx_build_res.is_ok(), "{:?}", tx_build_res.err());
+        let tx = tx_build_res.unwrap();
+        // we need to look up the values to ensure there's enough
+        let mut input_values = BTreeMap::new();
+        for utxo in available_inputs.0.iter() {
+            input_values.insert(utxo.input.transaction_id(), utxo.output.amount.clone());
+        }
+        let mut encountered = std::collections::HashSet::new();
+        let mut input_total = Value::new(&Coin::zero());
+        for input in tx.inputs.0.iter() {
+            let txid = input.transaction_id();
+            if !encountered.insert(txid.clone()) {
+                panic!("Input {:?} duplicated", txid);
+            }
+            let value = input_values.get(&txid).unwrap();
+            input_total = input_total.checked_add(value).unwrap();
+        }
+        assert!(input_total >= Value::new(&tx_builder.min_fee().unwrap().checked_add(&to_bignum(COST)).unwrap()));
+    }
+
+    #[test]
     fn tx_builder_cip2_random_improve_when_using_all_available_inputs() {
         // we have a = 1 to test increasing fees when more inputs are added
         let linear_fee = LinearFee::new(&to_bignum(1), &to_bignum(0));

--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -425,14 +425,14 @@ impl TransactionBuilder {
         Ok(())
     }
 
-    fn cip2_random_improve_by<F>(
+    fn cip2_random_improve_by<F, R: Rng + ?Sized>(
         &mut self,
         available_inputs: &[TransactionUnspentOutput],
         available_indices: &mut BTreeSet<usize>,
         input_total: &mut Value,
         output_total: &mut Value,
         by: F,
-        rng: &mut rand::rngs::ThreadRng) -> Result<(), JsError>
+        rng: &mut R) -> Result<(), JsError>
     where
         F: Fn(&Value) -> Option<BigNum> {
         // Phase 1: Random Selection
@@ -3150,7 +3150,8 @@ mod tests {
             .checked_add(&Value::new(&tx_builder.min_fee().unwrap())).unwrap();
         let mut available_indices: BTreeSet<usize> = (0..available_inputs.len()).collect();
         assert!(available_indices.len() == 2);
-        let mut rng = rand::thread_rng();
+        use rand::SeedableRng;
+        let mut rng = rand_chacha::ChaChaRng::seed_from_u64(1);
         tx_builder.cip2_random_improve_by(
             &available_inputs.0,
             &mut available_indices,

--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -499,9 +499,9 @@ impl TransactionBuilder {
                         move_closer && not_exceed_max
                     };
                     if should_improve {
-                        std::mem::swap(i, j);
                         available_indices.insert(*i);
                         available_indices.remove(j);
+                        std::mem::swap(i, j);
                     }
                 }
             }

--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -4,6 +4,7 @@ use crate::utils;
 use super::output_builder::{TransactionOutputAmountBuilder};
 use super::certificate_builder::*;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use rand::Rng;
 
 fn fake_private_key() -> Bip32PrivateKey {
     Bip32PrivateKey::from_bytes(
@@ -294,7 +295,6 @@ impl TransactionBuilder {
                 if self.outputs.0.iter().any(|output| output.amount.multiasset.is_some()) {
                     return Err(JsError::from_str("Multiasset values not supported by RandomImprove. Please use RandomImproveMultiAsset"));
                 }
-                use rand::Rng;
                 let mut rng = rand::thread_rng();
                 let mut available_indices = (0..available_inputs.len()).collect::<BTreeSet<usize>>();
                 self.cip2_random_improve_by(
@@ -345,7 +345,6 @@ impl TransactionBuilder {
                     |value| Some(value.coin))?;
             },
             CoinSelectionStrategyCIP2::RandomImproveMultiAsset => {
-                use rand::Rng;
                 let mut rng = rand::thread_rng();
                 let mut available_indices = (0..available_inputs.len()).collect::<BTreeSet<usize>>();
                 // run random-improve by each asset type
@@ -436,7 +435,6 @@ impl TransactionBuilder {
         rng: &mut rand::rngs::ThreadRng) -> Result<(), JsError>
     where
         F: Fn(&Value) -> Option<BigNum> {
-        use rand::Rng;
         // Phase 1: Random Selection
         let mut relevant_indices = available_indices.iter()
             .filter(|i| by(&available_inputs[**i].output.amount).is_some())

--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -485,16 +485,20 @@ impl TransactionBuilder {
                 for i in associated.iter_mut() {
                     let random_index = rng.gen_range(0..relevant_indices.len());
                     let j: &mut usize = relevant_indices.get_mut(random_index).unwrap();
-                    let input = &available_inputs[*i];
-                    let new_input = &available_inputs[*j];
-                    let cur = from_bignum(&input.output.amount.coin);
-                    let new = from_bignum(&new_input.output.amount.coin);
-                    let min = from_bignum(&output.amount.coin);
-                    let ideal = 2 * min;
-                    let max = 3 * min;
-                    let move_closer = (ideal as i128 - new as i128).abs() < (ideal as i128 - cur as i128).abs();
-                    let not_exceed_max = new < max;
-                    if move_closer && not_exceed_max {
+                    let should_improve = {
+                        let input = &available_inputs[*i];
+                        let new_input = &available_inputs[*j];
+                        let cur = from_bignum(&input.output.amount.coin);
+                        let new = from_bignum(&new_input.output.amount.coin);
+                        let min = from_bignum(&output.amount.coin);
+                        let ideal = 2 * min;
+                        let max = 3 * min;
+                        let move_closer = (ideal as i128 - new as i128).abs() < (ideal as i128 - cur as i128).abs();
+                        let not_exceed_max = new < max;
+
+                        move_closer && not_exceed_max
+                    };
+                    if should_improve {
                         std::mem::swap(i, j);
                         available_indices.insert(*i);
                         available_indices.remove(j);

--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -3089,47 +3089,6 @@ mod tests {
     }
 
     #[test]
-    fn tx_builder_cip2_random_improve_on_real_data() {
-        let mut tx_builder = create_tx_builder_with_fee(&create_linear_fee(44, 155381));
-        const COST: u64 = 1000000;
-        tx_builder.add_output(
-            &TransactionOutputBuilder::new()
-                .with_address(&Address::from_bech32("addr1vyy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqs6l44z").unwrap())
-                .next().unwrap()
-                .with_coin(&to_bignum(COST))
-                .build().unwrap()
-            ).unwrap();
-        let mut available_inputs = TransactionUnspentOutputs::new();
-        available_inputs.add(&make_input(0u8, Value::new(&to_bignum(1000000))));
-        available_inputs.add(&make_input(1u8, Value::new(&to_bignum(10000000))));
-        let add_inputs_res =
-            tx_builder.add_inputs_from(&available_inputs, CoinSelectionStrategyCIP2::RandomImprove);
-        assert!(add_inputs_res.is_ok(), "{:?}", add_inputs_res.err());
-        let change_addr = ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap().to_address();
-        let add_change_res = tx_builder.add_change_if_needed(&change_addr);
-        assert!(add_change_res.is_ok(), "{:?}", add_change_res.err());
-        let tx_build_res = tx_builder.build();
-        assert!(tx_build_res.is_ok(), "{:?}", tx_build_res.err());
-        let tx = tx_build_res.unwrap();
-        // we need to look up the values to ensure there's enough
-        let mut input_values = BTreeMap::new();
-        for utxo in available_inputs.0.iter() {
-            input_values.insert(utxo.input.transaction_id(), utxo.output.amount.clone());
-        }
-        let mut encountered = std::collections::HashSet::new();
-        let mut input_total = Value::new(&Coin::zero());
-        for input in tx.inputs.0.iter() {
-            let txid = input.transaction_id();
-            if !encountered.insert(txid.clone()) {
-                panic!("Input {:?} duplicated", txid);
-            }
-            let value = input_values.get(&txid).unwrap();
-            input_total = input_total.checked_add(value).unwrap();
-        }
-        assert!(input_total >= Value::new(&tx_builder.min_fee().unwrap().checked_add(&to_bignum(COST)).unwrap()));
-    }
-
-    #[test]
     fn tx_builder_cip2_random_improve_exclude_used_indices() {
         let mut tx_builder = create_tx_builder_with_fee(&create_linear_fee(44, 155381));
         const COST: u64 = 1000000;


### PR DESCRIPTION
As we have discussed [here](https://discord.com/channels/881538386857451560/942104729725567007/967404977347772436), `add_inputs_from` may spend duplicate UTxOs when 1 UTxO is not enough to cover all the outputs. I'm trying to fix this issue in this PR.
I'll add unit test to show the issue first.

#### Fee Settings (on Testnet)
A: 44
B: 155381

#### UTxOs
1. 1 tADA
2. 10 tADA

#### Outputs
1 tADA