### PR TITLE
Fix for >u64 slots in Pointer addresses

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "linked-hash-map",
  "noop_proc_macro",
  "num-bigint",
+ "num-integer",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
@@ -294,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ cfg-if = "1"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 num-bigint = "0.4.0"
+num-integer = "0.1.45"
 # The default can't be compiled to wasm, so it's necessary to use either the 'nightly'
 # feature or this one
 clear_on_drop = { version = "0.2", features = ["no_cc"] }


### PR DESCRIPTION
Pointer addresses with slots that don't fit in uint (u64) have been
found on testnet. To facilitate parsing these this updates Pointer to
use bigints and updates the variable nat encoding/decoding functions to
handle larger sizes.