### PR TITLE
Simplify payment key added in component builders

### DIFF
--- a/rust/pkg/cardano_multiplatform_lib.js.flow
+++ b/rust/pkg/cardano_multiplatform_lib.js.flow
@@ -1718,6 +1718,16 @@ declare export class BootstrapWitness {
     chain_code: Uint8Array,
     attributes: AddrAttributes
   ): BootstrapWitness;
+
+  /**
+   * @returns {Bip32PublicKey}
+   */
+  to_public_key(): Bip32PublicKey;
+
+  /**
+   * @returns {AddressContent}
+   */
+  to_address(): AddressContent;
 }
 /**
  */
@@ -5849,19 +5859,9 @@ declare export class RequiredWitnessSet {
   add_vkey_key_hash(hash: Ed25519KeyHash): void;
 
   /**
-   * @param {BootstrapWitness} bootstrap
+   * @param {ByronAddress} address
    */
-  add_bootstrap(bootstrap: BootstrapWitness): void;
-
-  /**
-   * @param {Vkey} bootstrap
-   */
-  add_bootstrap_key(bootstrap: Vkey): void;
-
-  /**
-   * @param {Ed25519KeyHash} hash
-   */
-  add_bootstrap_key_hash(hash: Ed25519KeyHash): void;
+  add_bootstrap(address: ByronAddress): void;
 
   /**
    * @param {NativeScript} native_script
@@ -6429,16 +6429,9 @@ declare export class SingleCertificateBuilder {
   skip_witness(): CertificateBuilderResult;
 
   /**
-   * @param {Vkeys} vkeys
    * @returns {CertificateBuilderResult}
    */
-  vkeys(vkeys: Vkeys): CertificateBuilderResult;
-
-  /**
-   * @param {Vkey} vkey
-   * @returns {CertificateBuilderResult}
-   */
-  vkey(vkey: Vkey): CertificateBuilderResult;
+  payment_key(): CertificateBuilderResult;
 
   /**
    * Signer keys don't have to be set. You can leave it empty and then add the required witnesses later
@@ -6583,20 +6576,7 @@ declare export class SingleInputBuilder {
   /**
    * @returns {InputBuilderResult}
    */
-  skip_witness(): InputBuilderResult;
-
-  /**
-   * @param {Vkey} vkey
-   * @returns {InputBuilderResult}
-   */
-  vkey(vkey: Vkey): InputBuilderResult;
-
-  /**
-   * @param {Vkey} vkey
-   * @param {ByronAddress} address
-   * @returns {InputBuilderResult}
-   */
-  bootstrap(vkey: Vkey, address: ByronAddress): InputBuilderResult;
+  payment_key(): InputBuilderResult;
 
   /**
    * @param {NativeScript} native_script
@@ -6715,13 +6695,7 @@ declare export class SingleWithdrawalBuilder {
   /**
    * @returns {WithdrawalBuilderResult}
    */
-  skip_witness(): WithdrawalBuilderResult;
-
-  /**
-   * @param {Vkey} vkey
-   * @returns {WithdrawalBuilderResult}
-   */
-  vkey(vkey: Vkey): WithdrawalBuilderResult;
+  payment_key(): WithdrawalBuilderResult;
 
   /**
    * @param {NativeScript} native_script

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -1,7 +1,7 @@
 use super::*;
 use cbor_event::{de::Deserializer, se::Serializer};
 use bech32::ToBase32;
-use crate::{ledger::common::{binary::*, value::{to_bignum, from_bignum}}, byron::{ProtocolMagic, ByronAddress}};
+use crate::{ledger::common::{value::{to_bignum, from_bignum}}, byron::{ProtocolMagic, ByronAddress}};
 
 // returns (Number represented, bytes read) if valid encoding
 // or None if decoding prematurely finished
@@ -166,35 +166,6 @@ impl Deserialize for StakeCredential {
         })().map_err(|e| e.annotate("StakeCredential"))
     }
 }
-
-#[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
-pub struct ByronAddressAttributes(pub (crate) legacy_address::Attributes);
-
-impl ByronAddressAttributes {
-}
-
-impl cbor_event::se::Serialize for ByronAddressAttributes {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.serialize(serializer)
-    }
-}
-
-impl Deserialize for ByronAddressAttributes {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(legacy_address::Attributes::deserialize(raw)?))
-    }
-}
-
-impl JsonSchema for ByronAddressAttributes {
-    fn schema_name() -> String { String::from("ByronAddressAttributes") }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema { String::json_schema(gen) }
-    fn is_referenceable() -> bool { String::is_referenceable() }
-}
-
-to_from_bytes!(ByronAddressAttributes);
-
-to_from_json!(ByronAddressAttributes);
 
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum AddrType {

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -1,4 +1,5 @@
 use super::*;
+use cbor_event::{de::Deserializer, se::Serializer};
 use bech32::ToBase32;
 use crate::{ledger::common::{binary::*, value::{to_bignum, from_bignum}}, byron::{ProtocolMagic, ByronAddress}};
 
@@ -165,6 +166,35 @@ impl Deserialize for StakeCredential {
         })().map_err(|e| e.annotate("StakeCredential"))
     }
 }
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+pub struct ByronAddressAttributes(pub (crate) legacy_address::Attributes);
+
+impl ByronAddressAttributes {
+}
+
+impl cbor_event::se::Serialize for ByronAddressAttributes {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.serialize(serializer)
+    }
+}
+
+impl Deserialize for ByronAddressAttributes {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(legacy_address::Attributes::deserialize(raw)?))
+    }
+}
+
+impl JsonSchema for ByronAddressAttributes {
+    fn schema_name() -> String { String::from("ByronAddressAttributes") }
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema { String::json_schema(gen) }
+    fn is_referenceable() -> bool { String::is_referenceable() }
+}
+
+to_from_bytes!(ByronAddressAttributes);
+
+to_from_json!(ByronAddressAttributes);
 
 #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub enum AddrType {

--- a/rust/src/builders/input_builder.rs
+++ b/rust/src/builders/input_builder.rs
@@ -1,6 +1,5 @@
 use crate::*;
 use crate::builders::witness_builder::{InputAggregateWitnessData, PartialPlutusWitness};
-use crate::byron::ByronAddress;
 use crate::ledger::common::hash::hash_plutus_data;
 
 use super::witness_builder::{RequiredWitnessSet, NativeScriptWitnessInfo, PlutusScriptWitnessInfo};
@@ -20,7 +19,7 @@ pub fn input_required_wits(utxo_info: &TransactionOutput, required_witnesses: &m
         }
     };
     if let Some(byron) = &utxo_info.address().as_byron() {
-        required_witnesses.add_bootstrap_address(byron);
+        required_witnesses.add_bootstrap(byron);
     }
 }
 
@@ -52,10 +51,10 @@ impl SingleInputBuilder {
     pub fn payment_key(&self) -> Result<InputBuilderResult, JsError> {
         let mut required_wits = RequiredWitnessSet::default();
         input_required_wits(&self.utxo_info,&mut required_wits);
-        let mut required_wits_left = required_wits.clone();
+        let required_wits_left = required_wits.clone();
 
         
-        if required_wits_left.scripts.len() > 0 {
+        if !required_wits_left.scripts.is_empty() {
             return Err(JsError::from_str(&format!("UTXO address was not a payment key: \n{:#?}", hex::encode(self.utxo_info.address.to_bytes()))));
         }
 

--- a/rust/src/builders/withdrawal_builder.rs
+++ b/rust/src/builders/withdrawal_builder.rs
@@ -41,34 +41,19 @@ impl SingleWithdrawalBuilder {
         }
     }
 
-    pub fn skip_witness(&self) -> WithdrawalBuilderResult {
-        let mut required_wits = RequiredWitnessSet::default();
-        withdrawal_required_wits(&self.address, &mut required_wits);
-
-        WithdrawalBuilderResult {
-            address: self.address.clone(),
-            amount: self.amount,
-            aggregate_witness: None,
-            required_wits,
-        }
-    }
-
-    pub fn vkey(&self, vkey: &Vkey) -> Result<WithdrawalBuilderResult, JsError> {
+    pub fn payment_key(&self) -> Result<WithdrawalBuilderResult, JsError> {
         let mut required_wits = RequiredWitnessSet::default();
         withdrawal_required_wits(&self.address, &mut required_wits);
         let mut required_wits_left = required_wits.clone();
 
-        // check the user provided all the required witnesses
-        required_wits_left.vkeys.remove(&vkey.public_key().hash());
-
-        if required_wits_left.len() > 0 {
-            return Err(JsError::from_str(&format!("Missing the following witnesses for the withdrawal: \n{:#?}", required_wits_left.to_str())));
+        if required_wits_left.scripts.len() > 0 {
+            return Err(JsError::from_str(&format!("Withdrawal required a script, not a payment key: \n{:#?}", self.address.to_address().to_bech32(None))));
         }
 
         Ok(WithdrawalBuilderResult {
             address: self.address.clone(),
             amount: self.amount,
-            aggregate_witness: Some(InputAggregateWitnessData::Vkeys(vec![vkey.clone()])),
+            aggregate_witness: None,
             required_wits,
         })
     }

--- a/rust/src/byron/mod.rs
+++ b/rust/src/byron/mod.rs
@@ -155,7 +155,7 @@ type Crc32 = u64;
 
 #[wasm_bindgen]
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema)]
 pub struct ByronAddress {
     addr: Vec<u8>,
     crc32: Crc32,


### PR DESCRIPTION
Previously the component builders for the tx builder required knowing the vkeys ahead of time which isn't always possible. This PR sets up the framework for removing this requirement, but it's blocked at the moment because of our good friend "hacky byron support" which comes back to haunt me every single PR we make to this project.