### PR TITLE
Bump wasm_bindgen + fixes for JsError

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -247,9 +247,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -380,6 +380,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -689,9 +695,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "serde",
@@ -701,13 +707,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -716,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -726,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -739,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "winapi"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,9 +46,9 @@ noop_proc_macro = "0.3.0"
 
 # wasm
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "=0.2.78", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.82", features = ["serde-serialize"] }
 rand_os = { version = "0.1", features = ["wasm-bindgen"] }
-js-sys = "=0.3.51"
+js-sys = "=0.3.59"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -179,7 +179,7 @@ impl From<chain_crypto::PublicKeyError> for DeserializeError {
 // since JsError panics when used for non-constants in non-wasm builds even just creating one
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-pub type JsError = JsValue;
+pub type JsError = wasm_bindgen::prelude::JsValue;
 
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 #[derive(Debug, Clone)]

--- a/rust/src/ledger/common/binary.rs
+++ b/rust/src/ledger/common/binary.rs
@@ -4,7 +4,7 @@ use cbor_event::{de::Deserializer, se::Serializer};
 use cbor_event::Special as CBORSpecial;
 use cbor_event::Type as CBORType;
 
-use crate::error::{DeserializeError, DeserializeFailure};
+use crate::error::{DeserializeError, DeserializeFailure, JsError};
 
 // JsError can't be used by non-wasm targets so we use this macro to expose
 // either a DeserializeError or a JsError error depending on if we're on a

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,7 +24,7 @@ use ledger::common::value::{BigNum, Int, Coin, Value};
 use noop_proc_macro::wasm_bindgen;
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::prelude::{JsValue, wasm_bindgen};
 
 // This file was code-generated using an experimental CDDL to rust tool:
 // https://github.com/Emurgo/cddl-codegen


### PR DESCRIPTION
During #81 `utils.rs` was refactored into many places and some wouldn't
be using `error::JsError` which in wasm builds is a typedef for
`js_sys::JsValue` and is its own struct for rust builds (to avoid panics
in JsValue when used from non-wasm builds).

Howeve, some places couldn't see these types and would pull it in
directly from `wasm_bindgen::prelude` from the wildcare import in
`lib.rs`. This caused an issue when bumping `wasm_bindgen` as the
`from_str()` method is no longer in `js_sys::JsError` but still is in
`JsValue`. Between now and #81 this would have also led to panics if
many places when an error was returned when using CML from rust instead
of wasm.

In the future we should deprecate the direct usage of `js_sys::JsValue`
and remove our `JsError` type on rust in favor for real rust errors (not
just string wrappers).

See rustwasm/wasm-bindgen#2710

>Expands the acceptable return-position types to Result<T, E> where T: IntoWasmAbi, E: Into<JsValue>, so you can easily throw your own custom error classes imported from JS

which will greatly improve error handling from the rust side but this
should be done after the rust/wasm split.