### PR TITLE
Rust/WASM initial regeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ rust/target
 .idea
 rust/.idea
 binaryen/
+
+rust/core/target/**
+rust/core/Cargo.lock
+rust/wasm/target/**
+rust/wasm/Cargo.lock
+rust/json-gen-split/target/**

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,3 @@
+# Crate Architecture
+
+For current users, this root `rust/ `crate is the main version of CML and is the only one that should be used. There are also two crates here `rust/core` and `rust/wasm` which are a part of a big refactor and will eventually replace the root crate here at some point in the future, but are still quite WIP for now. The root crate when used for WASM builds via the npm scripts in the root repo dir will utilize the `rust/json-gen` crate here in the build scripts to generate typescript definitions for the JSON conversion. The `rust/json-gen-split` crate is the equivalent for the `rust/core`/`rust/wasm` crates and is not called anywhere from the build scripts, but will someday replace the `rust/json-gen` crate once the refactoring is completed.

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cddl-lib-core"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cbor_event = "2.2.0"
+linked-hash-map = "0.5.3"
+derivative = "2.2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.57"
+schemars = "0.8.8"

--- a/rust/core/src/address.rs
+++ b/rust/core/src/address.rs
@@ -1,0 +1,31 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Address {
+    #[serde(skip)]
+    pub encodings: Option<AddressEncoding>,
+}
+
+impl Address {
+    pub fn new() -> Self {
+        Self {
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct RewardAccount {
+    #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+    #[serde(skip)]
+    pub encodings: Option<RewardAccountEncoding>,
+}
+
+impl RewardAccount {
+    pub fn new() -> Self {
+        Self {
+            encodings: None,
+        }
+    }
+}
+
+use super::*;

--- a/rust/core/src/block.rs
+++ b/rust/core/src/block.rs
@@ -1,0 +1,117 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Block {
+    pub header: Header,
+    pub transaction_bodies: Vec<TransactionBody>,
+    pub transaction_witness_sets: Vec<TransactionWitnessSet>,
+    pub auxiliary_data_set: OrderedHashMap<TransactionIndex, AuxiliaryData>,
+    pub invalid_transactions: Vec<TransactionIndex>,
+    #[serde(skip)]
+    pub encodings: Option<BlockEncoding>,
+}
+
+impl Block {
+    pub fn new(header: Header, transaction_bodies: Vec<TransactionBody>, transaction_witness_sets: Vec<TransactionWitnessSet>, auxiliary_data_set: OrderedHashMap<TransactionIndex, AuxiliaryData>, invalid_transactions: Vec<TransactionIndex>) -> Self {
+        Self {
+            header,
+            transaction_bodies,
+            transaction_witness_sets,
+            auxiliary_data_set,
+            invalid_transactions,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Header {
+    pub header_body: HeaderBody,
+    pub body_signature: KesSignature,
+    #[serde(skip)]
+    pub encodings: Option<HeaderEncoding>,
+}
+
+impl Header {
+    pub fn new(header_body: HeaderBody, body_signature: KesSignature) -> Self {
+        Self {
+            header_body,
+            body_signature,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct HeaderBody {
+    pub block_number: u64,
+    pub slot: u64,
+    pub prev_hash: Option<Hash32>,
+    pub issuer_vkey: Vkey,
+    pub vrf_vkey: VrfVkey,
+    pub vrf_result: VrfCert,
+    pub block_body_size: u64,
+    pub block_body_hash: Hash32,
+    pub operational_cert: OperationalCert,
+    pub protocol_version: ProtocolVersion,
+    #[serde(skip)]
+    pub encodings: Option<HeaderBodyEncoding>,
+}
+
+impl HeaderBody {
+    pub fn new(block_number: u64, slot: u64, prev_hash: Option<Hash32>, issuer_vkey: Vkey, vrf_vkey: VrfVkey, vrf_result: VrfCert, block_body_size: u64, block_body_hash: Hash32, operational_cert: OperationalCert, protocol_version: ProtocolVersion) -> Self {
+        Self {
+            block_number,
+            slot,
+            prev_hash,
+            issuer_vkey,
+            vrf_vkey,
+            vrf_result,
+            block_body_size,
+            block_body_hash,
+            operational_cert,
+            protocol_version,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct OperationalCert {
+    pub hot_vkey: KesVkey,
+    pub sequence_number: u64,
+    pub kes_period: u64,
+    pub sigma: Signature,
+    #[serde(skip)]
+    pub encodings: Option<OperationalCertEncoding>,
+}
+
+impl OperationalCert {
+    pub fn new(hot_vkey: KesVkey, sequence_number: u64, kes_period: u64, sigma: Signature) -> Self {
+        Self {
+            hot_vkey,
+            sequence_number,
+            kes_period,
+            sigma,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ProtocolVersion {
+    pub index_0: u64,
+    pub index_1: u64,
+    #[serde(skip)]
+    pub encodings: Option<ProtocolVersionEncoding>,
+}
+
+impl ProtocolVersion {
+    pub fn new(index_0: u64, index_1: u64) -> Self {
+        Self {
+            index_0,
+            index_1,
+            encodings: None,
+        }
+    }
+}
+
+use super::*;

--- a/rust/core/src/cbor_encodings.rs
+++ b/rust/core/src/cbor_encodings.rs
@@ -1,0 +1,567 @@
+use super::*;
+
+#[derive(Clone, Debug, Default)]
+pub struct AddressEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoAuxDataEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<Sz>,
+    pub orig_deser_order: Vec<usize>,
+    pub key_0_encoding: LenEncoding,
+    pub key_0_key_encodings: BTreeMap<u64, Option<cbor_event::Sz>>,
+    pub key_0_key_encoding: Option<cbor_event::Sz>,
+    pub key_1_encoding: LenEncoding,
+    pub key_1_key_encoding: Option<cbor_event::Sz>,
+    pub key_2_encoding: LenEncoding,
+    pub key_2_elem_encodings: Vec<StringEncoding>,
+    pub key_2_key_encoding: Option<cbor_event::Sz>,
+    pub key_3_encoding: LenEncoding,
+    pub key_3_elem_encodings: Vec<StringEncoding>,
+    pub key_3_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoTxOutEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AssetNameEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BabbageTxOutEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub key_0_key_encoding: Option<cbor_event::Sz>,
+    pub key_1_key_encoding: Option<cbor_event::Sz>,
+    pub key_2_key_encoding: Option<cbor_event::Sz>,
+    pub key_3_tag_encoding: Option<cbor_event::Sz>,
+    pub key_3_bytes_encoding: StringEncoding,
+    pub key_3_encoding: StringEncoding,
+    pub key_3_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BigIntEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub index_1_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BlockEncoding {
+    pub len_encoding: LenEncoding,
+    pub transaction_bodies_encoding: LenEncoding,
+    pub transaction_witness_sets_encoding: LenEncoding,
+    pub auxiliary_data_set_encoding: LenEncoding,
+    pub auxiliary_data_set_key_encodings: BTreeMap<u16, Option<cbor_event::Sz>>,
+    pub invalid_transactions_encoding: LenEncoding,
+    pub invalid_transactions_elem_encodings: Vec<Option<cbor_event::Sz>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BootstrapWitnessEncoding {
+    pub len_encoding: LenEncoding,
+    pub chain_code_encoding: StringEncoding,
+    pub attributes_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ConstrPlutusDataEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<Sz>,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub plutus_datas_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CostmdlsEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub key_0_encoding: LenEncoding,
+    pub key_0_key_encoding: Option<cbor_event::Sz>,
+    pub key_1_encoding: LenEncoding,
+    pub key_1_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DatumOption0Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DatumOption1Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub data_tag_encoding: Option<cbor_event::Sz>,
+    pub data_bytes_encoding: StringEncoding,
+    pub data_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DnsNameEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExUnitPricesEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ExUnitsEncoding {
+    pub len_encoding: LenEncoding,
+    pub mem_encoding: Option<cbor_event::Sz>,
+    pub steps_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GenesisKeyDelegationEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Hash28Encoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Hash32Encoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct HeaderEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct HeaderBodyEncoding {
+    pub len_encoding: LenEncoding,
+    pub block_number_encoding: Option<cbor_event::Sz>,
+    pub slot_encoding: Option<cbor_event::Sz>,
+    pub block_body_size_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InvalidBeforeEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub index_1_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct InvalidHereafterEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub index_1_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Ipv4Encoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Ipv6Encoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct KesSignatureEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct KesVkeyEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MoveInstantaneousRewardEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_1_encoding: LenEncoding,
+    pub coin_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MoveInstantaneousRewardsCertEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MultiHostNameEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Nonce1Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub bytes_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OperationalCertEncoding {
+    pub len_encoding: LenEncoding,
+    pub sequence_number_encoding: Option<cbor_event::Sz>,
+    pub kes_period_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PoolMetadataEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PoolParamsEncoding {
+    pub len_encoding: LenEncoding,
+    pub pledge_encoding: Option<cbor_event::Sz>,
+    pub cost_encoding: Option<cbor_event::Sz>,
+    pub pool_owners_encoding: LenEncoding,
+    pub relays_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PoolRegistrationEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PoolRetirementEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub epoch_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PositiveIntervalEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<Sz>,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub index_1_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ProtocolParamUpdateEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub key_0_encoding: Option<cbor_event::Sz>,
+    pub key_0_key_encoding: Option<cbor_event::Sz>,
+    pub key_1_encoding: Option<cbor_event::Sz>,
+    pub key_1_key_encoding: Option<cbor_event::Sz>,
+    pub key_2_encoding: Option<cbor_event::Sz>,
+    pub key_2_key_encoding: Option<cbor_event::Sz>,
+    pub key_3_encoding: Option<cbor_event::Sz>,
+    pub key_3_key_encoding: Option<cbor_event::Sz>,
+    pub key_4_encoding: Option<cbor_event::Sz>,
+    pub key_4_key_encoding: Option<cbor_event::Sz>,
+    pub key_5_encoding: Option<cbor_event::Sz>,
+    pub key_5_key_encoding: Option<cbor_event::Sz>,
+    pub key_6_encoding: Option<cbor_event::Sz>,
+    pub key_6_key_encoding: Option<cbor_event::Sz>,
+    pub key_7_encoding: Option<cbor_event::Sz>,
+    pub key_7_key_encoding: Option<cbor_event::Sz>,
+    pub key_8_encoding: Option<cbor_event::Sz>,
+    pub key_8_key_encoding: Option<cbor_event::Sz>,
+    pub key_9_key_encoding: Option<cbor_event::Sz>,
+    pub key_10_key_encoding: Option<cbor_event::Sz>,
+    pub key_11_key_encoding: Option<cbor_event::Sz>,
+    pub key_14_key_encoding: Option<cbor_event::Sz>,
+    pub key_16_encoding: Option<cbor_event::Sz>,
+    pub key_16_key_encoding: Option<cbor_event::Sz>,
+    pub key_17_encoding: Option<cbor_event::Sz>,
+    pub key_17_key_encoding: Option<cbor_event::Sz>,
+    pub key_18_key_encoding: Option<cbor_event::Sz>,
+    pub key_19_key_encoding: Option<cbor_event::Sz>,
+    pub key_20_key_encoding: Option<cbor_event::Sz>,
+    pub key_21_key_encoding: Option<cbor_event::Sz>,
+    pub key_22_encoding: Option<cbor_event::Sz>,
+    pub key_22_key_encoding: Option<cbor_event::Sz>,
+    pub key_23_encoding: Option<cbor_event::Sz>,
+    pub key_23_key_encoding: Option<cbor_event::Sz>,
+    pub key_24_encoding: Option<cbor_event::Sz>,
+    pub key_24_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ProtocolVersionEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub index_1_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ProtocolVersionStructEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RationalEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<Sz>,
+    pub numerator_encoding: Option<cbor_event::Sz>,
+    pub denominator_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RedeemerEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RequiredSignersEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RewardAccountEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Script0Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Script1Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub plutus_v1_script_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Script2Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub plutus_v2_script_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ScriptAllEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub native_scripts_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ScriptAnyEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub native_scripts_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ScriptNOfKEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub n_encoding: Option<cbor_event::Sz>,
+    pub native_scripts_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ScriptPubkeyEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyMaAuxDataEncoding {
+    pub len_encoding: LenEncoding,
+    pub transaction_metadata_encoding: LenEncoding,
+    pub transaction_metadata_key_encodings: BTreeMap<u64, Option<cbor_event::Sz>>,
+    pub auxiliary_scripts_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyTxOutEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SignatureEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SignkeyKESEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SingleHostAddrEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub port_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SingleHostNameEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub port_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct StakeCredential0Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct StakeCredential1Encoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct StakeDelegationEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct StakeDeregistrationEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct StakeRegistrationEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TransactionEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TransactionBodyEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub key_0_encoding: LenEncoding,
+    pub key_0_key_encoding: Option<cbor_event::Sz>,
+    pub key_1_encoding: LenEncoding,
+    pub key_1_key_encoding: Option<cbor_event::Sz>,
+    pub key_2_encoding: Option<cbor_event::Sz>,
+    pub key_2_key_encoding: Option<cbor_event::Sz>,
+    pub key_3_encoding: Option<cbor_event::Sz>,
+    pub key_3_key_encoding: Option<cbor_event::Sz>,
+    pub key_4_encoding: LenEncoding,
+    pub key_4_key_encoding: Option<cbor_event::Sz>,
+    pub key_5_encoding: LenEncoding,
+    pub key_5_value_encodings: BTreeMap<RewardAccount, Option<cbor_event::Sz>>,
+    pub key_5_key_encoding: Option<cbor_event::Sz>,
+    pub key_6_key_encoding: Option<cbor_event::Sz>,
+    pub key_7_key_encoding: Option<cbor_event::Sz>,
+    pub key_8_encoding: Option<cbor_event::Sz>,
+    pub key_8_key_encoding: Option<cbor_event::Sz>,
+    pub key_9_encoding: LenEncoding,
+    pub key_9_value_encodings: BTreeMap<Hash28, (LenEncoding, BTreeMap<AssetName, Option<cbor_event::Sz>>)>,
+    pub key_9_key_encoding: Option<cbor_event::Sz>,
+    pub key_11_key_encoding: Option<cbor_event::Sz>,
+    pub key_13_encoding: LenEncoding,
+    pub key_13_key_encoding: Option<cbor_event::Sz>,
+    pub key_14_key_encoding: Option<cbor_event::Sz>,
+    pub key_15_key_encoding: Option<cbor_event::Sz>,
+    pub key_16_key_encoding: Option<cbor_event::Sz>,
+    pub key_17_encoding: Option<cbor_event::Sz>,
+    pub key_17_key_encoding: Option<cbor_event::Sz>,
+    pub key_18_encoding: LenEncoding,
+    pub key_18_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TransactionInputEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TransactionWitnessSetEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub key_0_encoding: LenEncoding,
+    pub key_0_key_encoding: Option<cbor_event::Sz>,
+    pub key_1_encoding: LenEncoding,
+    pub key_1_key_encoding: Option<cbor_event::Sz>,
+    pub key_2_encoding: LenEncoding,
+    pub key_2_key_encoding: Option<cbor_event::Sz>,
+    pub key_3_encoding: LenEncoding,
+    pub key_3_elem_encodings: Vec<StringEncoding>,
+    pub key_3_key_encoding: Option<cbor_event::Sz>,
+    pub key_4_encoding: LenEncoding,
+    pub key_4_key_encoding: Option<cbor_event::Sz>,
+    pub key_5_encoding: LenEncoding,
+    pub key_5_key_encoding: Option<cbor_event::Sz>,
+    pub key_6_encoding: LenEncoding,
+    pub key_6_elem_encodings: Vec<StringEncoding>,
+    pub key_6_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct UnitIntervalEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<Sz>,
+    pub index_0_encoding: Option<cbor_event::Sz>,
+    pub index_1_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct UpdateEncoding {
+    pub len_encoding: LenEncoding,
+    pub proposed_protocol_parameter_updates_encoding: LenEncoding,
+    pub epoch_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct UrlEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ValueEncoding {
+    pub len_encoding: LenEncoding,
+    pub coin_encoding: Option<cbor_event::Sz>,
+    pub multiasset_encoding: LenEncoding,
+    pub multiasset_value_encodings: BTreeMap<Hash28, (LenEncoding, BTreeMap<AssetName, Option<cbor_event::Sz>>)>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VkeyEncoding {
+    pub inner_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VkeywitnessEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VrfCertEncoding {
+    pub len_encoding: LenEncoding,
+    pub index_0_encoding: StringEncoding,
+    pub bytes_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VrfVkeyEncoding {
+    pub inner_encoding: StringEncoding,
+}

--- a/rust/core/src/certs.rs
+++ b/rust/core/src/certs.rs
@@ -1,0 +1,472 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum Certificate {
+    StakeRegistration(StakeRegistration),
+    StakeDeregistration(StakeDeregistration),
+    StakeDelegation(StakeDelegation),
+    PoolRegistration(PoolRegistration),
+    PoolRetirement(PoolRetirement),
+    GenesisKeyDelegation(GenesisKeyDelegation),
+    MoveInstantaneousRewardsCert(MoveInstantaneousRewardsCert),
+}
+
+impl Certificate {
+    pub fn new_stake_registration(stake_credential: StakeCredential) -> Self {
+        Self::StakeRegistration(StakeRegistration::new(stake_credential))
+    }
+
+    pub fn new_stake_deregistration(stake_credential: StakeCredential) -> Self {
+        Self::StakeDeregistration(StakeDeregistration::new(stake_credential))
+    }
+
+    pub fn new_stake_delegation(stake_credential: StakeCredential, pool_keyhash: PoolKeyhash) -> Self {
+        Self::StakeDelegation(StakeDelegation::new(stake_credential, pool_keyhash))
+    }
+
+    pub fn new_pool_registration(pool_params: PoolParams) -> Self {
+        Self::PoolRegistration(PoolRegistration::new(pool_params))
+    }
+
+    pub fn new_pool_retirement(pool_keyhash: PoolKeyhash, epoch: Epoch) -> Self {
+        Self::PoolRetirement(PoolRetirement::new(pool_keyhash, epoch))
+    }
+
+    pub fn new_genesis_key_delegation(genesishash: Genesishash, genesis_delegate_hash: GenesisDelegateHash, vrf_keyhash: VrfKeyhash) -> Self {
+        Self::GenesisKeyDelegation(GenesisKeyDelegation::new(genesishash, genesis_delegate_hash, vrf_keyhash))
+    }
+
+    pub fn new_move_instantaneous_rewards_cert(move_instantaneous_reward: MoveInstantaneousReward) -> Self {
+        Self::MoveInstantaneousRewardsCert(MoveInstantaneousRewardsCert::new(move_instantaneous_reward))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct DnsName {
+    pub inner: String,
+    #[serde(skip)]
+    pub encodings: Option<DnsNameEncoding>,
+}
+
+impl DnsName {
+    pub fn get(&self) -> &String {
+        &self.inner
+    }
+
+    pub fn new(inner: String) -> Result<Self, DeserializeError> {
+        if inner.len() > 64 {
+            return Err(DeserializeError::new("DnsName", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(0), max: Some(64) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<String> for DnsName {
+    type Error = DeserializeError;
+
+    fn try_from(inner: String) -> Result<Self, Self::Error> {
+        DnsName::new(inner)
+    }
+}
+
+impl From<DnsName> for String {
+    fn from(wrapper: DnsName) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct GenesisKeyDelegation {
+    pub genesishash: Genesishash,
+    pub genesis_delegate_hash: GenesisDelegateHash,
+    pub vrf_keyhash: VrfKeyhash,
+    #[serde(skip)]
+    pub encodings: Option<GenesisKeyDelegationEncoding>,
+}
+
+impl GenesisKeyDelegation {
+    pub fn new(genesishash: Genesishash, genesis_delegate_hash: GenesisDelegateHash, vrf_keyhash: VrfKeyhash) -> Self {
+        Self {
+            genesishash,
+            genesis_delegate_hash,
+            vrf_keyhash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Ipv4 {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<Ipv4Encoding>,
+}
+
+impl Ipv4 {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 4 {
+            return Err(DeserializeError::new("Ipv4", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(4), max: Some(4) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for Ipv4 {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        Ipv4::new(inner)
+    }
+}
+
+impl From<Ipv4> for Vec<u8> {
+    fn from(wrapper: Ipv4) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Ipv6 {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<Ipv6Encoding>,
+}
+
+impl Ipv6 {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 16 {
+            return Err(DeserializeError::new("Ipv6", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(16), max: Some(16) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for Ipv6 {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        Ipv6::new(inner)
+    }
+}
+
+impl From<Ipv6> for Vec<u8> {
+    fn from(wrapper: Ipv6) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MoveInstantaneousReward {
+    pub index_0: I0OrI1,
+    pub index_1: OrderedHashMap<StakeCredential, DeltaCoin>,
+    pub coin: Coin,
+    #[serde(skip)]
+    pub encodings: Option<MoveInstantaneousRewardEncoding>,
+}
+
+impl MoveInstantaneousReward {
+    pub fn new(index_0: I0OrI1, index_1: OrderedHashMap<StakeCredential, DeltaCoin>, coin: Coin) -> Self {
+        Self {
+            index_0,
+            index_1,
+            coin,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MoveInstantaneousRewardsCert {
+    pub move_instantaneous_reward: MoveInstantaneousReward,
+    #[serde(skip)]
+    pub encodings: Option<MoveInstantaneousRewardsCertEncoding>,
+}
+
+impl MoveInstantaneousRewardsCert {
+    pub fn new(move_instantaneous_reward: MoveInstantaneousReward) -> Self {
+        Self {
+            move_instantaneous_reward,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MultiHostName {
+    pub dns_name: DnsName,
+    #[serde(skip)]
+    pub encodings: Option<MultiHostNameEncoding>,
+}
+
+impl MultiHostName {
+    pub fn new(dns_name: DnsName) -> Self {
+        Self {
+            dns_name,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct PoolMetadata {
+    pub url: Url,
+    pub pool_metadata_hash: PoolMetadataHash,
+    #[serde(skip)]
+    pub encodings: Option<PoolMetadataEncoding>,
+}
+
+impl PoolMetadata {
+    pub fn new(url: Url, pool_metadata_hash: PoolMetadataHash) -> Self {
+        Self {
+            url,
+            pool_metadata_hash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct PoolParams {
+    pub operator: PoolKeyhash,
+    pub vrf_keyhash: VrfKeyhash,
+    pub pledge: Coin,
+    pub cost: Coin,
+    pub margin: UnitInterval,
+    pub reward_account: RewardAccount,
+    pub pool_owners: Vec<AddrKeyhash>,
+    pub relays: Vec<Relay>,
+    pub pool_metadata: Option<PoolMetadata>,
+    #[serde(skip)]
+    pub encodings: Option<PoolParamsEncoding>,
+}
+
+impl PoolParams {
+    pub fn new(operator: PoolKeyhash, vrf_keyhash: VrfKeyhash, pledge: Coin, cost: Coin, margin: UnitInterval, reward_account: RewardAccount, pool_owners: Vec<AddrKeyhash>, relays: Vec<Relay>, pool_metadata: Option<PoolMetadata>) -> Self {
+        Self {
+            operator,
+            vrf_keyhash,
+            pledge,
+            cost,
+            margin,
+            reward_account,
+            pool_owners,
+            relays,
+            pool_metadata,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct PoolRegistration {
+    pub pool_params: PoolParams,
+    #[serde(skip)]
+    pub encodings: Option<PoolRegistrationEncoding>,
+}
+
+impl PoolRegistration {
+    pub fn new(pool_params: PoolParams) -> Self {
+        Self {
+            pool_params,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct PoolRetirement {
+    pub pool_keyhash: PoolKeyhash,
+    pub epoch: Epoch,
+    #[serde(skip)]
+    pub encodings: Option<PoolRetirementEncoding>,
+}
+
+impl PoolRetirement {
+    pub fn new(pool_keyhash: PoolKeyhash, epoch: Epoch) -> Self {
+        Self {
+            pool_keyhash,
+            epoch,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum Relay {
+    SingleHostAddr(SingleHostAddr),
+    SingleHostName(SingleHostName),
+    MultiHostName(MultiHostName),
+}
+
+impl Relay {
+    pub fn new_single_host_addr(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
+        Self::SingleHostAddr(SingleHostAddr::new(port, ipv4, ipv6))
+    }
+
+    pub fn new_single_host_name(port: Option<Port>, dns_name: DnsName) -> Self {
+        Self::SingleHostName(SingleHostName::new(port, dns_name))
+    }
+
+    pub fn new_multi_host_name(dns_name: DnsName) -> Self {
+        Self::MultiHostName(MultiHostName::new(dns_name))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct SingleHostAddr {
+    pub port: Option<Port>,
+    pub ipv4: Option<Ipv4>,
+    pub ipv6: Option<Ipv6>,
+    #[serde(skip)]
+    pub encodings: Option<SingleHostAddrEncoding>,
+}
+
+impl SingleHostAddr {
+    pub fn new(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
+        Self {
+            port,
+            ipv4,
+            ipv6,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct SingleHostName {
+    pub port: Option<Port>,
+    pub dns_name: DnsName,
+    #[serde(skip)]
+    pub encodings: Option<SingleHostNameEncoding>,
+}
+
+impl SingleHostName {
+    pub fn new(port: Option<Port>, dns_name: DnsName) -> Self {
+        Self {
+            port,
+            dns_name,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord="feature_allow_slow_enum", PartialOrd="feature_allow_slow_enum", Hash)]
+pub enum StakeCredential {
+    StakeCredential0(StakeCredential0),
+    StakeCredential1(StakeCredential1),
+}
+
+impl StakeCredential {
+    pub fn new_stake_credential0(addr_keyhash: AddrKeyhash) -> Self {
+        Self::StakeCredential0(StakeCredential0::new(addr_keyhash))
+    }
+
+    pub fn new_stake_credential1(scripthash: Scripthash) -> Self {
+        Self::StakeCredential1(StakeCredential1::new(scripthash))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct StakeDelegation {
+    pub stake_credential: StakeCredential,
+    pub pool_keyhash: PoolKeyhash,
+    #[serde(skip)]
+    pub encodings: Option<StakeDelegationEncoding>,
+}
+
+impl StakeDelegation {
+    pub fn new(stake_credential: StakeCredential, pool_keyhash: PoolKeyhash) -> Self {
+        Self {
+            stake_credential,
+            pool_keyhash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct StakeDeregistration {
+    pub stake_credential: StakeCredential,
+    #[serde(skip)]
+    pub encodings: Option<StakeDeregistrationEncoding>,
+}
+
+impl StakeDeregistration {
+    pub fn new(stake_credential: StakeCredential) -> Self {
+        Self {
+            stake_credential,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct StakeRegistration {
+    pub stake_credential: StakeCredential,
+    #[serde(skip)]
+    pub encodings: Option<StakeRegistrationEncoding>,
+}
+
+impl StakeRegistration {
+    pub fn new(stake_credential: StakeCredential) -> Self {
+        Self {
+            stake_credential,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Url {
+    pub inner: String,
+    #[serde(skip)]
+    pub encodings: Option<UrlEncoding>,
+}
+
+impl Url {
+    pub fn get(&self) -> &String {
+        &self.inner
+    }
+
+    pub fn new(inner: String) -> Result<Self, DeserializeError> {
+        if inner.len() > 64 {
+            return Err(DeserializeError::new("Url", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(0), max: Some(64) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<String> for Url {
+    type Error = DeserializeError;
+
+    fn try_from(inner: String) -> Result<Self, Self::Error> {
+        Url::new(inner)
+    }
+}
+
+impl From<Url> for String {
+    fn from(wrapper: Url) -> Self {
+        wrapper.inner
+    }
+}
+
+use super::*;

--- a/rust/core/src/crypto.rs
+++ b/rust/core/src/crypto.rs
@@ -1,0 +1,342 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Hash28 {
+    pub inner: Vec<u8>,
+    #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+    #[serde(skip)]
+    pub encodings: Option<Hash28Encoding>,
+}
+
+impl Hash28 {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 28 {
+            return Err(DeserializeError::new("Hash28", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(28), max: Some(28) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for Hash28 {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        Hash28::new(inner)
+    }
+}
+
+impl From<Hash28> for Vec<u8> {
+    fn from(wrapper: Hash28) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Hash32 {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<Hash32Encoding>,
+}
+
+impl Hash32 {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 32 {
+            return Err(DeserializeError::new("Hash32", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(32), max: Some(32) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for Hash32 {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        Hash32::new(inner)
+    }
+}
+
+impl From<Hash32> for Vec<u8> {
+    fn from(wrapper: Hash32) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct KesSignature {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<KesSignatureEncoding>,
+}
+
+impl KesSignature {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 32 {
+            return Err(DeserializeError::new("KesSignature", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(32), max: Some(32) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for KesSignature {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        KesSignature::new(inner)
+    }
+}
+
+impl From<KesSignature> for Vec<u8> {
+    fn from(wrapper: KesSignature) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct KesVkey {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<KesVkeyEncoding>,
+}
+
+impl KesVkey {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 8 {
+            return Err(DeserializeError::new("KesVkey", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(8), max: Some(8) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for KesVkey {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        KesVkey::new(inner)
+    }
+}
+
+impl From<KesVkey> for Vec<u8> {
+    fn from(wrapper: KesVkey) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum Nonce {
+    I0 {
+        #[serde(skip)]
+        i0_encoding: Option<cbor_event::Sz>,
+        #[serde(skip)]
+        outer_len_encoding: LenEncoding,
+    }
+    ,
+    Nonce1(Nonce1),
+}
+
+impl Nonce {
+    pub fn new_i0() -> Self {
+        Self::I0 {
+            i0_encoding: None,
+            outer_len_encoding: LenEncoding::default(),
+        }
+    }
+
+    pub fn new_nonce1(bytes: Vec<u8>) -> Self {
+        Self::Nonce1(Nonce1::new(bytes))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Signature {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<SignatureEncoding>,
+}
+
+impl Signature {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 16 {
+            return Err(DeserializeError::new("Signature", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(16), max: Some(16) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for Signature {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        Signature::new(inner)
+    }
+}
+
+impl From<Signature> for Vec<u8> {
+    fn from(wrapper: Signature) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct SignkeyKES {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<SignkeyKESEncoding>,
+}
+
+impl SignkeyKES {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 16 {
+            return Err(DeserializeError::new("SignkeyKES", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(16), max: Some(16) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for SignkeyKES {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        SignkeyKES::new(inner)
+    }
+}
+
+impl From<SignkeyKES> for Vec<u8> {
+    fn from(wrapper: SignkeyKES) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Vkey {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<VkeyEncoding>,
+}
+
+impl Vkey {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 8 {
+            return Err(DeserializeError::new("Vkey", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(8), max: Some(8) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for Vkey {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        Vkey::new(inner)
+    }
+}
+
+impl From<Vkey> for Vec<u8> {
+    fn from(wrapper: Vkey) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct VrfCert {
+    pub index_0: Vec<u8>,
+    pub bytes: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<VrfCertEncoding>,
+}
+
+impl VrfCert {
+    pub fn new(index_0: Vec<u8>, bytes: Vec<u8>) -> Self {
+        Self {
+            index_0,
+            bytes,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct VrfVkey {
+    pub inner: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<VrfVkeyEncoding>,
+}
+
+impl VrfVkey {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 8 {
+            return Err(DeserializeError::new("VrfVkey", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(8), max: Some(8) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for VrfVkey {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        VrfVkey::new(inner)
+    }
+}
+
+impl From<VrfVkey> for Vec<u8> {
+    fn from(wrapper: VrfVkey) -> Self {
+        wrapper.inner
+    }
+}
+
+use super::*;

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -1,0 +1,636 @@
+use std::io::{BufRead, Seek, Write};
+use prelude::*;
+
+// This library was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cbor_event::{self, de::Deserializer, se::Serializer};
+
+use cbor_event::Type as CBORType;
+
+use cbor_event::Special as CBORSpecial;
+
+use serialization::*;
+
+use std::collections::BTreeMap;
+
+use std::convert::{From, TryFrom};
+
+pub mod prelude;
+
+pub mod serialization;
+
+pub mod ordered_hash_map;
+
+use ordered_hash_map::OrderedHashMap;
+
+use cbor_event::{Sz, LenSz, StringLenSz};
+
+pub mod cbor_encodings;
+
+use cbor_encodings::*;
+
+extern crate derivative;
+
+use derivative::Derivative;
+
+pub type AddrKeyhash = Hash28;
+
+pub type AuxiliaryDataHash = Hash32;
+
+pub type BoundedBytes = Vec<u8>;
+
+pub type Coin = u64;
+
+pub type Data = Vec<u8>;
+
+pub type DatumHash = Hash32;
+
+pub type DeltaCoin = Int;
+
+pub type Epoch = u64;
+
+pub type GenesisDelegateHash = Hash28;
+
+pub type Genesishash = Hash28;
+
+pub type Genesishashs = Vec<Genesishash>;
+
+pub type Int64 = i64;
+
+pub type Metadata = OrderedHashMap<TransactionMetadatumLabel, TransactionMetadatum>;
+
+pub type Mint = OrderedHashMap<PolicyId, OrderedHashMap<AssetName, Int64>>;
+
+pub type Multiasset = OrderedHashMap<PolicyId, OrderedHashMap<AssetName, u64>>;
+
+pub type Natural = Vec<u8>;
+
+pub type PlutusV1Script = Vec<u8>;
+
+pub type PlutusV2Script = Vec<u8>;
+
+pub type PolicyId = Hash28;
+
+pub type PolicyIds = Vec<PolicyId>;
+
+pub type PoolKeyhash = Hash28;
+
+pub type PoolMetadataHash = Hash32;
+
+pub type Port = u16;
+
+pub type ProposedProtocolParameterUpdates = OrderedHashMap<Genesishash, ProtocolParamUpdate>;
+
+pub type RewardAccounts = Vec<RewardAccount>;
+
+pub type ScriptDataHash = Hash32;
+
+pub type ScriptRef = Vec<u8>;
+
+pub type Scripthash = Hash28;
+
+pub type ShelleyAuxData = OrderedHashMap<TransactionMetadatumLabel, TransactionMetadatum>;
+
+pub type SubCoin = PositiveInterval;
+
+pub type TransactionIndex = u16;
+
+pub type TransactionMetadatumLabel = u64;
+
+pub type VrfKeyhash = Hash32;
+
+pub type Withdrawals = OrderedHashMap<RewardAccount, Coin>;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord="feature_allow_slow_enum", PartialOrd="feature_allow_slow_enum", Hash)]
+pub enum Int {
+    Uint {
+        value: u64,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        encoding: Option<cbor_event::Sz>,
+    }
+    ,
+    Nint {
+        value: u64,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        encoding: Option<cbor_event::Sz>,
+    }
+    ,
+}
+
+#[derive(Clone, Debug)]
+pub enum IntError {
+    Bounds(std::num::TryFromIntError),
+    Parsing(std::num::ParseIntError),
+}
+
+impl Int {
+    pub fn new_uint(value: u64) -> Self {
+        Self::Uint {
+            value,
+            encoding: None,
+        }
+    }
+
+    /// * `value` - Value as encoded in CBOR - note: a negative `x` here would be `|x + 1|` due to CBOR's `nint` encoding e.g. to represent -5, pass in 4.
+    pub fn new_nint(value: u64) -> Self {
+        Self::Nint {
+            value,
+            encoding: None,
+        }
+    }
+}
+
+impl std::fmt::Display for Int {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Uint{ value, .. } => write!(f, "{}", value),
+            Self::Nint{ value, .. } => write!(f, "-{}", value + 1),
+        }
+    }
+}
+
+impl std::str::FromStr for Int {
+    type Err = IntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let x = i128::from_str(s).map_err(IntError::Parsing)?;
+        Self::try_from(x).map_err(IntError::Bounds)
+    }
+}
+
+impl TryFrom<i128> for Int {
+    type Error = std::num::TryFromIntError;
+
+    fn try_from(x: i128) -> Result<Self, Self::Error> {
+        if x >= 0 {
+            u64::try_from(x).map(|x| Self::Uint{ value: x, encoding: None })
+        }
+        else {
+            u64::try_from((x + 1).abs()).map(|x| Self::Nint{ value: x, encoding: None })
+        }
+    }
+}
+
+pub mod address;
+
+pub use address::*;
+
+
+pub mod block;
+
+pub use block::*;
+
+
+pub mod certs;
+
+pub use certs::*;
+
+
+pub mod crypto;
+
+pub use crypto::*;
+
+
+pub mod metadata;
+
+pub use metadata::*;
+
+
+pub mod plutus;
+
+pub use plutus::*;
+
+
+pub mod transaction;
+
+pub use transaction::*;
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct AssetName {
+    pub inner: Vec<u8>,
+    #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+    #[serde(skip)]
+    pub encodings: Option<AssetNameEncoding>,
+}
+
+impl AssetName {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.inner
+    }
+
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() > 32 {
+            return Err(DeserializeError::new("AssetName", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(0), max: Some(32) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: None,
+        })
+    }
+}
+
+impl TryFrom<Vec<u8>> for AssetName {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+        AssetName::new(inner)
+    }
+}
+
+impl From<AssetName> for Vec<u8> {
+    fn from(wrapper: AssetName) -> Self {
+        wrapper.inner
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct BootstrapWitness {
+    pub public_key: Vkey,
+    pub signature: Signature,
+    pub chain_code: Vec<u8>,
+    pub attributes: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<BootstrapWitnessEncoding>,
+}
+
+impl BootstrapWitness {
+    pub fn new(public_key: Vkey, signature: Signature, chain_code: Vec<u8>, attributes: Vec<u8>) -> Self {
+        Self {
+            public_key,
+            signature,
+            chain_code,
+            attributes,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct DatumOption0 {
+    pub hash32: Hash32,
+    #[serde(skip)]
+    pub encodings: Option<DatumOption0Encoding>,
+}
+
+impl DatumOption0 {
+    pub fn new(hash32: Hash32) -> Self {
+        Self {
+            hash32,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct DatumOption1 {
+    pub data: Data,
+    #[serde(skip)]
+    pub encodings: Option<DatumOption1Encoding>,
+}
+
+impl DatumOption1 {
+    pub fn new(data: Data) -> Self {
+        Self {
+            data,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum I0OrI1 {
+    I0 {
+        #[serde(skip)]
+        i0_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+    I1 {
+        #[serde(skip)]
+        i1_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+}
+
+impl I0OrI1 {
+    pub fn new_i0() -> Self {
+        Self::I0 {
+            i0_encoding: None,
+        }
+    }
+
+    pub fn new_i1() -> Self {
+        Self::I1 {
+            i1_encoding: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum NetworkId {
+    I0 {
+        #[serde(skip)]
+        i0_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+    I1 {
+        #[serde(skip)]
+        i1_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+}
+
+impl NetworkId {
+    pub fn new_i0() -> Self {
+        Self::I0 {
+            i0_encoding: None,
+        }
+    }
+
+    pub fn new_i1() -> Self {
+        Self::I1 {
+            i1_encoding: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Nonce1 {
+    pub bytes: Vec<u8>,
+    #[serde(skip)]
+    pub encodings: Option<Nonce1Encoding>,
+}
+
+impl Nonce1 {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct PositiveInterval {
+    #[serde(skip)]
+    pub encodings: Option<PositiveIntervalEncoding>,
+}
+
+impl PositiveInterval {
+    pub fn new() -> Self {
+        Self {
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ProtocolParamUpdate {
+    pub key_0: Option<u64>,
+    pub key_1: Option<u64>,
+    pub key_2: Option<u64>,
+    pub key_3: Option<u64>,
+    pub key_4: Option<u64>,
+    pub key_5: Option<Coin>,
+    pub key_6: Option<Coin>,
+    pub key_7: Option<Epoch>,
+    pub key_8: Option<u64>,
+    pub key_9: Option<Rational>,
+    pub key_10: Option<UnitInterval>,
+    pub key_11: Option<UnitInterval>,
+    pub key_14: Option<ProtocolVersionStruct>,
+    pub key_16: Option<Coin>,
+    pub key_17: Option<Coin>,
+    pub key_18: Option<Costmdls>,
+    pub key_19: Option<ExUnitPrices>,
+    pub key_20: Option<ExUnits>,
+    pub key_21: Option<ExUnits>,
+    pub key_22: Option<u64>,
+    pub key_23: Option<u64>,
+    pub key_24: Option<u64>,
+    #[serde(skip)]
+    pub encodings: Option<ProtocolParamUpdateEncoding>,
+}
+
+impl ProtocolParamUpdate {
+    pub fn new() -> Self {
+        Self {
+            key_0: None,
+            key_1: None,
+            key_2: None,
+            key_3: None,
+            key_4: None,
+            key_5: None,
+            key_6: None,
+            key_7: None,
+            key_8: None,
+            key_9: None,
+            key_10: None,
+            key_11: None,
+            key_14: None,
+            key_16: None,
+            key_17: None,
+            key_18: None,
+            key_19: None,
+            key_20: None,
+            key_21: None,
+            key_22: None,
+            key_23: None,
+            key_24: None,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ProtocolVersionStruct {
+    pub protocol_version: ProtocolVersion,
+    #[serde(skip)]
+    pub encodings: Option<ProtocolVersionStructEncoding>,
+}
+
+impl ProtocolVersionStruct {
+    pub fn new(protocol_version: ProtocolVersion) -> Self {
+        Self {
+            protocol_version,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Rational {
+    pub numerator: u64,
+    pub denominator: u64,
+    #[serde(skip)]
+    pub encodings: Option<RationalEncoding>,
+}
+
+impl Rational {
+    pub fn new(numerator: u64, denominator: u64) -> Self {
+        Self {
+            numerator,
+            denominator,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Script0 {
+    pub native_script: NativeScript,
+    #[serde(skip)]
+    pub encodings: Option<Script0Encoding>,
+}
+
+impl Script0 {
+    pub fn new(native_script: NativeScript) -> Self {
+        Self {
+            native_script,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Script1 {
+    pub plutus_v1_script: PlutusV1Script,
+    #[serde(skip)]
+    pub encodings: Option<Script1Encoding>,
+}
+
+impl Script1 {
+    pub fn new(plutus_v1_script: PlutusV1Script) -> Self {
+        Self {
+            plutus_v1_script,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Script2 {
+    pub plutus_v2_script: PlutusV2Script,
+    #[serde(skip)]
+    pub encodings: Option<Script2Encoding>,
+}
+
+impl Script2 {
+    pub fn new(plutus_v2_script: PlutusV2Script) -> Self {
+        Self {
+            plutus_v2_script,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct StakeCredential0 {
+    pub addr_keyhash: AddrKeyhash,
+    #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+    #[serde(skip)]
+    pub encodings: Option<StakeCredential0Encoding>,
+}
+
+impl StakeCredential0 {
+    pub fn new(addr_keyhash: AddrKeyhash) -> Self {
+        Self {
+            addr_keyhash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct StakeCredential1 {
+    pub scripthash: Scripthash,
+    #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+    #[serde(skip)]
+    pub encodings: Option<StakeCredential1Encoding>,
+}
+
+impl StakeCredential1 {
+    pub fn new(scripthash: Scripthash) -> Self {
+        Self {
+            scripthash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct UnitInterval {
+    pub index_0: u64,
+    pub index_1: u64,
+    #[serde(skip)]
+    pub encodings: Option<UnitIntervalEncoding>,
+}
+
+impl UnitInterval {
+    pub fn new(index_0: u64, index_1: u64) -> Self {
+        Self {
+            index_0,
+            index_1,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Update {
+    pub proposed_protocol_parameter_updates: ProposedProtocolParameterUpdates,
+    pub epoch: Epoch,
+    #[serde(skip)]
+    pub encodings: Option<UpdateEncoding>,
+}
+
+impl Update {
+    pub fn new(proposed_protocol_parameter_updates: ProposedProtocolParameterUpdates, epoch: Epoch) -> Self {
+        Self {
+            proposed_protocol_parameter_updates,
+            epoch,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Value {
+    pub coin: Coin,
+    pub multiasset: Multiasset,
+    #[serde(skip)]
+    pub encodings: Option<ValueEncoding>,
+}
+
+impl Value {
+    pub fn new(coin: Coin, multiasset: Multiasset) -> Self {
+        Self {
+            coin,
+            multiasset,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Vkeywitness {
+    pub vkey: Vkey,
+    pub signature: Signature,
+    #[serde(skip)]
+    pub encodings: Option<VkeywitnessEncoding>,
+}
+
+impl Vkeywitness {
+    pub fn new(vkey: Vkey, signature: Signature) -> Self {
+        Self {
+            vkey,
+            signature,
+            encodings: None,
+        }
+    }
+}

--- a/rust/core/src/metadata.rs
+++ b/rust/core/src/metadata.rs
@@ -1,0 +1,141 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoAuxData {
+    pub key_0: Option<Metadata>,
+    pub key_1: Option<Vec<NativeScript>>,
+    pub key_2: Option<Vec<PlutusV1Script>>,
+    pub key_3: Option<Vec<PlutusV2Script>>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoAuxDataEncoding>,
+}
+
+impl AlonzoAuxData {
+    pub fn new() -> Self {
+        Self {
+            key_0: None,
+            key_1: None,
+            key_2: None,
+            key_3: None,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum AuxiliaryData {
+    ShelleyAuxData {
+        shelley_aux_data: ShelleyAuxData,
+        #[serde(skip)]
+        shelley_aux_data_encoding: LenEncoding,
+        #[serde(skip)]
+        shelley_aux_data_key_encodings: BTreeMap<u64, Option<cbor_event::Sz>>,
+    }
+    ,
+    ShelleyMaAuxData(ShelleyMaAuxData),
+    AlonzoAuxData(AlonzoAuxData),
+}
+
+impl AuxiliaryData {
+    pub fn new_shelley_aux_data(shelley_aux_data: ShelleyAuxData) -> Self {
+        Self::ShelleyAuxData {
+            shelley_aux_data,
+            shelley_aux_data_encoding: LenEncoding::default(),
+            shelley_aux_data_key_encodings: BTreeMap::new(),
+        }
+    }
+
+    pub fn new_shelley_ma_aux_data(shelley_ma_aux_data: ShelleyMaAuxData) -> Self {
+        Self::ShelleyMaAuxData(shelley_ma_aux_data)
+    }
+
+    pub fn new_alonzo_aux_data(alonzo_aux_data: AlonzoAuxData) -> Self {
+        Self::AlonzoAuxData(alonzo_aux_data)
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyMaAuxData {
+    pub transaction_metadata: Metadata,
+    pub auxiliary_scripts: Vec<NativeScript>,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyMaAuxDataEncoding>,
+}
+
+impl ShelleyMaAuxData {
+    pub fn new(transaction_metadata: Metadata, auxiliary_scripts: Vec<NativeScript>) -> Self {
+        Self {
+            transaction_metadata,
+            auxiliary_scripts,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord="feature_allow_slow_enum", PartialOrd="feature_allow_slow_enum", Hash)]
+pub enum TransactionMetadatum {
+    MapTransactionMetadatumToTransactionMetadatum {
+        map_transaction_metadatum_to_transaction_metadatum: OrderedHashMap<TransactionMetadatum, TransactionMetadatum>,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        map_transaction_metadatum_to_transaction_metadatum_encoding: LenEncoding,
+    }
+    ,
+    ArrTransactionMetadatum {
+        arr_transaction_metadatum: Vec<TransactionMetadatum>,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        arr_transaction_metadatum_encoding: LenEncoding,
+    }
+    ,
+    Int(Int),
+    Bytes {
+        bytes: Vec<u8>,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        bytes_encoding: StringEncoding,
+    }
+    ,
+    Text {
+        text: String,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        text_encoding: StringEncoding,
+    }
+    ,
+}
+
+impl TransactionMetadatum {
+    pub fn new_map_transaction_metadatum_to_transaction_metadatum(map_transaction_metadatum_to_transaction_metadatum: OrderedHashMap<TransactionMetadatum, TransactionMetadatum>) -> Self {
+        Self::MapTransactionMetadatumToTransactionMetadatum {
+            map_transaction_metadatum_to_transaction_metadatum,
+            map_transaction_metadatum_to_transaction_metadatum_encoding: LenEncoding::default(),
+        }
+    }
+
+    pub fn new_arr_transaction_metadatum(arr_transaction_metadatum: Vec<TransactionMetadatum>) -> Self {
+        Self::ArrTransactionMetadatum {
+            arr_transaction_metadatum,
+            arr_transaction_metadatum_encoding: LenEncoding::default(),
+        }
+    }
+
+    pub fn new_int(int: Int) -> Self {
+        Self::Int(int)
+    }
+
+    pub fn new_bytes(bytes: Vec<u8>) -> Self {
+        Self::Bytes {
+            bytes,
+            bytes_encoding: StringEncoding::default(),
+        }
+    }
+
+    pub fn new_text(text: String) -> Self {
+        Self::Text {
+            text,
+            text_encoding: StringEncoding::default(),
+        }
+    }
+}
+
+use super::*;

--- a/rust/core/src/ordered_hash_map.rs
+++ b/rust/core/src/ordered_hash_map.rs
@@ -1,0 +1,62 @@
+use core::hash::{Hash, Hasher};
+
+#[derive(Clone, Debug, Ord, Eq, PartialEq, PartialOrd)]
+pub struct OrderedHashMap<K, V>(linked_hash_map::LinkedHashMap<K, V>) where
+    K : Hash + Eq + Ord;
+
+impl<K, V> std::ops::Deref for OrderedHashMap<K, V> where K : Hash + Eq + Ord {
+    type Target = linked_hash_map::LinkedHashMap<K, V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K, V> std::ops::DerefMut for OrderedHashMap<K, V> where K : Hash + Eq + Ord {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K, V> OrderedHashMap<K, V> where K : Hash + Eq + Ord {
+    pub fn new() -> Self {
+        Self(linked_hash_map::LinkedHashMap::new())
+    }
+}
+
+impl<K, V> Hash for OrderedHashMap<K, V> where K : Hash + Eq + Ord, V : Hash {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.0.hash(h);
+    }
+}
+
+impl<K, V> serde::Serialize for OrderedHashMap<K, V> where
+    K : Hash + Eq + Ord + serde::Serialize,
+    V: serde::Serialize {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        let map = self.iter().collect::<std::collections::BTreeMap<_, _>>();
+        map.serialize(serializer)
+    }
+}
+
+impl<'de, K, V> serde::de::Deserialize<'de> for OrderedHashMap<K, V> where
+    K: Hash + Eq + Ord + serde::Deserialize<'de>,
+    V: serde::Deserialize<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where
+    D: serde::de::Deserializer<'de> {
+        let map = <std::collections::BTreeMap<_, _> as serde::de::Deserialize>::deserialize(deserializer)?;
+        Ok(Self(map.into_iter().collect()))
+    }
+}
+
+impl<K, V> schemars::JsonSchema for OrderedHashMap<K, V> where
+    K: Hash + Eq + Ord + schemars::JsonSchema,
+    V: schemars::JsonSchema {
+    fn schema_name() -> String { format!("OrderedHashMap<{}, {}>", K::schema_name(), V::schema_name()) }
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        std::collections::BTreeMap::<K, V>::json_schema(gen)
+    }
+    fn is_referenceable() -> bool { std::collections::BTreeMap::<K, V>::is_referenceable() }
+}
+

--- a/rust/core/src/plutus.rs
+++ b/rust/core/src/plutus.rs
@@ -1,0 +1,250 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct BigInt {
+    #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+    #[serde(skip)]
+    pub encodings: Option<BigIntEncoding>,
+}
+
+impl BigInt {
+    pub fn new() -> Self {
+        Self {
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ConstrPlutusData {
+    pub index_0: u64,
+    pub plutus_datas: Vec<PlutusData>,
+    #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+    #[serde(skip)]
+    pub encodings: Option<ConstrPlutusDataEncoding>,
+}
+
+impl ConstrPlutusData {
+    pub fn new(index_0: u64, plutus_datas: Vec<PlutusData>) -> Self {
+        Self {
+            index_0,
+            plutus_datas,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Costmdls {
+    pub key_0: Option<Vec<Int>>,
+    pub key_1: Option<Vec<Int>>,
+    #[serde(skip)]
+    pub encodings: Option<CostmdlsEncoding>,
+}
+
+impl Costmdls {
+    pub fn new() -> Self {
+        Self {
+            key_0: None,
+            key_1: None,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ExUnitPrices {
+    pub mem_price: SubCoin,
+    pub step_price: SubCoin,
+    #[serde(skip)]
+    pub encodings: Option<ExUnitPricesEncoding>,
+}
+
+impl ExUnitPrices {
+    pub fn new(mem_price: SubCoin, step_price: SubCoin) -> Self {
+        Self {
+            mem_price,
+            step_price,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ExUnits {
+    pub mem: u64,
+    pub steps: u64,
+    #[serde(skip)]
+    pub encodings: Option<ExUnitsEncoding>,
+}
+
+impl ExUnits {
+    pub fn new(mem: u64, steps: u64) -> Self {
+        Self {
+            mem,
+            steps,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum Language {
+    I0 {
+        #[serde(skip)]
+        i0_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+    I1 {
+        #[serde(skip)]
+        i1_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+}
+
+impl Language {
+    pub fn new_i0() -> Self {
+        Self::I0 {
+            i0_encoding: None,
+        }
+    }
+
+    pub fn new_i1() -> Self {
+        Self::I1 {
+            i1_encoding: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derivative(Eq, PartialEq, Ord="feature_allow_slow_enum", PartialOrd="feature_allow_slow_enum", Hash)]
+pub enum PlutusData {
+    ConstrPlutusData(ConstrPlutusData),
+    MapPlutusDataToPlutusData {
+        map_plutus_data_to_plutus_data: OrderedHashMap<PlutusData, PlutusData>,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        map_plutus_data_to_plutus_data_encoding: LenEncoding,
+    }
+    ,
+    ArrPlutusData {
+        arr_plutus_data: Vec<PlutusData>,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        arr_plutus_data_encoding: LenEncoding,
+    }
+    ,
+    BigInt(BigInt),
+    BoundedBytes {
+        bounded_bytes: BoundedBytes,
+        #[derivative(PartialEq="ignore", Ord="ignore", PartialOrd="ignore", Hash="ignore")]
+        #[serde(skip)]
+        bounded_bytes_encoding: StringEncoding,
+    }
+    ,
+}
+
+impl PlutusData {
+    pub fn new_constr_plutus_data(constr_plutus_data: ConstrPlutusData) -> Self {
+        Self::ConstrPlutusData(constr_plutus_data)
+    }
+
+    pub fn new_map_plutus_data_to_plutus_data(map_plutus_data_to_plutus_data: OrderedHashMap<PlutusData, PlutusData>) -> Self {
+        Self::MapPlutusDataToPlutusData {
+            map_plutus_data_to_plutus_data,
+            map_plutus_data_to_plutus_data_encoding: LenEncoding::default(),
+        }
+    }
+
+    pub fn new_arr_plutus_data(arr_plutus_data: Vec<PlutusData>) -> Self {
+        Self::ArrPlutusData {
+            arr_plutus_data,
+            arr_plutus_data_encoding: LenEncoding::default(),
+        }
+    }
+
+    pub fn new_big_int(big_int: BigInt) -> Self {
+        Self::BigInt(big_int)
+    }
+
+    pub fn new_bounded_bytes(bounded_bytes: BoundedBytes) -> Self {
+        Self::BoundedBytes {
+            bounded_bytes,
+            bounded_bytes_encoding: StringEncoding::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Redeemer {
+    pub tag: RedeemerTag,
+    pub index: u64,
+    pub data: PlutusData,
+    pub ex_units: ExUnits,
+    #[serde(skip)]
+    pub encodings: Option<RedeemerEncoding>,
+}
+
+impl Redeemer {
+    pub fn new(tag: RedeemerTag, index: u64, data: PlutusData, ex_units: ExUnits) -> Self {
+        Self {
+            tag,
+            index,
+            data,
+            ex_units,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum RedeemerTag {
+    I0 {
+        #[serde(skip)]
+        i0_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+    I1 {
+        #[serde(skip)]
+        i1_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+    I2 {
+        #[serde(skip)]
+        i2_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+    I3 {
+        #[serde(skip)]
+        i3_encoding: Option<cbor_event::Sz>,
+    }
+    ,
+}
+
+impl RedeemerTag {
+    pub fn new_i0() -> Self {
+        Self::I0 {
+            i0_encoding: None,
+        }
+    }
+
+    pub fn new_i1() -> Self {
+        Self::I1 {
+            i1_encoding: None,
+        }
+    }
+
+    pub fn new_i2() -> Self {
+        Self::I2 {
+            i2_encoding: None,
+        }
+    }
+
+    pub fn new_i3() -> Self {
+        Self::I3 {
+            i3_encoding: None,
+        }
+    }
+}
+
+use super::*;

--- a/rust/core/src/prelude.rs
+++ b/rust/core/src/prelude.rs
@@ -1,0 +1,146 @@
+use cbor_event::{self, de::Deserializer, se::{Serialize, Serializer}};
+use std::io::{BufRead, Seek, Write};
+use crate::serialization::CBORReadLen;
+
+#[derive(Debug)]
+pub enum Key {
+    Str(String),
+    Uint(u64),
+}
+
+impl std::fmt::Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Key::Str(x) => write!(f, "\"{}\"", x),
+            Key::Uint(x) => write!(f, "{}", x),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum DeserializeFailure {
+    BreakInDefiniteLen,
+    CBOR(cbor_event::Error),
+    DefiniteLenMismatch(u64, Option<u64>),
+    DuplicateKey(Key),
+    EndingBreakMissing,
+    ExpectedNull,
+    FixedValueMismatch{
+        found: Key,
+        expected: Key,
+    },
+    MandatoryFieldMissing(Key),
+    NoVariantMatched,
+    RangeCheck{
+        found: usize,
+        min: Option<isize>,
+        max: Option<isize>,
+    },
+    TagMismatch{
+        found: u64,
+        expected: u64,
+    },
+    UnknownKey(Key),
+    UnexpectedKeyType(cbor_event::Type),
+}
+
+// we might want to add more info like which field,
+#[derive(Debug)]
+pub struct DeserializeError {
+    location: Option<String>,
+    failure: DeserializeFailure,
+}
+
+impl DeserializeError {
+    pub fn new<T: Into<String>>(location: T, failure: DeserializeFailure) -> Self {
+        Self {
+            location: Some(location.into()),
+            failure,
+        }
+    }
+
+    pub fn annotate<T: Into<String>>(self, location: T) -> Self {
+        match self.location {
+            Some(loc) => Self::new(format!("{}.{}", location.into(), loc), self.failure),
+            None => Self::new(location, self.failure),
+        }
+    }
+}
+
+impl std::fmt::Display for DeserializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.location {
+            Some(loc) => write!(f, "Deserialization failed in {} because: ", loc),
+            None => write!(f, "Deserialization: "),
+        }?;
+        match &self.failure {
+            DeserializeFailure::BreakInDefiniteLen => write!(f, "Encountered CBOR Break while reading definite length sequence"),
+            DeserializeFailure::CBOR(e) => e.fmt(f),
+            DeserializeFailure::DefiniteLenMismatch(found, expected) => {
+                write!(f, "Definite length mismatch: found {}", found)?;
+                if let Some(expected_elems) = expected {
+                    write!(f, ", expected: {}", expected_elems)?;
+                }
+                Ok(())
+            },
+            DeserializeFailure::DuplicateKey(key) => write!(f, "Duplicate key: {}", key),
+            DeserializeFailure::EndingBreakMissing => write!(f, "Missing ending CBOR Break"),
+            DeserializeFailure::ExpectedNull => write!(f, "Expected null, found other type"),
+            DeserializeFailure::FixedValueMismatch{ found, expected } => write!(f, "Expected fixed value {} found {}", expected, found),
+            DeserializeFailure::MandatoryFieldMissing(key) => write!(f, "Mandatory field {} not found", key),
+            DeserializeFailure::NoVariantMatched => write!(f, "No variant matched"),
+            DeserializeFailure::RangeCheck{ found, min, max } => match (min, max) {
+                (Some(min), Some(max)) => write!(f, "{} not in range {} - {}", found, min, max),
+                (Some(min), None) => write!(f, "{} not at least {}", found, min),
+                (None, Some(max)) => write!(f, "{} not at most {}", found, max),
+                (None, None) => write!(f, "invalid range (no min nor max specified)"),
+            },
+            DeserializeFailure::TagMismatch{ found, expected } => write!(f, "Expected tag {}, found {}", expected, found),
+            DeserializeFailure::UnknownKey(key) => write!(f, "Found unexpected key {}", key),
+            DeserializeFailure::UnexpectedKeyType(ty) => write!(f, "Found unexpected key of CBOR type {:?}", ty),
+        }
+    }
+}
+
+impl From<DeserializeFailure> for DeserializeError {
+    fn from(failure: DeserializeFailure) -> DeserializeError {
+        DeserializeError {
+            location: None,
+            failure,
+        }
+    }
+}
+
+impl From<cbor_event::Error> for DeserializeError {
+    fn from(err: cbor_event::Error) -> DeserializeError {
+        DeserializeError {
+            location: None,
+            failure: DeserializeFailure::CBOR(err),
+        }
+    }
+}
+
+// same as cbor_event::de::Deserialize but with our DeserializeError
+pub trait Deserialize {
+    fn deserialize<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+    ) -> Result<Self, DeserializeError> where Self: Sized;
+}
+
+impl<T: cbor_event::de::Deserialize> Deserialize for T {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<T, DeserializeError> {
+        T::deserialize(raw).map_err(|e| DeserializeError::from(e))
+    }
+}
+
+pub trait FromBytes {
+    fn from_bytes(data: Vec<u8>) -> Result<Self, DeserializeError> where Self: Sized;
+}
+
+impl<T: Deserialize + Sized> FromBytes for T {
+    fn from_bytes(data: Vec<u8>) -> Result<Self, DeserializeError> {
+        let mut raw = Deserializer::from(std::io::Cursor::new(data));
+        Self::deserialize(&mut raw)
+    }
+}
+

--- a/rust/core/src/serialization.rs
+++ b/rust/core/src/serialization.rs
@@ -1,0 +1,6856 @@
+pub struct CBORReadLen {
+    deser_len: cbor_event::LenSz,
+    read: u64,
+}
+
+impl CBORReadLen {
+    pub fn new(len: cbor_event::LenSz) -> Self {
+        Self {
+            deser_len: len,
+            read: 0,
+        }
+    }
+
+    // Marks {n} values as being read, and if we go past the available definite length
+    // given by the CBOR, we return an error.
+    pub fn read_elems(&mut self, count: usize) -> Result<(), DeserializeFailure> {
+        match self.deser_len {
+            cbor_event::LenSz::Len(n, _) => {
+                self.read += count as u64;
+                if self.read > n {
+                    Err(DeserializeFailure::DefiniteLenMismatch(n, None))
+                } else {
+                    Ok(())
+                }
+            },
+            cbor_event::LenSz::Indefinite => Ok(()),
+        }
+    }
+
+    pub fn finish(&self) -> Result<(), DeserializeFailure> {
+        match self.deser_len {
+            cbor_event::LenSz::Len(n, _) => {
+                if self.read == n {
+                    Ok(())
+                } else {
+                    Err(DeserializeFailure::DefiniteLenMismatch(n, Some(self.read)))
+                }
+            },
+            cbor_event::LenSz::Indefinite => Ok(()),
+        }
+    }
+}
+
+pub trait DeserializeEmbeddedGroup {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+        read_len: &mut CBORReadLen,
+        len: cbor_event::LenSz,
+    ) -> Result<Self, DeserializeError> where Self: Sized;
+}
+
+#[inline]
+fn sz_max(sz: cbor_event::Sz) -> u64 {
+    match sz {
+        Sz::Inline => 23u64,
+        Sz::One => u8::MAX as u64,
+        Sz::Two => u16::MAX as u64,
+        Sz::Four => u32::MAX as u64,
+        Sz::Eight => u64::MAX,
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum LenEncoding {
+    Canonical,
+    Definite(cbor_event::Sz),
+    Indefinite,
+}
+
+impl Default for LenEncoding {
+    fn default() -> Self {
+        Self::Canonical
+    }
+}
+
+impl From<cbor_event::LenSz> for LenEncoding {
+    fn from(len_sz: cbor_event::LenSz) -> Self {
+        match len_sz {
+            cbor_event::LenSz::Len(len, sz) => if cbor_event::Sz::canonical(len) == sz {
+                Self::Canonical
+            } else {
+                Self::Definite(sz)
+            },
+            cbor_event::LenSz::Indefinite => Self::Indefinite,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum StringEncoding {
+    Canonical,
+    Indefinite(Vec<(u64, Sz)>),
+    Definite(Sz),
+}
+
+impl Default for StringEncoding {
+    fn default() -> Self {
+        Self::Canonical
+    }
+}
+
+impl From<cbor_event::StringLenSz> for StringEncoding {
+    fn from(len_sz: cbor_event::StringLenSz) -> Self {
+        match len_sz {
+            cbor_event::StringLenSz::Len(sz) => Self::Definite(sz),
+            cbor_event::StringLenSz::Indefinite(lens) => Self::Indefinite(lens),
+        }
+    }
+}#[inline]
+fn fit_sz(len: u64, sz: Option<cbor_event::Sz>, force_canonical: bool) -> Sz {
+    match sz {
+        Some(sz) => if !force_canonical && len <= sz_max(sz) {
+            sz
+        } else {
+            Sz::canonical(len)
+        },
+        None => Sz::canonical(len),
+    }
+}
+
+impl LenEncoding {
+    pub fn to_len_sz(&self, len: u64, force_canonical: bool) -> cbor_event::LenSz {
+        if force_canonical {
+            cbor_event::LenSz::Len(len, cbor_event::Sz::canonical(len))
+        } else {
+            match self {
+                Self::Canonical => cbor_event::LenSz::Len(len, cbor_event::Sz::canonical(len)),
+                Self::Definite(sz) => if sz_max(*sz) >= len {
+                    cbor_event::LenSz::Len(len, *sz)
+                } else {
+                    cbor_event::LenSz::Len(len, cbor_event::Sz::canonical(len))
+                },
+                Self::Indefinite => cbor_event::LenSz::Indefinite,
+            }
+        }
+    }
+
+    pub fn end<'a, W: Write + Sized>(&self, serializer: &'a mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'a mut Serializer<W>> {
+        if !force_canonical && *self == Self::Indefinite {
+            serializer.write_special(CBORSpecial::Break)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl StringEncoding {
+    pub fn to_str_len_sz(&self, len: u64, force_canonical: bool) -> cbor_event::StringLenSz {
+        if force_canonical {
+            cbor_event::StringLenSz::Len(cbor_event::Sz::canonical(len))
+        } else {
+            match self {
+                Self::Canonical => cbor_event::StringLenSz::Len(cbor_event::Sz::canonical(len)),
+                Self::Definite(sz) => if sz_max(*sz) >= len {
+                    cbor_event::StringLenSz::Len(*sz)
+                } else {
+                    cbor_event::StringLenSz::Len(cbor_event::Sz::canonical(len))
+                },
+                Self::Indefinite(lens) => cbor_event::StringLenSz::Indefinite(lens.clone()),
+            }
+        }
+    }
+}
+
+pub trait Serialize {
+    fn serialize<'a, W: Write + Sized>(
+        &self,
+        serializer: &'a mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'a mut Serializer<W>>;
+}
+
+impl<T: cbor_event::se::Serialize> Serialize for T {
+    fn serialize<'a, W: Write + Sized>(
+        &self,
+        serializer: &'a mut Serializer<W>,
+        _force_canonical: bool,
+    ) -> cbor_event::Result<&'a mut Serializer<W>> {
+        <T as cbor_event::se::Serialize>::serialize(self, serializer)
+    }
+}
+
+pub trait SerializeEmbeddedGroup {
+    fn serialize_as_embedded_group<'a, W: Write + Sized>(
+        &self,
+        serializer: &'a mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'a mut Serializer<W>>;
+}
+
+
+pub trait ToBytes {
+    fn to_bytes(&self, force_canonical: bool) -> Vec<u8>;
+}
+
+impl<T: Serialize> ToBytes for T {
+    fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        let mut buf = Serializer::new_vec();
+        self.serialize(&mut buf, force_canonical).unwrap();
+        buf.finalize()
+    }
+}
+use super::*;
+use std::io::{Seek, SeekFrom};
+
+impl Serialize for Address {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(1, force_canonical))?;
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Address {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(1)?;
+            let index_0_encoding = (|| -> Result<_, DeserializeError> {
+                let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+                if index_0_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+                }
+                Ok(Some(index_0_encoding))
+            })().map_err(|e| e.annotate("index_0"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Address {
+                encodings: Some(AddressEncoding {
+                    len_encoding,
+                    index_0_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Address"))
+    }
+}
+
+impl Serialize for AlonzoAuxData {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_tag_sz(259u64, fit_sz(259u64, self.encodings.as_ref().map(|encs| encs.tag_encoding).unwrap_or_default(), force_canonical))?;
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 } + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 }, force_canonical))?;
+        let deser_order = self.encodings.as_ref().filter(|encs| !force_canonical && encs.orig_deser_order.len() == match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 } + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 }).map(|encs| encs.orig_deser_order.clone()).unwrap_or_else(|| vec![0,1,2,3]);
+        for field_index in deser_order {
+            match field_index {
+                0 => if let Some(field) = &self.key_0 {
+                    serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.key_0_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    let mut key_order = field.iter().map(|(k, v)| {
+                        let mut buf = cbor_event::se::Serializer::new_vec();
+                        let key_0_key_encoding = self.encodings.as_ref().and_then(|encs| encs.key_0_key_encodings.get(k)).map(|e| e.clone()).unwrap_or_else(|| None);
+                        buf.write_unsigned_integer_sz(*k, fit_sz(*k, key_0_key_encoding, force_canonical))?;
+                        Ok((buf.finalize(), k, v))
+                    }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                    if force_canonical {
+                        key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                            match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                                std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                                diff_ord => diff_ord,
+                            }
+                        });
+                    }
+                    for (key_bytes, key, value) in key_order {
+                        serializer.write_raw_bytes(&key_bytes)?;
+                        value.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                1 => if let Some(field) = &self.key_1 {
+                    serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.key_1_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                2 => if let Some(field) = &self.key_2 {
+                    serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.key_2_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_2_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for (i, element) in field.iter().enumerate() {
+                        let key_2_elem_encoding = self.encodings.as_ref().and_then(|encs| encs.key_2_elem_encodings.get(i)).map(|e| e.clone()).unwrap_or_else(|| StringEncoding::default());
+                        serializer.write_bytes_sz(&element, key_2_elem_encoding.to_str_len_sz(element.len() as u64, force_canonical))?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_2_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                3 => if let Some(field) = &self.key_3 {
+                    serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, self.encodings.as_ref().map(|encs| encs.key_3_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_3_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for (i, element) in field.iter().enumerate() {
+                        let key_3_elem_encoding = self.encodings.as_ref().and_then(|encs| encs.key_3_elem_encodings.get(i)).map(|e| e.clone()).unwrap_or_else(|| StringEncoding::default());
+                        serializer.write_bytes_sz(&element, key_3_elem_encoding.to_str_len_sz(element.len() as u64, force_canonical))?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_3_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                _ => unreachable!()
+            };
+        }
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoAuxData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let (tag, tag_encoding) = raw.tag_sz()?;
+            if tag != 259 {
+                return Err(DeserializeError::new("AlonzoAuxData", DeserializeFailure::TagMismatch{ found: tag, expected: 259 }));
+            }
+            let len = raw.map_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let mut orig_deser_order = Vec::new();
+            let mut key_0_encoding = LenEncoding::default();
+            let mut key_0_key_encodings = BTreeMap::new();
+            let mut key_0_key_encoding = None;
+            let mut key_0 = None;
+            let mut key_1_encoding = LenEncoding::default();
+            let mut key_1_key_encoding = None;
+            let mut key_1 = None;
+            let mut key_2_encoding = LenEncoding::default();
+            let mut key_2_elem_encodings = Vec::new();
+            let mut key_2_key_encoding = None;
+            let mut key_2 = None;
+            let mut key_3_encoding = LenEncoding::default();
+            let mut key_3_elem_encodings = Vec::new();
+            let mut key_3_key_encoding = None;
+            let mut key_3 = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if key_0.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_key_0, tmp_key_0_encoding, tmp_key_0_key_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_0_table = OrderedHashMap::new();
+                                let key_0_len = raw.map_sz()?;
+                                let key_0_encoding = key_0_len.into();
+                                let mut key_0_key_encodings = BTreeMap::new();
+                                while match key_0_len { cbor_event::LenSz::Len(n, _) => key_0_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    let (key_0_key, key_0_key_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                                    let key_0_value = TransactionMetadatum::deserialize(raw)?;
+                                    if key_0_table.insert(key_0_key.clone(), key_0_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    key_0_key_encodings.insert(key_0_key.clone(), key_0_key_encoding);
+                                }
+                                Ok((key_0_table, key_0_encoding, key_0_key_encodings))
+                            })().map_err(|e| e.annotate("key_0"))?;
+                            key_0 = Some(tmp_key_0);
+                            key_0_encoding = tmp_key_0_encoding;
+                            key_0_key_encodings = tmp_key_0_key_encodings;
+                            key_0_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if key_1.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_key_1, tmp_key_1_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_1_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_1_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_1_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_1_arr.push(NativeScript::deserialize(raw)?);
+                                }
+                                Ok((key_1_arr, key_1_encoding))
+                            })().map_err(|e| e.annotate("key_1"))?;
+                            key_1 = Some(tmp_key_1);
+                            key_1_encoding = tmp_key_1_encoding;
+                            key_1_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if key_2.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_key_2, tmp_key_2_encoding, tmp_key_2_elem_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_2_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_2_encoding = len.into();
+                                let mut key_2_elem_encodings = Vec::new();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_2_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    let (key_2_elem, key_2_elem_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+                                    key_2_arr.push(key_2_elem);
+                                    key_2_elem_encodings.push(key_2_elem_encoding);
+                                }
+                                Ok((key_2_arr, key_2_encoding, key_2_elem_encodings))
+                            })().map_err(|e| e.annotate("key_2"))?;
+                            key_2 = Some(tmp_key_2);
+                            key_2_encoding = tmp_key_2_encoding;
+                            key_2_elem_encodings = tmp_key_2_elem_encodings;
+                            key_2_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if key_3.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_key_3, tmp_key_3_encoding, tmp_key_3_elem_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_3_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_3_encoding = len.into();
+                                let mut key_3_elem_encodings = Vec::new();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_3_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    let (key_3_elem, key_3_elem_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+                                    key_3_arr.push(key_3_elem);
+                                    key_3_elem_encodings.push(key_3_elem_encoding);
+                                }
+                                Ok((key_3_arr, key_3_encoding, key_3_elem_encodings))
+                            })().map_err(|e| e.annotate("key_3"))?;
+                            key_3 = Some(tmp_key_3);
+                            key_3_encoding = tmp_key_3_encoding;
+                            key_3_elem_encodings = tmp_key_3_elem_encodings;
+                            key_3_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    CBORType::Text => {
+                        let (text_key, key_enc) = raw.text_sz()?;
+                        match text_key.as_str() {
+                            unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Str(unknown_key.to_owned())).into()),
+                        }
+                    },
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                key_0,
+                key_1,
+                key_2,
+                key_3,
+                encodings: Some(AlonzoAuxDataEncoding {
+                    tag_encoding: Some(tag_encoding),
+                    len_encoding,
+                    orig_deser_order,
+                    key_0_key_encoding,
+                    key_0_encoding,
+                    key_0_key_encodings,
+                    key_1_key_encoding,
+                    key_1_encoding,
+                    key_2_key_encoding,
+                    key_2_encoding,
+                    key_2_elem_encodings,
+                    key_3_key_encoding,
+                    key_3_encoding,
+                    key_3_elem_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("AlonzoAuxData"))
+    }
+}
+
+impl Serialize for AlonzoTxOut {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(3, force_canonical))?;
+        self.address.serialize(serializer, force_canonical)?;
+        self.amount.serialize(serializer, force_canonical)?;
+        self.datum_hash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoTxOut {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(3)?;
+            let address = (|| -> Result<_, DeserializeError> {
+                Ok(Address::deserialize(raw)?)
+            })().map_err(|e| e.annotate("address"))?;
+            let amount = (|| -> Result<_, DeserializeError> {
+                Ok(Value::deserialize(raw)?)
+            })().map_err(|e| e.annotate("amount"))?;
+            let datum_hash = (|| -> Result<_, DeserializeError> {
+                Ok(Hash32::deserialize(raw)?)
+            })().map_err(|e| e.annotate("datum_hash"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(AlonzoTxOut {
+                address,
+                amount,
+                datum_hash,
+                encodings: Some(AlonzoTxOutEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("AlonzoTxOut"))
+    }
+}
+
+impl Serialize for AssetName {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for AssetName {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() > 32 {
+            return Err(DeserializeError::new("AssetName", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(0), max: Some(32) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(AssetNameEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for AuxiliaryData {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            AuxiliaryData::ShelleyAuxData{ shelley_aux_data, shelley_aux_data_encoding, shelley_aux_data_key_encodings } => {
+                serializer.write_map_sz(shelley_aux_data_encoding.to_len_sz(shelley_aux_data.len() as u64, force_canonical))?;
+                let mut key_order = shelley_aux_data.iter().map(|(k, v)| {
+                    let mut buf = cbor_event::se::Serializer::new_vec();
+                    let shelley_aux_data_key_encoding = shelley_aux_data_key_encodings.get(k).map(|e| e.clone()).unwrap_or_else(|| None);
+                    buf.write_unsigned_integer_sz(*k, fit_sz(*k, shelley_aux_data_key_encoding, force_canonical))?;
+                    Ok((buf.finalize(), k, v))
+                }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                if force_canonical {
+                    key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                        match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                            std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                            diff_ord => diff_ord,
+                        }
+                    });
+                }
+                for (key_bytes, key, value) in key_order {
+                    serializer.write_raw_bytes(&key_bytes)?;
+                    value.serialize(serializer, force_canonical)?;
+                }
+                shelley_aux_data_encoding.end(serializer, force_canonical)
+            },
+            AuxiliaryData::ShelleyMaAuxData(shelley_ma_aux_data) => {
+                shelley_ma_aux_data.serialize(serializer, force_canonical)
+            },
+            AuxiliaryData::AlonzoAuxData(alonzo_aux_data) => {
+                alonzo_aux_data.serialize(serializer, force_canonical)
+            },
+        }
+    }
+}
+
+impl Deserialize for AuxiliaryData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut shelley_aux_data_table = OrderedHashMap::new();
+                let shelley_aux_data_len = raw.map_sz()?;
+                let shelley_aux_data_encoding = shelley_aux_data_len.into();
+                let mut shelley_aux_data_key_encodings = BTreeMap::new();
+                while match shelley_aux_data_len { cbor_event::LenSz::Len(n, _) => shelley_aux_data_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let (shelley_aux_data_key, shelley_aux_data_key_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                    let shelley_aux_data_value = TransactionMetadatum::deserialize(raw)?;
+                    if shelley_aux_data_table.insert(shelley_aux_data_key.clone(), shelley_aux_data_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                    shelley_aux_data_key_encodings.insert(shelley_aux_data_key.clone(), shelley_aux_data_key_encoding);
+                }
+                Ok((shelley_aux_data_table, shelley_aux_data_encoding, shelley_aux_data_key_encodings))
+            })(raw)
+            {
+                Ok((shelley_aux_data, shelley_aux_data_encoding, shelley_aux_data_key_encodings)) => return Ok(Self::ShelleyAuxData {
+                    shelley_aux_data,
+                    shelley_aux_data_encoding,
+                    shelley_aux_data_key_encodings,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(ShelleyMaAuxData::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(shelley_ma_aux_data) => return Ok(Self::ShelleyMaAuxData(shelley_ma_aux_data)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(AlonzoAuxData::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(alonzo_aux_data) => return Ok(Self::AlonzoAuxData(alonzo_aux_data)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("AuxiliaryData", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("AuxiliaryData"))
+    }
+}
+
+impl Serialize for BabbageTxOut {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2 + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 }, force_canonical))?;
+        let deser_order = self.encodings.as_ref().filter(|encs| !force_canonical && encs.orig_deser_order.len() == 2 + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 }).map(|encs| encs.orig_deser_order.clone()).unwrap_or_else(|| vec![0,1,2,3]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.key_0_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    self.key_0.serialize(serializer, force_canonical)?;
+                }
+                1 => {
+                    serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.key_1_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    self.key_1.serialize(serializer, force_canonical)?;
+                }
+                2 => if let Some(field) = &self.key_2 {
+                    serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.key_2_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                3 => if let Some(field) = &self.key_3 {
+                    serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, self.encodings.as_ref().map(|encs| encs.key_3_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_tag_sz(24u64, fit_sz(24u64, self.encodings.as_ref().map(|encs| encs.key_3_tag_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    let mut key_3_inner_se = Serializer::new_vec();
+                    key_3_inner_se.write_bytes_sz(&field, self.encodings.as_ref().map(|encs| encs.key_3_encoding.clone()).unwrap_or_default().to_str_len_sz(field.len() as u64, force_canonical))?;
+                    let key_3_bytes = key_3_inner_se.finalize();
+                    serializer.write_bytes_sz(&key_3_bytes, self.encodings.as_ref().map(|encs| encs.key_3_bytes_encoding.clone()).unwrap_or_default().to_str_len_sz(key_3_bytes.len() as u64, force_canonical))?;
+                }
+                _ => unreachable!()
+            };
+        }
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for BabbageTxOut {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let mut orig_deser_order = Vec::new();
+            let mut key_0_key_encoding = None;
+            let mut key_0 = None;
+            let mut key_1_key_encoding = None;
+            let mut key_1 = None;
+            let mut key_2_key_encoding = None;
+            let mut key_2 = None;
+            let mut key_3_tag_encoding = None;
+            let mut key_3_bytes_encoding = StringEncoding::default();
+            let mut key_3_encoding = StringEncoding::default();
+            let mut key_3_key_encoding = None;
+            let mut key_3 = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if key_0.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let tmp_key_0 = (|| -> Result<_, DeserializeError> {
+                                Ok(Address::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_0"))?;
+                            key_0 = Some(tmp_key_0);
+                            key_0_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if key_1.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let tmp_key_1 = (|| -> Result<_, DeserializeError> {
+                                Ok(Value::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_1"))?;
+                            key_1 = Some(tmp_key_1);
+                            key_1_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if key_2.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let tmp_key_2 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(DatumOption::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_2"))?;
+                            key_2 = Some(tmp_key_2);
+                            key_2_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if key_3.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_key_3, tmp_key_3_tag_encoding, tmp_key_3_bytes_encoding, tmp_key_3_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(match raw.tag_sz()? {
+                                    (24, tag_enc) => {
+                                        let (key_3_bytes, key_3_bytes_encoding) = raw.bytes_sz()?;
+                                        let mut inner_de = &mut Deserializer::from(std::io::Cursor::new(key_3_bytes));
+                                        inner_de.bytes_sz().map(|(bytes, enc)| (bytes, Some(tag_enc), StringEncoding::from(key_3_bytes_encoding), StringEncoding::from(enc)))?
+                                    },
+                                    (tag, _enc) => return Err(DeserializeFailure::TagMismatch{ found: tag, expected: 24 }.into()),
+                                })
+                            })().map_err(|e| e.annotate("key_3"))?;
+                            key_3 = Some(tmp_key_3);
+                            key_3_tag_encoding = tmp_key_3_tag_encoding;
+                            key_3_bytes_encoding = tmp_key_3_bytes_encoding;
+                            key_3_encoding = tmp_key_3_encoding;
+                            key_3_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    CBORType::Text => {
+                        let (text_key, key_enc) = raw.text_sz()?;
+                        match text_key.as_str() {
+                            unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Str(unknown_key.to_owned())).into()),
+                        }
+                    },
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            let key_0 = match key_0 {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(0)).into()),
+            };
+            let key_1 = match key_1 {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(1)).into()),
+            };
+            read_len.finish()?;
+            Ok(Self {
+                key_0,
+                key_1,
+                key_2,
+                key_3,
+                encodings: Some(BabbageTxOutEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    key_0_key_encoding,
+                    key_1_key_encoding,
+                    key_2_key_encoding,
+                    key_3_key_encoding,
+                    key_3_tag_encoding,
+                    key_3_bytes_encoding,
+                    key_3_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("BabbageTxOut"))
+    }
+}
+
+impl Serialize for BigInt {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for BigInt {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let index_0_encoding = (|| -> Result<_, DeserializeError> {
+                let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+                if index_0_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+                }
+                Ok(Some(index_0_encoding))
+            })().map_err(|e| e.annotate("index_0"))?;
+            let index_1_encoding = (|| -> Result<_, DeserializeError> {
+                let (index_1_value, index_1_encoding) = raw.unsigned_integer_sz()?;
+                if index_1_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_1_value), expected: Key::Uint(1) }.into());
+                }
+                Ok(Some(index_1_encoding))
+            })().map_err(|e| e.annotate("index_1"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(BigInt {
+                encodings: Some(BigIntEncoding {
+                    len_encoding,
+                    index_0_encoding,
+                    index_1_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("BigInt"))
+    }
+}
+
+impl Serialize for Block {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(5, force_canonical))?;
+        self.header.serialize(serializer, force_canonical)?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.transaction_bodies_encoding.clone()).unwrap_or_default().to_len_sz(self.transaction_bodies.len() as u64, force_canonical))?;
+        for element in self.transaction_bodies.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.transaction_bodies_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.transaction_witness_sets_encoding.clone()).unwrap_or_default().to_len_sz(self.transaction_witness_sets.len() as u64, force_canonical))?;
+        for element in self.transaction_witness_sets.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.transaction_witness_sets_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.auxiliary_data_set_encoding.clone()).unwrap_or_default().to_len_sz(self.auxiliary_data_set.len() as u64, force_canonical))?;
+        let mut key_order = self.auxiliary_data_set.iter().map(|(k, v)| {
+            let mut buf = cbor_event::se::Serializer::new_vec();
+            let auxiliary_data_set_key_encoding = self.encodings.as_ref().and_then(|encs| encs.auxiliary_data_set_key_encodings.get(k)).map(|e| e.clone()).unwrap_or_else(|| None);
+            buf.write_unsigned_integer_sz(*k as u64, fit_sz(*k as u64, auxiliary_data_set_key_encoding, force_canonical))?;
+            Ok((buf.finalize(), k, v))
+        }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.auxiliary_data_set_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.invalid_transactions_encoding.clone()).unwrap_or_default().to_len_sz(self.invalid_transactions.len() as u64, force_canonical))?;
+        for (i, element) in self.invalid_transactions.iter().enumerate() {
+            let invalid_transactions_elem_encoding = self.encodings.as_ref().and_then(|encs| encs.invalid_transactions_elem_encodings.get(i)).map(|e| e.clone()).unwrap_or_else(|| None);
+            serializer.write_unsigned_integer_sz(*element as u64, fit_sz(*element as u64, invalid_transactions_elem_encoding, force_canonical))?;
+        }
+        self.encodings.as_ref().map(|encs| encs.invalid_transactions_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Block {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(5)?;
+            let header = (|| -> Result<_, DeserializeError> {
+                Ok(Header::deserialize(raw)?)
+            })().map_err(|e| e.annotate("header"))?;
+            let (transaction_bodies, transaction_bodies_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_bodies_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_bodies_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => transaction_bodies_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    transaction_bodies_arr.push(TransactionBody::deserialize(raw)?);
+                }
+                Ok((transaction_bodies_arr, transaction_bodies_encoding))
+            })().map_err(|e| e.annotate("transaction_bodies"))?;
+            let (transaction_witness_sets, transaction_witness_sets_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_witness_sets_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_witness_sets_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => transaction_witness_sets_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    transaction_witness_sets_arr.push(TransactionWitnessSet::deserialize(raw)?);
+                }
+                Ok((transaction_witness_sets_arr, transaction_witness_sets_encoding))
+            })().map_err(|e| e.annotate("transaction_witness_sets"))?;
+            let (auxiliary_data_set, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut auxiliary_data_set_table = OrderedHashMap::new();
+                let auxiliary_data_set_len = raw.map_sz()?;
+                let auxiliary_data_set_encoding = auxiliary_data_set_len.into();
+                let mut auxiliary_data_set_key_encodings = BTreeMap::new();
+                while match auxiliary_data_set_len { cbor_event::LenSz::Len(n, _) => auxiliary_data_set_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let (auxiliary_data_set_key, auxiliary_data_set_key_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?;
+                    let auxiliary_data_set_value = AuxiliaryData::deserialize(raw)?;
+                    if auxiliary_data_set_table.insert(auxiliary_data_set_key.clone(), auxiliary_data_set_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                    auxiliary_data_set_key_encodings.insert(auxiliary_data_set_key.clone(), auxiliary_data_set_key_encoding);
+                }
+                Ok((auxiliary_data_set_table, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings))
+            })().map_err(|e| e.annotate("auxiliary_data_set"))?;
+            let (invalid_transactions, invalid_transactions_encoding, invalid_transactions_elem_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut invalid_transactions_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let invalid_transactions_encoding = len.into();
+                let mut invalid_transactions_elem_encodings = Vec::new();
+                while match len { cbor_event::LenSz::Len(n, _) => invalid_transactions_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let (invalid_transactions_elem, invalid_transactions_elem_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?;
+                    invalid_transactions_arr.push(invalid_transactions_elem);
+                    invalid_transactions_elem_encodings.push(invalid_transactions_elem_encoding);
+                }
+                Ok((invalid_transactions_arr, invalid_transactions_encoding, invalid_transactions_elem_encodings))
+            })().map_err(|e| e.annotate("invalid_transactions"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Block {
+                header,
+                transaction_bodies,
+                transaction_witness_sets,
+                auxiliary_data_set,
+                invalid_transactions,
+                encodings: Some(BlockEncoding {
+                    len_encoding,
+                    transaction_bodies_encoding,
+                    transaction_witness_sets_encoding,
+                    auxiliary_data_set_encoding,
+                    auxiliary_data_set_key_encodings,
+                    invalid_transactions_encoding,
+                    invalid_transactions_elem_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("Block"))
+    }
+}
+
+impl Serialize for BootstrapWitness {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(4, force_canonical))?;
+        self.public_key.serialize(serializer, force_canonical)?;
+        self.signature.serialize(serializer, force_canonical)?;
+        serializer.write_bytes_sz(&self.chain_code, self.encodings.as_ref().map(|encs| encs.chain_code_encoding.clone()).unwrap_or_default().to_str_len_sz(self.chain_code.len() as u64, force_canonical))?;
+        serializer.write_bytes_sz(&self.attributes, self.encodings.as_ref().map(|encs| encs.attributes_encoding.clone()).unwrap_or_default().to_str_len_sz(self.attributes.len() as u64, force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for BootstrapWitness {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(4)?;
+            let public_key = (|| -> Result<_, DeserializeError> {
+                Ok(Vkey::deserialize(raw)?)
+            })().map_err(|e| e.annotate("public_key"))?;
+            let signature = (|| -> Result<_, DeserializeError> {
+                Ok(Signature::deserialize(raw)?)
+            })().map_err(|e| e.annotate("signature"))?;
+            let (chain_code, chain_code_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+            })().map_err(|e| e.annotate("chain_code"))?;
+            let (attributes, attributes_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+            })().map_err(|e| e.annotate("attributes"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(BootstrapWitness {
+                public_key,
+                signature,
+                chain_code,
+                attributes,
+                encodings: Some(BootstrapWitnessEncoding {
+                    len_encoding,
+                    chain_code_encoding,
+                    attributes_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("BootstrapWitness"))
+    }
+}
+
+impl Serialize for Certificate {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            Certificate::StakeRegistration(stake_registration) => stake_registration.serialize(serializer, force_canonical),
+            Certificate::StakeDeregistration(stake_deregistration) => stake_deregistration.serialize(serializer, force_canonical),
+            Certificate::StakeDelegation(stake_delegation) => stake_delegation.serialize(serializer, force_canonical),
+            Certificate::PoolRegistration(pool_registration) => pool_registration.serialize(serializer, force_canonical),
+            Certificate::PoolRetirement(pool_retirement) => pool_retirement.serialize(serializer, force_canonical),
+            Certificate::GenesisKeyDelegation(genesis_key_delegation) => genesis_key_delegation.serialize(serializer, force_canonical),
+            Certificate::MoveInstantaneousRewardsCert(move_instantaneous_rewards_cert) => move_instantaneous_rewards_cert.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for Certificate {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let outer_len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(StakeRegistration::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(stake_registration) => return Ok(Self::StakeRegistration(stake_registration)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(StakeDeregistration::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(stake_deregistration) => return Ok(Self::StakeDeregistration(stake_deregistration)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(StakeDelegation::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(stake_delegation) => return Ok(Self::StakeDelegation(stake_delegation)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(PoolRegistration::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(pool_registration) => return Ok(Self::PoolRegistration(pool_registration)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(PoolRetirement::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(pool_retirement) => return Ok(Self::PoolRetirement(pool_retirement)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(GenesisKeyDelegation::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(genesis_key_delegation) => return Ok(Self::GenesisKeyDelegation(genesis_key_delegation)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(MoveInstantaneousRewardsCert::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(move_instantaneous_rewards_cert) => return Ok(Self::MoveInstantaneousRewardsCert(move_instantaneous_rewards_cert)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new("Certificate", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("Certificate"))
+    }
+}
+
+impl Serialize for ConstrPlutusData {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_tag_sz(102u64, fit_sz(102u64, self.encodings.as_ref().map(|encs| encs.tag_encoding).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.index_0, fit_sz(self.index_0, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.plutus_datas_encoding.clone()).unwrap_or_default().to_len_sz(self.plutus_datas.len() as u64, force_canonical))?;
+        for element in self.plutus_datas.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.plutus_datas_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ConstrPlutusData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let (tag, tag_encoding) = raw.tag_sz()?;
+            if tag != 102 {
+                return Err(DeserializeError::new("ConstrPlutusData", DeserializeFailure::TagMismatch{ found: tag, expected: 102 }));
+            }
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (index_0, index_0_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("index_0"))?;
+            let (plutus_datas, plutus_datas_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut plutus_datas_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let plutus_datas_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => plutus_datas_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    plutus_datas_arr.push(PlutusData::deserialize(raw)?);
+                }
+                Ok((plutus_datas_arr, plutus_datas_encoding))
+            })().map_err(|e| e.annotate("plutus_datas"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ConstrPlutusData {
+                index_0,
+                plutus_datas,
+                encodings: Some(ConstrPlutusDataEncoding {
+                    len_encoding,
+                    tag_encoding: Some(tag_encoding),
+                    index_0_encoding,
+                    plutus_datas_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("ConstrPlutusData"))
+    }
+}
+
+impl Serialize for Costmdls {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 }, force_canonical))?;
+        let deser_order = self.encodings.as_ref().filter(|encs| !force_canonical && encs.orig_deser_order.len() == match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 }).map(|encs| encs.orig_deser_order.clone()).unwrap_or_else(|| vec![0,1]);
+        for field_index in deser_order {
+            match field_index {
+                0 => if let Some(field) = &self.key_0 {
+                    serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.key_0_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                1 => if let Some(field) = &self.key_1 {
+                    serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.key_1_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                _ => unreachable!()
+            };
+        }
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Costmdls {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let mut orig_deser_order = Vec::new();
+            let mut key_0_encoding = LenEncoding::default();
+            let mut key_0_key_encoding = None;
+            let mut key_0 = None;
+            let mut key_1_encoding = LenEncoding::default();
+            let mut key_1_key_encoding = None;
+            let mut key_1 = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if key_0.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_key_0, tmp_key_0_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_0_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_0_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_0_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_0_arr.push(Int::deserialize(raw)?);
+                                }
+                                Ok((key_0_arr, key_0_encoding))
+                            })().map_err(|e| e.annotate("key_0"))?;
+                            key_0 = Some(tmp_key_0);
+                            key_0_encoding = tmp_key_0_encoding;
+                            key_0_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if key_1.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_key_1, tmp_key_1_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_1_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_1_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_1_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_1_arr.push(Int::deserialize(raw)?);
+                                }
+                                Ok((key_1_arr, key_1_encoding))
+                            })().map_err(|e| e.annotate("key_1"))?;
+                            key_1 = Some(tmp_key_1);
+                            key_1_encoding = tmp_key_1_encoding;
+                            key_1_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    CBORType::Text => {
+                        let (text_key, key_enc) = raw.text_sz()?;
+                        match text_key.as_str() {
+                            unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Str(unknown_key.to_owned())).into()),
+                        }
+                    },
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                key_0,
+                key_1,
+                encodings: Some(CostmdlsEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    key_0_key_encoding,
+                    key_0_encoding,
+                    key_1_key_encoding,
+                    key_1_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Costmdls"))
+    }
+}
+
+impl Serialize for DatumOption {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            DatumOption::DatumOption0(datum_option0) => datum_option0.serialize(serializer, force_canonical),
+            DatumOption::DatumOption1(datum_option1) => datum_option1.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for DatumOption {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let outer_len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(DatumOption0::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(datum_option0) => return Ok(Self::DatumOption0(datum_option0)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(DatumOption1::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(datum_option1) => return Ok(Self::DatumOption1(datum_option1)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new("DatumOption", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("DatumOption"))
+    }
+}
+
+impl Serialize for DatumOption0 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for DatumOption0 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.hash32.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for DatumOption0 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("DatumOption0"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for DatumOption0 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let hash32 = (|| -> Result<_, DeserializeError> {
+            Ok(Hash32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("hash32"))?;
+        Ok(DatumOption0 {
+            hash32,
+            encodings: Some(DatumOption0Encoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for DatumOption1 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for DatumOption1 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_tag_sz(24u64, fit_sz(24u64, self.encodings.as_ref().map(|encs| encs.data_tag_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        let mut data_inner_se = Serializer::new_vec();
+        data_inner_se.write_bytes_sz(&self.data, self.encodings.as_ref().map(|encs| encs.data_encoding.clone()).unwrap_or_default().to_str_len_sz(self.data.len() as u64, force_canonical))?;
+        let data_bytes = data_inner_se.finalize();
+        serializer.write_bytes_sz(&data_bytes, self.encodings.as_ref().map(|encs| encs.data_bytes_encoding.clone()).unwrap_or_default().to_str_len_sz(data_bytes.len() as u64, force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for DatumOption1 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("DatumOption1"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for DatumOption1 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (data, data_tag_encoding, data_bytes_encoding, data_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.tag_sz()? {
+                (24, tag_enc) => {
+                    let (data_bytes, data_bytes_encoding) = raw.bytes_sz()?;
+                    let mut inner_de = &mut Deserializer::from(std::io::Cursor::new(data_bytes));
+                    inner_de.bytes_sz().map(|(bytes, enc)| (bytes, Some(tag_enc), StringEncoding::from(data_bytes_encoding), StringEncoding::from(enc)))?
+                },
+                (tag, _enc) => return Err(DeserializeFailure::TagMismatch{ found: tag, expected: 24 }.into()),
+            })
+        })().map_err(|e| e.annotate("data"))?;
+        Ok(DatumOption1 {
+            data,
+            encodings: Some(DatumOption1Encoding {
+                len_encoding,
+                index_0_encoding,
+                data_tag_encoding,
+                data_bytes_encoding,
+                data_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for DnsName {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_text_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for DnsName {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.text_sz().map(|(s, enc)| (s, StringEncoding::from(enc)))?;
+        if inner.len() > 64 {
+            return Err(DeserializeError::new("DnsName", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(0), max: Some(64) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(DnsNameEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for ExUnitPrices {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.mem_price.serialize(serializer, force_canonical)?;
+        self.step_price.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ExUnitPrices {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let mem_price = (|| -> Result<_, DeserializeError> {
+                Ok(PositiveInterval::deserialize(raw)?)
+            })().map_err(|e| e.annotate("mem_price"))?;
+            let step_price = (|| -> Result<_, DeserializeError> {
+                Ok(PositiveInterval::deserialize(raw)?)
+            })().map_err(|e| e.annotate("step_price"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ExUnitPrices {
+                mem_price,
+                step_price,
+                encodings: Some(ExUnitPricesEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("ExUnitPrices"))
+    }
+}
+
+impl Serialize for ExUnits {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.mem, fit_sz(self.mem, self.encodings.as_ref().map(|encs| encs.mem_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.steps, fit_sz(self.steps, self.encodings.as_ref().map(|encs| encs.steps_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ExUnits {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (mem, mem_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("mem"))?;
+            let (steps, steps_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("steps"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ExUnits {
+                mem,
+                steps,
+                encodings: Some(ExUnitsEncoding {
+                    len_encoding,
+                    mem_encoding,
+                    steps_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("ExUnits"))
+    }
+}
+
+impl Serialize for GenesisKeyDelegation {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(4, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for GenesisKeyDelegation {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(5u64, fit_sz(5u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.genesishash.serialize(serializer, force_canonical)?;
+        self.genesis_delegate_hash.serialize(serializer, force_canonical)?;
+        self.vrf_keyhash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for GenesisKeyDelegation {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(4)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("GenesisKeyDelegation"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for GenesisKeyDelegation {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 5 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(5) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let genesishash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("genesishash"))?;
+        let genesis_delegate_hash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("genesis_delegate_hash"))?;
+        let vrf_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("vrf_keyhash"))?;
+        Ok(GenesisKeyDelegation {
+            genesishash,
+            genesis_delegate_hash,
+            vrf_keyhash,
+            encodings: Some(GenesisKeyDelegationEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Hash28 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for Hash28 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 28 {
+            return Err(DeserializeError::new("Hash28", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(28), max: Some(28) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(Hash28Encoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Hash32 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for Hash32 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 32 {
+            return Err(DeserializeError::new("Hash32", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(32), max: Some(32) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(Hash32Encoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Header {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.header_body.serialize(serializer, force_canonical)?;
+        self.body_signature.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Header {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let header_body = (|| -> Result<_, DeserializeError> {
+                Ok(HeaderBody::deserialize(raw)?)
+            })().map_err(|e| e.annotate("header_body"))?;
+            let body_signature = (|| -> Result<_, DeserializeError> {
+                Ok(KesSignature::deserialize(raw)?)
+            })().map_err(|e| e.annotate("body_signature"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Header {
+                header_body,
+                body_signature,
+                encodings: Some(HeaderEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Header"))
+    }
+}
+
+impl Serialize for HeaderBody {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(14, force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.block_number, fit_sz(self.block_number, self.encodings.as_ref().map(|encs| encs.block_number_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.slot, fit_sz(self.slot, self.encodings.as_ref().map(|encs| encs.slot_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        match &self.prev_hash {
+            Some(x) => {
+                x.serialize(serializer, force_canonical)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        self.issuer_vkey.serialize(serializer, force_canonical)?;
+        self.vrf_vkey.serialize(serializer, force_canonical)?;
+        self.vrf_result.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.block_body_size, fit_sz(self.block_body_size, self.encodings.as_ref().map(|encs| encs.block_body_size_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.block_body_hash.serialize(serializer, force_canonical)?;
+        self.operational_cert.serialize_as_embedded_group(serializer, force_canonical)?;
+        self.protocol_version.serialize_as_embedded_group(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for HeaderBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(14)?;
+            let (block_number, block_number_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("block_number"))?;
+            let (slot, slot_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("slot"))?;
+            let prev_hash = (|| -> Result<_, DeserializeError> {
+                Ok(match raw.cbor_type()? != CBORType::Special {
+                    true => {
+                        Some(Hash32::deserialize(raw)?)
+                    },
+                    false => {
+                        if raw.special()? != CBORSpecial::Null {
+                            return Err(DeserializeFailure::ExpectedNull.into());
+                        }
+                        None
+                    }
+                })
+            })().map_err(|e| e.annotate("prev_hash"))?;
+            let issuer_vkey = (|| -> Result<_, DeserializeError> {
+                Ok(Vkey::deserialize(raw)?)
+            })().map_err(|e| e.annotate("issuer_vkey"))?;
+            let vrf_vkey = (|| -> Result<_, DeserializeError> {
+                Ok(VrfVkey::deserialize(raw)?)
+            })().map_err(|e| e.annotate("vrf_vkey"))?;
+            let vrf_result = (|| -> Result<_, DeserializeError> {
+                Ok(VrfCert::deserialize(raw)?)
+            })().map_err(|e| e.annotate("vrf_result"))?;
+            let (block_body_size, block_body_size_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("block_body_size"))?;
+            let block_body_hash = (|| -> Result<_, DeserializeError> {
+                Ok(Hash32::deserialize(raw)?)
+            })().map_err(|e| e.annotate("block_body_hash"))?;
+            let operational_cert = (|| -> Result<_, DeserializeError> {
+                Ok(OperationalCert::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })().map_err(|e| e.annotate("operational_cert"))?;
+            let protocol_version = (|| -> Result<_, DeserializeError> {
+                Ok(ProtocolVersion::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })().map_err(|e| e.annotate("protocol_version"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(HeaderBody {
+                block_number,
+                slot,
+                prev_hash,
+                issuer_vkey,
+                vrf_vkey,
+                vrf_result,
+                block_body_size,
+                block_body_hash,
+                operational_cert,
+                protocol_version,
+                encodings: Some(HeaderBodyEncoding {
+                    len_encoding,
+                    block_number_encoding,
+                    slot_encoding,
+                    block_body_size_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("HeaderBody"))
+    }
+}
+
+impl Serialize for I0OrI1 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            I0OrI1::I0{ i0_encoding } => {
+                serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, *i0_encoding, force_canonical))
+            },
+            I0OrI1::I1{ i1_encoding } => {
+                serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, *i1_encoding, force_canonical))
+            },
+        }
+    }
+}
+
+impl Deserialize for I0OrI1 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i0_value, i0_encoding) = raw.unsigned_integer_sz()?;
+                if i0_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i0_value), expected: Key::Uint(0) }.into());
+                }
+                Ok(Some(i0_encoding))
+            })(raw)
+            {
+                Ok(i0_encoding) => return Ok(Self::I0 {
+                    i0_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i1_value, i1_encoding) = raw.unsigned_integer_sz()?;
+                if i1_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i1_value), expected: Key::Uint(1) }.into());
+                }
+                Ok(Some(i1_encoding))
+            })(raw)
+            {
+                Ok(i1_encoding) => return Ok(Self::I1 {
+                    i1_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("I0OrI1", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("I0OrI1"))
+    }
+}
+
+impl Serialize for Int {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            Self::Uint{ value, encoding } => serializer.write_unsigned_integer_sz(*value, fit_sz(*value, *encoding, force_canonical)),
+            Self::Nint{ value, encoding } => serializer.write_negative_integer_sz(-((*value as i128) + 1), fit_sz(*value, *encoding, force_canonical)),
+        }
+    }
+}
+
+impl Deserialize for Int {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            match raw.cbor_type()? {
+                cbor_event::Type::UnsignedInteger => raw.unsigned_integer_sz().map(|(x, enc)| Self::Uint{ value: x, encoding: Some(enc) }).map_err(std::convert::Into::into),
+                cbor_event::Type::NegativeInteger => raw.negative_integer_sz().map(|(x, enc)| Self::Nint{ value: (-1 - x) as u64, encoding: Some(enc) }).map_err(std::convert::Into::into),
+                _ => Err(DeserializeFailure::NoVariantMatched.into()),
+            }
+        })().map_err(|e| e.annotate("Int"))
+    }
+}
+
+impl Serialize for InvalidBefore {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for InvalidBefore {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(4u64, fit_sz(4u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.index_1, fit_sz(self.index_1, self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for InvalidBefore {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("InvalidBefore"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for InvalidBefore {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 4 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(4) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (index_1, index_1_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("index_1"))?;
+        Ok(InvalidBefore {
+            index_1,
+            encodings: Some(InvalidBeforeEncoding {
+                len_encoding,
+                index_0_encoding,
+                index_1_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for InvalidHereafter {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for InvalidHereafter {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(5u64, fit_sz(5u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.index_1, fit_sz(self.index_1, self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for InvalidHereafter {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("InvalidHereafter"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for InvalidHereafter {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 5 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(5) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (index_1, index_1_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("index_1"))?;
+        Ok(InvalidHereafter {
+            index_1,
+            encodings: Some(InvalidHereafterEncoding {
+                len_encoding,
+                index_0_encoding,
+                index_1_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Ipv4 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for Ipv4 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 4 {
+            return Err(DeserializeError::new("Ipv4", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(4), max: Some(4) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(Ipv4Encoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Ipv6 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for Ipv6 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 16 {
+            return Err(DeserializeError::new("Ipv6", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(16), max: Some(16) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(Ipv6Encoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for KesSignature {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for KesSignature {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 32 {
+            return Err(DeserializeError::new("KesSignature", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(32), max: Some(32) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(KesSignatureEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for KesVkey {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for KesVkey {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 8 {
+            return Err(DeserializeError::new("KesVkey", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(8), max: Some(8) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(KesVkeyEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Language {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            Language::I0{ i0_encoding } => {
+                serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, *i0_encoding, force_canonical))
+            },
+            Language::I1{ i1_encoding } => {
+                serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, *i1_encoding, force_canonical))
+            },
+        }
+    }
+}
+
+impl Deserialize for Language {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i0_value, i0_encoding) = raw.unsigned_integer_sz()?;
+                if i0_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i0_value), expected: Key::Uint(0) }.into());
+                }
+                Ok(Some(i0_encoding))
+            })(raw)
+            {
+                Ok(i0_encoding) => return Ok(Self::I0 {
+                    i0_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i1_value, i1_encoding) = raw.unsigned_integer_sz()?;
+                if i1_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i1_value), expected: Key::Uint(1) }.into());
+                }
+                Ok(Some(i1_encoding))
+            })(raw)
+            {
+                Ok(i1_encoding) => return Ok(Self::I1 {
+                    i1_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("Language", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("Language"))
+    }
+}
+
+impl Serialize for MoveInstantaneousReward {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(3, force_canonical))?;
+        self.index_0.serialize(serializer, force_canonical)?;
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default().to_len_sz(self.index_1.len() as u64, force_canonical))?;
+        let mut key_order = self.index_1.iter().map(|(k, v)| {
+            let mut buf = cbor_event::se::Serializer::new_vec();
+            k.serialize(&mut buf, force_canonical)?;
+            Ok((buf.finalize(), k, v))
+        }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.coin, fit_sz(self.coin, self.encodings.as_ref().map(|encs| encs.coin_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MoveInstantaneousReward {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(3)?;
+            let index_0 = (|| -> Result<_, DeserializeError> {
+                Ok(I0OrI1::deserialize(raw)?)
+            })().map_err(|e| e.annotate("index_0"))?;
+            let (index_1, index_1_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut index_1_table = OrderedHashMap::new();
+                let index_1_len = raw.map_sz()?;
+                let index_1_encoding = index_1_len.into();
+                while match index_1_len { cbor_event::LenSz::Len(n, _) => index_1_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let index_1_key = StakeCredential::deserialize(raw)?;
+                    let index_1_value = Int::deserialize(raw)?;
+                    if index_1_table.insert(index_1_key.clone(), index_1_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                }
+                Ok((index_1_table, index_1_encoding))
+            })().map_err(|e| e.annotate("index_1"))?;
+            let (coin, coin_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("coin"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(MoveInstantaneousReward {
+                index_0,
+                index_1,
+                coin,
+                encodings: Some(MoveInstantaneousRewardEncoding {
+                    len_encoding,
+                    index_1_encoding,
+                    coin_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("MoveInstantaneousReward"))
+    }
+}
+
+impl Serialize for MoveInstantaneousRewardsCert {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for MoveInstantaneousRewardsCert {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(6u64, fit_sz(6u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.move_instantaneous_reward.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MoveInstantaneousRewardsCert {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MoveInstantaneousRewardsCert"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MoveInstantaneousRewardsCert {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 6 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(6) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let move_instantaneous_reward = (|| -> Result<_, DeserializeError> {
+            Ok(MoveInstantaneousReward::deserialize(raw)?)
+        })().map_err(|e| e.annotate("move_instantaneous_reward"))?;
+        Ok(MoveInstantaneousRewardsCert {
+            move_instantaneous_reward,
+            encodings: Some(MoveInstantaneousRewardsCertEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for MultiHostName {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for MultiHostName {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.dns_name.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MultiHostName {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MultiHostName"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MultiHostName {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 2 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let dns_name = (|| -> Result<_, DeserializeError> {
+            Ok(DnsName::deserialize(raw)?)
+        })().map_err(|e| e.annotate("dns_name"))?;
+        Ok(MultiHostName {
+            dns_name,
+            encodings: Some(MultiHostNameEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for NativeScript {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            NativeScript::ScriptPubkey(script_pubkey) => script_pubkey.serialize(serializer, force_canonical),
+            NativeScript::ScriptAll(script_all) => script_all.serialize(serializer, force_canonical),
+            NativeScript::ScriptAny(script_any) => script_any.serialize(serializer, force_canonical),
+            NativeScript::ScriptNOfK(script_n_of_k) => script_n_of_k.serialize(serializer, force_canonical),
+            NativeScript::InvalidBefore(invalid_before) => invalid_before.serialize(serializer, force_canonical),
+            NativeScript::InvalidHereafter(invalid_hereafter) => invalid_hereafter.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for NativeScript {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let outer_len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(ScriptPubkey::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(script_pubkey) => return Ok(Self::ScriptPubkey(script_pubkey)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(ScriptAll::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(script_all) => return Ok(Self::ScriptAll(script_all)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(ScriptAny::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(script_any) => return Ok(Self::ScriptAny(script_any)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(ScriptNOfK::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(script_n_of_k) => return Ok(Self::ScriptNOfK(script_n_of_k)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(InvalidBefore::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(invalid_before) => return Ok(Self::InvalidBefore(invalid_before)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(InvalidHereafter::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(invalid_hereafter) => return Ok(Self::InvalidHereafter(invalid_hereafter)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new("NativeScript", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("NativeScript"))
+    }
+}
+
+impl Serialize for NetworkId {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            NetworkId::I0{ i0_encoding } => {
+                serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, *i0_encoding, force_canonical))
+            },
+            NetworkId::I1{ i1_encoding } => {
+                serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, *i1_encoding, force_canonical))
+            },
+        }
+    }
+}
+
+impl Deserialize for NetworkId {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i0_value, i0_encoding) = raw.unsigned_integer_sz()?;
+                if i0_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i0_value), expected: Key::Uint(0) }.into());
+                }
+                Ok(Some(i0_encoding))
+            })(raw)
+            {
+                Ok(i0_encoding) => return Ok(Self::I0 {
+                    i0_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i1_value, i1_encoding) = raw.unsigned_integer_sz()?;
+                if i1_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i1_value), expected: Key::Uint(1) }.into());
+                }
+                Ok(Some(i1_encoding))
+            })(raw)
+            {
+                Ok(i1_encoding) => return Ok(Self::I1 {
+                    i1_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("NetworkId", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("NetworkId"))
+    }
+}
+
+impl Serialize for Nonce {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            Nonce::I0{ i0_encoding, outer_len_encoding } => {
+                serializer.write_array_sz(outer_len_encoding.to_len_sz(1, force_canonical))?;
+                serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, *i0_encoding, force_canonical))?;
+                outer_len_encoding.end(serializer, force_canonical)?;
+                Ok(serializer)
+            },
+            Nonce::Nonce1(nonce1) => nonce1.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for Nonce {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let outer_len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i0_value, i0_encoding) = raw.unsigned_integer_sz()?;
+                if i0_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i0_value), expected: Key::Uint(0) }.into());
+                }
+                Ok(Some(i0_encoding))
+            })(raw)
+            {
+                Ok(i0_encoding) => return Ok(Self::I0 {
+                    i0_encoding,
+                    outer_len_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(Nonce1::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(nonce1) => return Ok(Self::Nonce1(nonce1)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new("Nonce", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("Nonce"))
+    }
+}
+
+impl Serialize for Nonce1 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for Nonce1 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_bytes_sz(&self.bytes, self.encodings.as_ref().map(|encs| encs.bytes_encoding.clone()).unwrap_or_default().to_str_len_sz(self.bytes.len() as u64, force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Nonce1 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("Nonce1"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for Nonce1 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (bytes, bytes_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+        })().map_err(|e| e.annotate("bytes"))?;
+        Ok(Nonce1 {
+            bytes,
+            encodings: Some(Nonce1Encoding {
+                len_encoding,
+                index_0_encoding,
+                bytes_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for OperationalCert {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(4, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for OperationalCert {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.hot_vkey.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.sequence_number, fit_sz(self.sequence_number, self.encodings.as_ref().map(|encs| encs.sequence_number_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.kes_period, fit_sz(self.kes_period, self.encodings.as_ref().map(|encs| encs.kes_period_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.sigma.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for OperationalCert {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(4)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("OperationalCert"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for OperationalCert {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let hot_vkey = (|| -> Result<_, DeserializeError> {
+            Ok(KesVkey::deserialize(raw)?)
+        })().map_err(|e| e.annotate("hot_vkey"))?;
+        let (sequence_number, sequence_number_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("sequence_number"))?;
+        let (kes_period, kes_period_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("kes_period"))?;
+        let sigma = (|| -> Result<_, DeserializeError> {
+            Ok(Signature::deserialize(raw)?)
+        })().map_err(|e| e.annotate("sigma"))?;
+        Ok(OperationalCert {
+            hot_vkey,
+            sequence_number,
+            kes_period,
+            sigma,
+            encodings: Some(OperationalCertEncoding {
+                len_encoding,
+                sequence_number_encoding,
+                kes_period_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for PlutusData {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            PlutusData::ConstrPlutusData(constr_plutus_data) => {
+                constr_plutus_data.serialize(serializer, force_canonical)
+            },
+            PlutusData::MapPlutusDataToPlutusData{ map_plutus_data_to_plutus_data, map_plutus_data_to_plutus_data_encoding } => {
+                serializer.write_map_sz(map_plutus_data_to_plutus_data_encoding.to_len_sz(map_plutus_data_to_plutus_data.len() as u64, force_canonical))?;
+                let mut key_order = map_plutus_data_to_plutus_data.iter().map(|(k, v)| {
+                    let mut buf = cbor_event::se::Serializer::new_vec();
+                    k.serialize(&mut buf, force_canonical)?;
+                    Ok((buf.finalize(), k, v))
+                }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                if force_canonical {
+                    key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                        match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                            std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                            diff_ord => diff_ord,
+                        }
+                    });
+                }
+                for (key_bytes, key, value) in key_order {
+                    serializer.write_raw_bytes(&key_bytes)?;
+                    value.serialize(serializer, force_canonical)?;
+                }
+                map_plutus_data_to_plutus_data_encoding.end(serializer, force_canonical)
+            },
+            PlutusData::ArrPlutusData{ arr_plutus_data, arr_plutus_data_encoding } => {
+                serializer.write_array_sz(arr_plutus_data_encoding.to_len_sz(arr_plutus_data.len() as u64, force_canonical))?;
+                for element in arr_plutus_data.iter() {
+                    element.serialize(serializer, force_canonical)?;
+                }
+                arr_plutus_data_encoding.end(serializer, force_canonical)
+            },
+            PlutusData::BigInt(big_int) => {
+                big_int.serialize(serializer, force_canonical)
+            },
+            PlutusData::BoundedBytes{ bounded_bytes, bounded_bytes_encoding } => {
+                serializer.write_bytes_sz(&bounded_bytes, bounded_bytes_encoding.to_str_len_sz(bounded_bytes.len() as u64, force_canonical))
+            },
+        }
+    }
+}
+
+impl Deserialize for PlutusData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(ConstrPlutusData::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(constr_plutus_data) => return Ok(Self::ConstrPlutusData(constr_plutus_data)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut map_plutus_data_to_plutus_data_table = OrderedHashMap::new();
+                let map_plutus_data_to_plutus_data_len = raw.map_sz()?;
+                let map_plutus_data_to_plutus_data_encoding = map_plutus_data_to_plutus_data_len.into();
+                while match map_plutus_data_to_plutus_data_len { cbor_event::LenSz::Len(n, _) => map_plutus_data_to_plutus_data_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let map_plutus_data_to_plutus_data_key = PlutusData::deserialize(raw)?;
+                    let map_plutus_data_to_plutus_data_value = PlutusData::deserialize(raw)?;
+                    if map_plutus_data_to_plutus_data_table.insert(map_plutus_data_to_plutus_data_key.clone(), map_plutus_data_to_plutus_data_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                }
+                Ok((map_plutus_data_to_plutus_data_table, map_plutus_data_to_plutus_data_encoding))
+            })(raw)
+            {
+                Ok((map_plutus_data_to_plutus_data, map_plutus_data_to_plutus_data_encoding)) => return Ok(Self::MapPlutusDataToPlutusData {
+                    map_plutus_data_to_plutus_data,
+                    map_plutus_data_to_plutus_data_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut arr_plutus_data_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let arr_plutus_data_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => arr_plutus_data_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    arr_plutus_data_arr.push(PlutusData::deserialize(raw)?);
+                }
+                Ok((arr_plutus_data_arr, arr_plutus_data_encoding))
+            })(raw)
+            {
+                Ok((arr_plutus_data, arr_plutus_data_encoding)) => return Ok(Self::ArrPlutusData {
+                    arr_plutus_data,
+                    arr_plutus_data_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(BigInt::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(big_int) => return Ok(Self::BigInt(big_int)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+            })(raw)
+            {
+                Ok((bounded_bytes, bounded_bytes_encoding)) => return Ok(Self::BoundedBytes {
+                    bounded_bytes,
+                    bounded_bytes_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("PlutusData", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("PlutusData"))
+    }
+}
+
+impl Serialize for PoolMetadata {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.url.serialize(serializer, force_canonical)?;
+        self.pool_metadata_hash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for PoolMetadata {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let url = (|| -> Result<_, DeserializeError> {
+                Ok(Url::deserialize(raw)?)
+            })().map_err(|e| e.annotate("url"))?;
+            let pool_metadata_hash = (|| -> Result<_, DeserializeError> {
+                Ok(Hash32::deserialize(raw)?)
+            })().map_err(|e| e.annotate("pool_metadata_hash"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(PoolMetadata {
+                url,
+                pool_metadata_hash,
+                encodings: Some(PoolMetadataEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("PoolMetadata"))
+    }
+}
+
+impl Serialize for PoolParams {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(9, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for PoolParams {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.operator.serialize(serializer, force_canonical)?;
+        self.vrf_keyhash.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.pledge, fit_sz(self.pledge, self.encodings.as_ref().map(|encs| encs.pledge_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.cost, fit_sz(self.cost, self.encodings.as_ref().map(|encs| encs.cost_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.margin.serialize(serializer, force_canonical)?;
+        self.reward_account.serialize(serializer, force_canonical)?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.pool_owners_encoding.clone()).unwrap_or_default().to_len_sz(self.pool_owners.len() as u64, force_canonical))?;
+        for element in self.pool_owners.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.pool_owners_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.relays_encoding.clone()).unwrap_or_default().to_len_sz(self.relays.len() as u64, force_canonical))?;
+        for element in self.relays.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.relays_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        match &self.pool_metadata {
+            Some(x) => {
+                x.serialize(serializer, force_canonical)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for PoolParams {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(9)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("PoolParams"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for PoolParams {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let operator = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("operator"))?;
+        let vrf_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("vrf_keyhash"))?;
+        let (pledge, pledge_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("pledge"))?;
+        let (cost, cost_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("cost"))?;
+        let margin = (|| -> Result<_, DeserializeError> {
+            Ok(UnitInterval::deserialize(raw)?)
+        })().map_err(|e| e.annotate("margin"))?;
+        let reward_account = (|| -> Result<_, DeserializeError> {
+            Ok(RewardAccount::deserialize(raw)?)
+        })().map_err(|e| e.annotate("reward_account"))?;
+        let (pool_owners, pool_owners_encoding) = (|| -> Result<_, DeserializeError> {
+            let mut pool_owners_arr = Vec::new();
+            let len = raw.array_sz()?;
+            let pool_owners_encoding = len.into();
+            while match len { cbor_event::LenSz::Len(n, _) => pool_owners_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                pool_owners_arr.push(Hash28::deserialize(raw)?);
+            }
+            Ok((pool_owners_arr, pool_owners_encoding))
+        })().map_err(|e| e.annotate("pool_owners"))?;
+        let (relays, relays_encoding) = (|| -> Result<_, DeserializeError> {
+            let mut relays_arr = Vec::new();
+            let len = raw.array_sz()?;
+            let relays_encoding = len.into();
+            while match len { cbor_event::LenSz::Len(n, _) => relays_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                relays_arr.push(Relay::deserialize(raw)?);
+            }
+            Ok((relays_arr, relays_encoding))
+        })().map_err(|e| e.annotate("relays"))?;
+        let pool_metadata = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(PoolMetadata::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("pool_metadata"))?;
+        Ok(PoolParams {
+            operator,
+            vrf_keyhash,
+            pledge,
+            cost,
+            margin,
+            reward_account,
+            pool_owners,
+            relays,
+            pool_metadata,
+            encodings: Some(PoolParamsEncoding {
+                len_encoding,
+                pledge_encoding,
+                cost_encoding,
+                pool_owners_encoding,
+                relays_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for PoolRegistration {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(10, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for PoolRegistration {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.pool_params.serialize_as_embedded_group(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for PoolRegistration {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(10)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("PoolRegistration"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for PoolRegistration {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 3 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(3) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let pool_params = (|| -> Result<_, DeserializeError> {
+            Ok(PoolParams::deserialize_as_embedded_group(raw, read_len, len)?)
+        })().map_err(|e| e.annotate("pool_params"))?;
+        Ok(PoolRegistration {
+            pool_params,
+            encodings: Some(PoolRegistrationEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for PoolRetirement {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(3, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for PoolRetirement {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(4u64, fit_sz(4u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.pool_keyhash.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.epoch, fit_sz(self.epoch, self.encodings.as_ref().map(|encs| encs.epoch_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for PoolRetirement {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(3)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("PoolRetirement"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for PoolRetirement {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 4 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(4) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let pool_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("pool_keyhash"))?;
+        let (epoch, epoch_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("epoch"))?;
+        Ok(PoolRetirement {
+            pool_keyhash,
+            epoch,
+            encodings: Some(PoolRetirementEncoding {
+                len_encoding,
+                index_0_encoding,
+                epoch_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for PositiveInterval {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_tag_sz(30u64, fit_sz(30u64, self.encodings.as_ref().map(|encs| encs.tag_encoding).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for PositiveInterval {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let (tag, tag_encoding) = raw.tag_sz()?;
+            if tag != 30 {
+                return Err(DeserializeError::new("PositiveInterval", DeserializeFailure::TagMismatch{ found: tag, expected: 30 }));
+            }
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let index_0_encoding = (|| -> Result<_, DeserializeError> {
+                let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+                if index_0_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+                }
+                Ok(Some(index_0_encoding))
+            })().map_err(|e| e.annotate("index_0"))?;
+            let index_1_encoding = (|| -> Result<_, DeserializeError> {
+                let (index_1_value, index_1_encoding) = raw.unsigned_integer_sz()?;
+                if index_1_value != 2 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_1_value), expected: Key::Uint(2) }.into());
+                }
+                Ok(Some(index_1_encoding))
+            })().map_err(|e| e.annotate("index_1"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(PositiveInterval {
+                encodings: Some(PositiveIntervalEncoding {
+                    len_encoding,
+                    tag_encoding: Some(tag_encoding),
+                    index_0_encoding,
+                    index_1_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("PositiveInterval"))
+    }
+}
+
+impl Serialize for ProtocolParamUpdate {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 } + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 } + match &self.key_4 { Some(_) => 1, None => 0 } + match &self.key_5 { Some(_) => 1, None => 0 } + match &self.key_6 { Some(_) => 1, None => 0 } + match &self.key_7 { Some(_) => 1, None => 0 } + match &self.key_8 { Some(_) => 1, None => 0 } + match &self.key_9 { Some(_) => 1, None => 0 } + match &self.key_10 { Some(_) => 1, None => 0 } + match &self.key_11 { Some(_) => 1, None => 0 } + match &self.key_14 { Some(_) => 1, None => 0 } + match &self.key_16 { Some(_) => 1, None => 0 } + match &self.key_17 { Some(_) => 1, None => 0 } + match &self.key_18 { Some(_) => 1, None => 0 } + match &self.key_19 { Some(_) => 1, None => 0 } + match &self.key_20 { Some(_) => 1, None => 0 } + match &self.key_21 { Some(_) => 1, None => 0 } + match &self.key_22 { Some(_) => 1, None => 0 } + match &self.key_23 { Some(_) => 1, None => 0 } + match &self.key_24 { Some(_) => 1, None => 0 }, force_canonical))?;
+        let deser_order = self.encodings.as_ref().filter(|encs| !force_canonical && encs.orig_deser_order.len() == match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 } + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 } + match &self.key_4 { Some(_) => 1, None => 0 } + match &self.key_5 { Some(_) => 1, None => 0 } + match &self.key_6 { Some(_) => 1, None => 0 } + match &self.key_7 { Some(_) => 1, None => 0 } + match &self.key_8 { Some(_) => 1, None => 0 } + match &self.key_9 { Some(_) => 1, None => 0 } + match &self.key_10 { Some(_) => 1, None => 0 } + match &self.key_11 { Some(_) => 1, None => 0 } + match &self.key_14 { Some(_) => 1, None => 0 } + match &self.key_16 { Some(_) => 1, None => 0 } + match &self.key_17 { Some(_) => 1, None => 0 } + match &self.key_18 { Some(_) => 1, None => 0 } + match &self.key_19 { Some(_) => 1, None => 0 } + match &self.key_20 { Some(_) => 1, None => 0 } + match &self.key_21 { Some(_) => 1, None => 0 } + match &self.key_22 { Some(_) => 1, None => 0 } + match &self.key_23 { Some(_) => 1, None => 0 } + match &self.key_24 { Some(_) => 1, None => 0 }).map(|encs| encs.orig_deser_order.clone()).unwrap_or_else(|| vec![0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21]);
+        for field_index in deser_order {
+            match field_index {
+                0 => if let Some(field) = &self.key_0 {
+                    serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.key_0_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                1 => if let Some(field) = &self.key_1 {
+                    serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.key_1_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                2 => if let Some(field) = &self.key_2 {
+                    serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.key_2_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_2_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                3 => if let Some(field) = &self.key_3 {
+                    serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, self.encodings.as_ref().map(|encs| encs.key_3_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_3_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                4 => if let Some(field) = &self.key_4 {
+                    serializer.write_unsigned_integer_sz(4u64, fit_sz(4u64, self.encodings.as_ref().map(|encs| encs.key_4_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_4_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                5 => if let Some(field) = &self.key_5 {
+                    serializer.write_unsigned_integer_sz(5u64, fit_sz(5u64, self.encodings.as_ref().map(|encs| encs.key_5_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_5_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                6 => if let Some(field) = &self.key_6 {
+                    serializer.write_unsigned_integer_sz(6u64, fit_sz(6u64, self.encodings.as_ref().map(|encs| encs.key_6_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_6_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                7 => if let Some(field) = &self.key_7 {
+                    serializer.write_unsigned_integer_sz(7u64, fit_sz(7u64, self.encodings.as_ref().map(|encs| encs.key_7_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_7_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                8 => if let Some(field) = &self.key_8 {
+                    serializer.write_unsigned_integer_sz(8u64, fit_sz(8u64, self.encodings.as_ref().map(|encs| encs.key_8_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_8_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                9 => if let Some(field) = &self.key_9 {
+                    serializer.write_unsigned_integer_sz(9u64, fit_sz(9u64, self.encodings.as_ref().map(|encs| encs.key_9_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                10 => if let Some(field) = &self.key_10 {
+                    serializer.write_unsigned_integer_sz(10u64, fit_sz(10u64, self.encodings.as_ref().map(|encs| encs.key_10_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                11 => if let Some(field) = &self.key_11 {
+                    serializer.write_unsigned_integer_sz(11u64, fit_sz(11u64, self.encodings.as_ref().map(|encs| encs.key_11_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                12 => if let Some(field) = &self.key_14 {
+                    serializer.write_unsigned_integer_sz(14u64, fit_sz(14u64, self.encodings.as_ref().map(|encs| encs.key_14_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                13 => if let Some(field) = &self.key_16 {
+                    serializer.write_unsigned_integer_sz(16u64, fit_sz(16u64, self.encodings.as_ref().map(|encs| encs.key_16_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_16_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                14 => if let Some(field) = &self.key_17 {
+                    serializer.write_unsigned_integer_sz(17u64, fit_sz(17u64, self.encodings.as_ref().map(|encs| encs.key_17_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_17_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                15 => if let Some(field) = &self.key_18 {
+                    serializer.write_unsigned_integer_sz(18u64, fit_sz(18u64, self.encodings.as_ref().map(|encs| encs.key_18_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                16 => if let Some(field) = &self.key_19 {
+                    serializer.write_unsigned_integer_sz(19u64, fit_sz(19u64, self.encodings.as_ref().map(|encs| encs.key_19_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                17 => if let Some(field) = &self.key_20 {
+                    serializer.write_unsigned_integer_sz(20u64, fit_sz(20u64, self.encodings.as_ref().map(|encs| encs.key_20_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                18 => if let Some(field) = &self.key_21 {
+                    serializer.write_unsigned_integer_sz(21u64, fit_sz(21u64, self.encodings.as_ref().map(|encs| encs.key_21_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                19 => if let Some(field) = &self.key_22 {
+                    serializer.write_unsigned_integer_sz(22u64, fit_sz(22u64, self.encodings.as_ref().map(|encs| encs.key_22_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_22_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                20 => if let Some(field) = &self.key_23 {
+                    serializer.write_unsigned_integer_sz(23u64, fit_sz(23u64, self.encodings.as_ref().map(|encs| encs.key_23_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_23_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                21 => if let Some(field) = &self.key_24 {
+                    serializer.write_unsigned_integer_sz(24u64, fit_sz(24u64, self.encodings.as_ref().map(|encs| encs.key_24_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_24_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                _ => unreachable!()
+            };
+        }
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ProtocolParamUpdate {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let mut orig_deser_order = Vec::new();
+            let mut key_0_encoding = None;
+            let mut key_0_key_encoding = None;
+            let mut key_0 = None;
+            let mut key_1_encoding = None;
+            let mut key_1_key_encoding = None;
+            let mut key_1 = None;
+            let mut key_2_encoding = None;
+            let mut key_2_key_encoding = None;
+            let mut key_2 = None;
+            let mut key_3_encoding = None;
+            let mut key_3_key_encoding = None;
+            let mut key_3 = None;
+            let mut key_4_encoding = None;
+            let mut key_4_key_encoding = None;
+            let mut key_4 = None;
+            let mut key_5_encoding = None;
+            let mut key_5_key_encoding = None;
+            let mut key_5 = None;
+            let mut key_6_encoding = None;
+            let mut key_6_key_encoding = None;
+            let mut key_6 = None;
+            let mut key_7_encoding = None;
+            let mut key_7_key_encoding = None;
+            let mut key_7 = None;
+            let mut key_8_encoding = None;
+            let mut key_8_key_encoding = None;
+            let mut key_8 = None;
+            let mut key_9_key_encoding = None;
+            let mut key_9 = None;
+            let mut key_10_key_encoding = None;
+            let mut key_10 = None;
+            let mut key_11_key_encoding = None;
+            let mut key_11 = None;
+            let mut key_14_key_encoding = None;
+            let mut key_14 = None;
+            let mut key_16_encoding = None;
+            let mut key_16_key_encoding = None;
+            let mut key_16 = None;
+            let mut key_17_encoding = None;
+            let mut key_17_key_encoding = None;
+            let mut key_17 = None;
+            let mut key_18_key_encoding = None;
+            let mut key_18 = None;
+            let mut key_19_key_encoding = None;
+            let mut key_19 = None;
+            let mut key_20_key_encoding = None;
+            let mut key_20 = None;
+            let mut key_21_key_encoding = None;
+            let mut key_21 = None;
+            let mut key_22_encoding = None;
+            let mut key_22_key_encoding = None;
+            let mut key_22 = None;
+            let mut key_23_encoding = None;
+            let mut key_23_key_encoding = None;
+            let mut key_23 = None;
+            let mut key_24_encoding = None;
+            let mut key_24_key_encoding = None;
+            let mut key_24 = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if key_0.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_key_0, tmp_key_0_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_0"))?;
+                            key_0 = Some(tmp_key_0);
+                            key_0_encoding = tmp_key_0_encoding;
+                            key_0_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if key_1.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_key_1, tmp_key_1_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_1"))?;
+                            key_1 = Some(tmp_key_1);
+                            key_1_encoding = tmp_key_1_encoding;
+                            key_1_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if key_2.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_key_2, tmp_key_2_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_2"))?;
+                            key_2 = Some(tmp_key_2);
+                            key_2_encoding = tmp_key_2_encoding;
+                            key_2_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if key_3.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_key_3, tmp_key_3_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_3"))?;
+                            key_3 = Some(tmp_key_3);
+                            key_3_encoding = tmp_key_3_encoding;
+                            key_3_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (4, key_enc) =>  {
+                            if key_4.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_key_4, tmp_key_4_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_4"))?;
+                            key_4 = Some(tmp_key_4);
+                            key_4_encoding = tmp_key_4_encoding;
+                            key_4_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        },
+                        (5, key_enc) =>  {
+                            if key_5.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_key_5, tmp_key_5_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_5"))?;
+                            key_5 = Some(tmp_key_5);
+                            key_5_encoding = tmp_key_5_encoding;
+                            key_5_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        },
+                        (6, key_enc) =>  {
+                            if key_6.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let (tmp_key_6, tmp_key_6_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_6"))?;
+                            key_6 = Some(tmp_key_6);
+                            key_6_encoding = tmp_key_6_encoding;
+                            key_6_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        },
+                        (7, key_enc) =>  {
+                            if key_7.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let (tmp_key_7, tmp_key_7_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_7"))?;
+                            key_7 = Some(tmp_key_7);
+                            key_7_encoding = tmp_key_7_encoding;
+                            key_7_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        },
+                        (8, key_enc) =>  {
+                            if key_8.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(8)).into());
+                            }
+                            let (tmp_key_8, tmp_key_8_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_8"))?;
+                            key_8 = Some(tmp_key_8);
+                            key_8_encoding = tmp_key_8_encoding;
+                            key_8_key_encoding = Some(key_enc);
+                            orig_deser_order.push(8);
+                        },
+                        (9, key_enc) =>  {
+                            if key_9.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(9)).into());
+                            }
+                            let tmp_key_9 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(Rational::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_9"))?;
+                            key_9 = Some(tmp_key_9);
+                            key_9_key_encoding = Some(key_enc);
+                            orig_deser_order.push(9);
+                        },
+                        (10, key_enc) =>  {
+                            if key_10.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(10)).into());
+                            }
+                            let tmp_key_10 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(UnitInterval::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_10"))?;
+                            key_10 = Some(tmp_key_10);
+                            key_10_key_encoding = Some(key_enc);
+                            orig_deser_order.push(10);
+                        },
+                        (11, key_enc) =>  {
+                            if key_11.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(11)).into());
+                            }
+                            let tmp_key_11 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(UnitInterval::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_11"))?;
+                            key_11 = Some(tmp_key_11);
+                            key_11_key_encoding = Some(key_enc);
+                            orig_deser_order.push(11);
+                        },
+                        (14, key_enc) =>  {
+                            if key_14.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(14)).into());
+                            }
+                            let tmp_key_14 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(ProtocolVersionStruct::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_14"))?;
+                            key_14 = Some(tmp_key_14);
+                            key_14_key_encoding = Some(key_enc);
+                            orig_deser_order.push(12);
+                        },
+                        (16, key_enc) =>  {
+                            if key_16.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(16)).into());
+                            }
+                            let (tmp_key_16, tmp_key_16_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_16"))?;
+                            key_16 = Some(tmp_key_16);
+                            key_16_encoding = tmp_key_16_encoding;
+                            key_16_key_encoding = Some(key_enc);
+                            orig_deser_order.push(13);
+                        },
+                        (17, key_enc) =>  {
+                            if key_17.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(17)).into());
+                            }
+                            let (tmp_key_17, tmp_key_17_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_17"))?;
+                            key_17 = Some(tmp_key_17);
+                            key_17_encoding = tmp_key_17_encoding;
+                            key_17_key_encoding = Some(key_enc);
+                            orig_deser_order.push(14);
+                        },
+                        (18, key_enc) =>  {
+                            if key_18.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(18)).into());
+                            }
+                            let tmp_key_18 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(Costmdls::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_18"))?;
+                            key_18 = Some(tmp_key_18);
+                            key_18_key_encoding = Some(key_enc);
+                            orig_deser_order.push(15);
+                        },
+                        (19, key_enc) =>  {
+                            if key_19.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(19)).into());
+                            }
+                            let tmp_key_19 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(ExUnitPrices::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_19"))?;
+                            key_19 = Some(tmp_key_19);
+                            key_19_key_encoding = Some(key_enc);
+                            orig_deser_order.push(16);
+                        },
+                        (20, key_enc) =>  {
+                            if key_20.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(20)).into());
+                            }
+                            let tmp_key_20 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(ExUnits::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_20"))?;
+                            key_20 = Some(tmp_key_20);
+                            key_20_key_encoding = Some(key_enc);
+                            orig_deser_order.push(17);
+                        },
+                        (21, key_enc) =>  {
+                            if key_21.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(21)).into());
+                            }
+                            let tmp_key_21 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(ExUnits::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_21"))?;
+                            key_21 = Some(tmp_key_21);
+                            key_21_key_encoding = Some(key_enc);
+                            orig_deser_order.push(18);
+                        },
+                        (22, key_enc) =>  {
+                            if key_22.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(22)).into());
+                            }
+                            let (tmp_key_22, tmp_key_22_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_22"))?;
+                            key_22 = Some(tmp_key_22);
+                            key_22_encoding = tmp_key_22_encoding;
+                            key_22_key_encoding = Some(key_enc);
+                            orig_deser_order.push(19);
+                        },
+                        (23, key_enc) =>  {
+                            if key_23.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(23)).into());
+                            }
+                            let (tmp_key_23, tmp_key_23_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_23"))?;
+                            key_23 = Some(tmp_key_23);
+                            key_23_encoding = tmp_key_23_encoding;
+                            key_23_key_encoding = Some(key_enc);
+                            orig_deser_order.push(20);
+                        },
+                        (24, key_enc) =>  {
+                            if key_24.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(24)).into());
+                            }
+                            let (tmp_key_24, tmp_key_24_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_24"))?;
+                            key_24 = Some(tmp_key_24);
+                            key_24_encoding = tmp_key_24_encoding;
+                            key_24_key_encoding = Some(key_enc);
+                            orig_deser_order.push(21);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    CBORType::Text => {
+                        let (text_key, key_enc) = raw.text_sz()?;
+                        match text_key.as_str() {
+                            unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Str(unknown_key.to_owned())).into()),
+                        }
+                    },
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                key_0,
+                key_1,
+                key_2,
+                key_3,
+                key_4,
+                key_5,
+                key_6,
+                key_7,
+                key_8,
+                key_9,
+                key_10,
+                key_11,
+                key_14,
+                key_16,
+                key_17,
+                key_18,
+                key_19,
+                key_20,
+                key_21,
+                key_22,
+                key_23,
+                key_24,
+                encodings: Some(ProtocolParamUpdateEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    key_0_key_encoding,
+                    key_0_encoding,
+                    key_1_key_encoding,
+                    key_1_encoding,
+                    key_2_key_encoding,
+                    key_2_encoding,
+                    key_3_key_encoding,
+                    key_3_encoding,
+                    key_4_key_encoding,
+                    key_4_encoding,
+                    key_5_key_encoding,
+                    key_5_encoding,
+                    key_6_key_encoding,
+                    key_6_encoding,
+                    key_7_key_encoding,
+                    key_7_encoding,
+                    key_8_key_encoding,
+                    key_8_encoding,
+                    key_9_key_encoding,
+                    key_10_key_encoding,
+                    key_11_key_encoding,
+                    key_14_key_encoding,
+                    key_16_key_encoding,
+                    key_16_encoding,
+                    key_17_key_encoding,
+                    key_17_encoding,
+                    key_18_key_encoding,
+                    key_19_key_encoding,
+                    key_20_key_encoding,
+                    key_21_key_encoding,
+                    key_22_key_encoding,
+                    key_22_encoding,
+                    key_23_key_encoding,
+                    key_23_encoding,
+                    key_24_key_encoding,
+                    key_24_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("ProtocolParamUpdate"))
+    }
+}
+
+impl Serialize for ProtocolVersion {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for ProtocolVersion {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(self.index_0, fit_sz(self.index_0, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.index_1, fit_sz(self.index_1, self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ProtocolVersion {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("ProtocolVersion"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for ProtocolVersion {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let (index_0, index_0_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (index_1, index_1_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("index_1"))?;
+        Ok(ProtocolVersion {
+            index_0,
+            index_1,
+            encodings: Some(ProtocolVersionEncoding {
+                len_encoding,
+                index_0_encoding,
+                index_1_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for ProtocolVersionStruct {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.protocol_version.serialize_as_embedded_group(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ProtocolVersionStruct {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let protocol_version = (|| -> Result<_, DeserializeError> {
+                Ok(ProtocolVersion::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })().map_err(|e| e.annotate("protocol_version"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ProtocolVersionStruct {
+                protocol_version,
+                encodings: Some(ProtocolVersionStructEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("ProtocolVersionStruct"))
+    }
+}
+
+impl Serialize for Rational {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_tag_sz(30u64, fit_sz(30u64, self.encodings.as_ref().map(|encs| encs.tag_encoding).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.numerator, fit_sz(self.numerator, self.encodings.as_ref().map(|encs| encs.numerator_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.denominator, fit_sz(self.denominator, self.encodings.as_ref().map(|encs| encs.denominator_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Rational {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let (tag, tag_encoding) = raw.tag_sz()?;
+            if tag != 30 {
+                return Err(DeserializeError::new("Rational", DeserializeFailure::TagMismatch{ found: tag, expected: 30 }));
+            }
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (numerator, numerator_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("numerator"))?;
+            let (denominator, denominator_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("denominator"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Rational {
+                numerator,
+                denominator,
+                encodings: Some(RationalEncoding {
+                    len_encoding,
+                    tag_encoding: Some(tag_encoding),
+                    numerator_encoding,
+                    denominator_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Rational"))
+    }
+}
+
+impl Serialize for Redeemer {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(4, force_canonical))?;
+        self.tag.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.index, fit_sz(self.index, self.encodings.as_ref().map(|encs| encs.index_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.data.serialize(serializer, force_canonical)?;
+        self.ex_units.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Redeemer {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(4)?;
+            let tag = (|| -> Result<_, DeserializeError> {
+                Ok(RedeemerTag::deserialize(raw)?)
+            })().map_err(|e| e.annotate("tag"))?;
+            let (index, index_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("index"))?;
+            let data = (|| -> Result<_, DeserializeError> {
+                Ok(PlutusData::deserialize(raw)?)
+            })().map_err(|e| e.annotate("data"))?;
+            let ex_units = (|| -> Result<_, DeserializeError> {
+                Ok(ExUnits::deserialize(raw)?)
+            })().map_err(|e| e.annotate("ex_units"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Redeemer {
+                tag,
+                index,
+                data,
+                ex_units,
+                encodings: Some(RedeemerEncoding {
+                    len_encoding,
+                    index_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Redeemer"))
+    }
+}
+
+impl Serialize for RedeemerTag {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            RedeemerTag::I0{ i0_encoding } => {
+                serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, *i0_encoding, force_canonical))
+            },
+            RedeemerTag::I1{ i1_encoding } => {
+                serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, *i1_encoding, force_canonical))
+            },
+            RedeemerTag::I2{ i2_encoding } => {
+                serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, *i2_encoding, force_canonical))
+            },
+            RedeemerTag::I3{ i3_encoding } => {
+                serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, *i3_encoding, force_canonical))
+            },
+        }
+    }
+}
+
+impl Deserialize for RedeemerTag {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i0_value, i0_encoding) = raw.unsigned_integer_sz()?;
+                if i0_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i0_value), expected: Key::Uint(0) }.into());
+                }
+                Ok(Some(i0_encoding))
+            })(raw)
+            {
+                Ok(i0_encoding) => return Ok(Self::I0 {
+                    i0_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i1_value, i1_encoding) = raw.unsigned_integer_sz()?;
+                if i1_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i1_value), expected: Key::Uint(1) }.into());
+                }
+                Ok(Some(i1_encoding))
+            })(raw)
+            {
+                Ok(i1_encoding) => return Ok(Self::I1 {
+                    i1_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i2_value, i2_encoding) = raw.unsigned_integer_sz()?;
+                if i2_value != 2 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i2_value), expected: Key::Uint(2) }.into());
+                }
+                Ok(Some(i2_encoding))
+            })(raw)
+            {
+                Ok(i2_encoding) => return Ok(Self::I2 {
+                    i2_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let (i3_value, i3_encoding) = raw.unsigned_integer_sz()?;
+                if i3_value != 3 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i3_value), expected: Key::Uint(3) }.into());
+                }
+                Ok(Some(i3_encoding))
+            })(raw)
+            {
+                Ok(i3_encoding) => return Ok(Self::I3 {
+                    i3_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("RedeemerTag", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("RedeemerTag"))
+    }
+}
+
+impl Serialize for Relay {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            Relay::SingleHostAddr(single_host_addr) => single_host_addr.serialize(serializer, force_canonical),
+            Relay::SingleHostName(single_host_name) => single_host_name.serialize(serializer, force_canonical),
+            Relay::MultiHostName(multi_host_name) => multi_host_name.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for Relay {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let outer_len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(SingleHostAddr::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(single_host_addr) => return Ok(Self::SingleHostAddr(single_host_addr)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(SingleHostName::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(single_host_name) => return Ok(Self::SingleHostName(single_host_name)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(MultiHostName::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(multi_host_name) => return Ok(Self::MultiHostName(multi_host_name)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new("Relay", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("Relay"))
+    }
+}
+
+impl Serialize for RequiredSigners {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(1, force_canonical))?;
+        self.addr_keyhash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for RequiredSigners {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(1)?;
+            let addr_keyhash = (|| -> Result<_, DeserializeError> {
+                Ok(Hash28::deserialize(raw)?)
+            })().map_err(|e| e.annotate("addr_keyhash"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(RequiredSigners {
+                addr_keyhash,
+                encodings: Some(RequiredSignersEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("RequiredSigners"))
+    }
+}
+
+impl Serialize for RewardAccount {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(1, force_canonical))?;
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for RewardAccount {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(1)?;
+            let index_0_encoding = (|| -> Result<_, DeserializeError> {
+                let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+                if index_0_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+                }
+                Ok(Some(index_0_encoding))
+            })().map_err(|e| e.annotate("index_0"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(RewardAccount {
+                encodings: Some(RewardAccountEncoding {
+                    len_encoding,
+                    index_0_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("RewardAccount"))
+    }
+}
+
+impl Serialize for Script {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            Script::Script0(script0) => script0.serialize(serializer, force_canonical),
+            Script::Script1(script1) => script1.serialize(serializer, force_canonical),
+            Script::Script2(script2) => script2.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for Script {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let outer_len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(Script0::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(script0) => return Ok(Self::Script0(script0)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(Script1::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(script1) => return Ok(Self::Script1(script1)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(Script2::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(script2) => return Ok(Self::Script2(script2)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new("Script", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("Script"))
+    }
+}
+
+impl Serialize for Script0 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for Script0 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.native_script.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Script0 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("Script0"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for Script0 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let native_script = (|| -> Result<_, DeserializeError> {
+            Ok(NativeScript::deserialize(raw)?)
+        })().map_err(|e| e.annotate("native_script"))?;
+        Ok(Script0 {
+            native_script,
+            encodings: Some(Script0Encoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Script1 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for Script1 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_bytes_sz(&self.plutus_v1_script, self.encodings.as_ref().map(|encs| encs.plutus_v1_script_encoding.clone()).unwrap_or_default().to_str_len_sz(self.plutus_v1_script.len() as u64, force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Script1 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("Script1"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for Script1 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (plutus_v1_script, plutus_v1_script_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+        })().map_err(|e| e.annotate("plutus_v1_script"))?;
+        Ok(Script1 {
+            plutus_v1_script,
+            encodings: Some(Script1Encoding {
+                len_encoding,
+                index_0_encoding,
+                plutus_v1_script_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Script2 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for Script2 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_bytes_sz(&self.plutus_v2_script, self.encodings.as_ref().map(|encs| encs.plutus_v2_script_encoding.clone()).unwrap_or_default().to_str_len_sz(self.plutus_v2_script.len() as u64, force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Script2 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("Script2"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for Script2 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 2 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (plutus_v2_script, plutus_v2_script_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+        })().map_err(|e| e.annotate("plutus_v2_script"))?;
+        Ok(Script2 {
+            plutus_v2_script,
+            encodings: Some(Script2Encoding {
+                len_encoding,
+                index_0_encoding,
+                plutus_v2_script_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for ScriptAll {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for ScriptAll {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.native_scripts_encoding.clone()).unwrap_or_default().to_len_sz(self.native_scripts.len() as u64, force_canonical))?;
+        for element in self.native_scripts.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.native_scripts_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ScriptAll {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("ScriptAll"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for ScriptAll {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (native_scripts, native_scripts_encoding) = (|| -> Result<_, DeserializeError> {
+            let mut native_scripts_arr = Vec::new();
+            let len = raw.array_sz()?;
+            let native_scripts_encoding = len.into();
+            while match len { cbor_event::LenSz::Len(n, _) => native_scripts_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                native_scripts_arr.push(NativeScript::deserialize(raw)?);
+            }
+            Ok((native_scripts_arr, native_scripts_encoding))
+        })().map_err(|e| e.annotate("native_scripts"))?;
+        Ok(ScriptAll {
+            native_scripts,
+            encodings: Some(ScriptAllEncoding {
+                len_encoding,
+                index_0_encoding,
+                native_scripts_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for ScriptAny {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for ScriptAny {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.native_scripts_encoding.clone()).unwrap_or_default().to_len_sz(self.native_scripts.len() as u64, force_canonical))?;
+        for element in self.native_scripts.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.native_scripts_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ScriptAny {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("ScriptAny"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for ScriptAny {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 2 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (native_scripts, native_scripts_encoding) = (|| -> Result<_, DeserializeError> {
+            let mut native_scripts_arr = Vec::new();
+            let len = raw.array_sz()?;
+            let native_scripts_encoding = len.into();
+            while match len { cbor_event::LenSz::Len(n, _) => native_scripts_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                native_scripts_arr.push(NativeScript::deserialize(raw)?);
+            }
+            Ok((native_scripts_arr, native_scripts_encoding))
+        })().map_err(|e| e.annotate("native_scripts"))?;
+        Ok(ScriptAny {
+            native_scripts,
+            encodings: Some(ScriptAnyEncoding {
+                len_encoding,
+                index_0_encoding,
+                native_scripts_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for ScriptNOfK {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(3, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for ScriptNOfK {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.n, fit_sz(self.n, self.encodings.as_ref().map(|encs| encs.n_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.native_scripts_encoding.clone()).unwrap_or_default().to_len_sz(self.native_scripts.len() as u64, force_canonical))?;
+        for element in self.native_scripts.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.native_scripts_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ScriptNOfK {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(3)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("ScriptNOfK"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for ScriptNOfK {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 3 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(3) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (n, n_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+        })().map_err(|e| e.annotate("n"))?;
+        let (native_scripts, native_scripts_encoding) = (|| -> Result<_, DeserializeError> {
+            let mut native_scripts_arr = Vec::new();
+            let len = raw.array_sz()?;
+            let native_scripts_encoding = len.into();
+            while match len { cbor_event::LenSz::Len(n, _) => native_scripts_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                native_scripts_arr.push(NativeScript::deserialize(raw)?);
+            }
+            Ok((native_scripts_arr, native_scripts_encoding))
+        })().map_err(|e| e.annotate("native_scripts"))?;
+        Ok(ScriptNOfK {
+            n,
+            native_scripts,
+            encodings: Some(ScriptNOfKEncoding {
+                len_encoding,
+                index_0_encoding,
+                n_encoding,
+                native_scripts_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for ScriptPubkey {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for ScriptPubkey {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.addr_keyhash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ScriptPubkey {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("ScriptPubkey"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for ScriptPubkey {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let addr_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("addr_keyhash"))?;
+        Ok(ScriptPubkey {
+            addr_keyhash,
+            encodings: Some(ScriptPubkeyEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for ShelleyMaAuxData {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.transaction_metadata_encoding.clone()).unwrap_or_default().to_len_sz(self.transaction_metadata.len() as u64, force_canonical))?;
+        let mut key_order = self.transaction_metadata.iter().map(|(k, v)| {
+            let mut buf = cbor_event::se::Serializer::new_vec();
+            let transaction_metadata_key_encoding = self.encodings.as_ref().and_then(|encs| encs.transaction_metadata_key_encodings.get(k)).map(|e| e.clone()).unwrap_or_else(|| None);
+            buf.write_unsigned_integer_sz(*k, fit_sz(*k, transaction_metadata_key_encoding, force_canonical))?;
+            Ok((buf.finalize(), k, v))
+        }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.transaction_metadata_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.auxiliary_scripts_encoding.clone()).unwrap_or_default().to_len_sz(self.auxiliary_scripts.len() as u64, force_canonical))?;
+        for element in self.auxiliary_scripts.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.auxiliary_scripts_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyMaAuxData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (transaction_metadata, transaction_metadata_encoding, transaction_metadata_key_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_metadata_table = OrderedHashMap::new();
+                let transaction_metadata_len = raw.map_sz()?;
+                let transaction_metadata_encoding = transaction_metadata_len.into();
+                let mut transaction_metadata_key_encodings = BTreeMap::new();
+                while match transaction_metadata_len { cbor_event::LenSz::Len(n, _) => transaction_metadata_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let (transaction_metadata_key, transaction_metadata_key_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                    let transaction_metadata_value = TransactionMetadatum::deserialize(raw)?;
+                    if transaction_metadata_table.insert(transaction_metadata_key.clone(), transaction_metadata_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                    transaction_metadata_key_encodings.insert(transaction_metadata_key.clone(), transaction_metadata_key_encoding);
+                }
+                Ok((transaction_metadata_table, transaction_metadata_encoding, transaction_metadata_key_encodings))
+            })().map_err(|e| e.annotate("transaction_metadata"))?;
+            let (auxiliary_scripts, auxiliary_scripts_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut auxiliary_scripts_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let auxiliary_scripts_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => auxiliary_scripts_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    auxiliary_scripts_arr.push(NativeScript::deserialize(raw)?);
+                }
+                Ok((auxiliary_scripts_arr, auxiliary_scripts_encoding))
+            })().map_err(|e| e.annotate("auxiliary_scripts"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyMaAuxData {
+                transaction_metadata,
+                auxiliary_scripts,
+                encodings: Some(ShelleyMaAuxDataEncoding {
+                    len_encoding,
+                    transaction_metadata_encoding,
+                    transaction_metadata_key_encodings,
+                    auxiliary_scripts_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("ShelleyMaAuxData"))
+    }
+}
+
+impl Serialize for ShelleyTxOut {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.address.serialize(serializer, force_canonical)?;
+        self.amount.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyTxOut {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let address = (|| -> Result<_, DeserializeError> {
+                Ok(Address::deserialize(raw)?)
+            })().map_err(|e| e.annotate("address"))?;
+            let amount = (|| -> Result<_, DeserializeError> {
+                Ok(Value::deserialize(raw)?)
+            })().map_err(|e| e.annotate("amount"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyTxOut {
+                address,
+                amount,
+                encodings: Some(ShelleyTxOutEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("ShelleyTxOut"))
+    }
+}
+
+impl Serialize for Signature {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for Signature {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 16 {
+            return Err(DeserializeError::new("Signature", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(16), max: Some(16) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(SignatureEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for SignkeyKES {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for SignkeyKES {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 16 {
+            return Err(DeserializeError::new("SignkeyKES", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(16), max: Some(16) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(SignkeyKESEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for SingleHostAddr {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(4, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for SingleHostAddr {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        match &self.port {
+            Some(x) => {
+                serializer.write_unsigned_integer_sz(*x as u64, fit_sz(*x as u64, self.encodings.as_ref().map(|encs| encs.port_encoding.clone()).unwrap_or_default(), force_canonical))
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        match &self.ipv4 {
+            Some(x) => {
+                x.serialize(serializer, force_canonical)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        match &self.ipv6 {
+            Some(x) => {
+                x.serialize(serializer, force_canonical)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for SingleHostAddr {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(4)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("SingleHostAddr"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for SingleHostAddr {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (port, port_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Result::<_, DeserializeError>::Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?).map(|(x, port_encoding)| (Some(x), port_encoding))?
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    (None, None)
+                }
+            })
+        })().map_err(|e| e.annotate("port"))?;
+        let ipv4 = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(Ipv4::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("ipv4"))?;
+        let ipv6 = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(Ipv6::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("ipv6"))?;
+        Ok(SingleHostAddr {
+            port,
+            ipv4,
+            ipv6,
+            encodings: Some(SingleHostAddrEncoding {
+                len_encoding,
+                index_0_encoding,
+                port_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for SingleHostName {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(3, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for SingleHostName {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        match &self.port {
+            Some(x) => {
+                serializer.write_unsigned_integer_sz(*x as u64, fit_sz(*x as u64, self.encodings.as_ref().map(|encs| encs.port_encoding.clone()).unwrap_or_default(), force_canonical))
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        self.dns_name.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for SingleHostName {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(3)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("SingleHostName"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for SingleHostName {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let (port, port_encoding) = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Result::<_, DeserializeError>::Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?).map(|(x, port_encoding)| (Some(x), port_encoding))?
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    (None, None)
+                }
+            })
+        })().map_err(|e| e.annotate("port"))?;
+        let dns_name = (|| -> Result<_, DeserializeError> {
+            Ok(DnsName::deserialize(raw)?)
+        })().map_err(|e| e.annotate("dns_name"))?;
+        Ok(SingleHostName {
+            port,
+            dns_name,
+            encodings: Some(SingleHostNameEncoding {
+                len_encoding,
+                index_0_encoding,
+                port_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for StakeCredential {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            StakeCredential::StakeCredential0(stake_credential0) => stake_credential0.serialize(serializer, force_canonical),
+            StakeCredential::StakeCredential1(stake_credential1) => stake_credential1.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for StakeCredential {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let outer_len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(StakeCredential0::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(stake_credential0) => return Ok(Self::StakeCredential0(stake_credential0)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(StakeCredential1::deserialize_as_embedded_group(raw, &mut read_len, len)?)
+            })(raw)
+            {
+                Ok(stake_credential1) => return Ok(Self::StakeCredential1(stake_credential1)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new("StakeCredential", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("StakeCredential"))
+    }
+}
+
+impl Serialize for StakeCredential0 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for StakeCredential0 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.addr_keyhash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for StakeCredential0 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeCredential0"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeCredential0 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let addr_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("addr_keyhash"))?;
+        Ok(StakeCredential0 {
+            addr_keyhash,
+            encodings: Some(StakeCredential0Encoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for StakeCredential1 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for StakeCredential1 {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.scripthash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for StakeCredential1 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeCredential1"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeCredential1 {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let scripthash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("scripthash"))?;
+        Ok(StakeCredential1 {
+            scripthash,
+            encodings: Some(StakeCredential1Encoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for StakeDelegation {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(3, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for StakeDelegation {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.stake_credential.serialize(serializer, force_canonical)?;
+        self.pool_keyhash.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for StakeDelegation {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(3)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeDelegation"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeDelegation {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 2 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let stake_credential = (|| -> Result<_, DeserializeError> {
+            Ok(StakeCredential::deserialize(raw)?)
+        })().map_err(|e| e.annotate("stake_credential"))?;
+        let pool_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(Hash28::deserialize(raw)?)
+        })().map_err(|e| e.annotate("pool_keyhash"))?;
+        Ok(StakeDelegation {
+            stake_credential,
+            pool_keyhash,
+            encodings: Some(StakeDelegationEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for StakeDeregistration {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for StakeDeregistration {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.stake_credential.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for StakeDeregistration {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeDeregistration"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeDeregistration {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let stake_credential = (|| -> Result<_, DeserializeError> {
+            Ok(StakeCredential::deserialize(raw)?)
+        })().map_err(|e| e.annotate("stake_credential"))?;
+        Ok(StakeDeregistration {
+            stake_credential,
+            encodings: Some(StakeDeregistrationEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for StakeRegistration {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for StakeRegistration {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.stake_credential.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for StakeRegistration {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeRegistration"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeRegistration {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, read_len: &mut CBORReadLen, len: cbor_event::LenSz) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        let index_0_encoding = (|| -> Result<_, DeserializeError> {
+            let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(Some(index_0_encoding))
+        })().map_err(|e| e.annotate("index_0"))?;
+        let stake_credential = (|| -> Result<_, DeserializeError> {
+            Ok(StakeCredential::deserialize(raw)?)
+        })().map_err(|e| e.annotate("stake_credential"))?;
+        Ok(StakeRegistration {
+            stake_credential,
+            encodings: Some(StakeRegistrationEncoding {
+                len_encoding,
+                index_0_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Transaction {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(4, force_canonical))?;
+        self.transaction_body.serialize(serializer, force_canonical)?;
+        self.transaction_witness_set.serialize(serializer, force_canonical)?;
+        serializer.write_special(cbor_event::Special::Bool(self.index_2))?;
+        match &self.auxiliary_data {
+            Some(x) => {
+                x.serialize(serializer, force_canonical)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Transaction {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(4)?;
+            let transaction_body = (|| -> Result<_, DeserializeError> {
+                Ok(TransactionBody::deserialize(raw)?)
+            })().map_err(|e| e.annotate("transaction_body"))?;
+            let transaction_witness_set = (|| -> Result<_, DeserializeError> {
+                Ok(TransactionWitnessSet::deserialize(raw)?)
+            })().map_err(|e| e.annotate("transaction_witness_set"))?;
+            let index_2 = (|| -> Result<_, DeserializeError> {
+                Ok(bool::deserialize(raw)?)
+            })().map_err(|e| e.annotate("index_2"))?;
+            let auxiliary_data = (|| -> Result<_, DeserializeError> {
+                Ok(match raw.cbor_type()? != CBORType::Special {
+                    true => {
+                        Some(AuxiliaryData::deserialize(raw)?)
+                    },
+                    false => {
+                        if raw.special()? != CBORSpecial::Null {
+                            return Err(DeserializeFailure::ExpectedNull.into());
+                        }
+                        None
+                    }
+                })
+            })().map_err(|e| e.annotate("auxiliary_data"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Transaction {
+                transaction_body,
+                transaction_witness_set,
+                index_2,
+                auxiliary_data,
+                encodings: Some(TransactionEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Transaction"))
+    }
+}
+
+impl Serialize for TransactionBody {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(3 + match &self.key_3 { Some(_) => 1, None => 0 } + match &self.key_4 { Some(_) => 1, None => 0 } + match &self.key_5 { Some(_) => 1, None => 0 } + match &self.key_6 { Some(_) => 1, None => 0 } + match &self.key_7 { Some(_) => 1, None => 0 } + match &self.key_8 { Some(_) => 1, None => 0 } + match &self.key_9 { Some(_) => 1, None => 0 } + match &self.key_11 { Some(_) => 1, None => 0 } + match &self.key_13 { Some(_) => 1, None => 0 } + match &self.key_14 { Some(_) => 1, None => 0 } + match &self.key_15 { Some(_) => 1, None => 0 } + match &self.key_16 { Some(_) => 1, None => 0 } + match &self.key_17 { Some(_) => 1, None => 0 } + match &self.key_18 { Some(_) => 1, None => 0 }, force_canonical))?;
+        let deser_order = self.encodings.as_ref().filter(|encs| !force_canonical && encs.orig_deser_order.len() == 3 + match &self.key_3 { Some(_) => 1, None => 0 } + match &self.key_4 { Some(_) => 1, None => 0 } + match &self.key_5 { Some(_) => 1, None => 0 } + match &self.key_6 { Some(_) => 1, None => 0 } + match &self.key_7 { Some(_) => 1, None => 0 } + match &self.key_8 { Some(_) => 1, None => 0 } + match &self.key_9 { Some(_) => 1, None => 0 } + match &self.key_11 { Some(_) => 1, None => 0 } + match &self.key_13 { Some(_) => 1, None => 0 } + match &self.key_14 { Some(_) => 1, None => 0 } + match &self.key_15 { Some(_) => 1, None => 0 } + match &self.key_16 { Some(_) => 1, None => 0 } + match &self.key_17 { Some(_) => 1, None => 0 } + match &self.key_18 { Some(_) => 1, None => 0 }).map(|encs| encs.orig_deser_order.clone()).unwrap_or_else(|| vec![0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.key_0_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().to_len_sz(self.key_0.len() as u64, force_canonical))?;
+                    for element in self.key_0.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                1 => {
+                    serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.key_1_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().to_len_sz(self.key_1.len() as u64, force_canonical))?;
+                    for element in self.key_1.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                2 => {
+                    serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.key_2_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(self.key_2, fit_sz(self.key_2, self.encodings.as_ref().map(|encs| encs.key_2_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                3 => if let Some(field) = &self.key_3 {
+                    serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, self.encodings.as_ref().map(|encs| encs.key_3_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_3_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                4 => if let Some(field) = &self.key_4 {
+                    serializer.write_unsigned_integer_sz(4u64, fit_sz(4u64, self.encodings.as_ref().map(|encs| encs.key_4_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_4_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_4_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                5 => if let Some(field) = &self.key_5 {
+                    serializer.write_unsigned_integer_sz(5u64, fit_sz(5u64, self.encodings.as_ref().map(|encs| encs.key_5_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.key_5_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    let mut key_order = field.iter().map(|(k, v)| {
+                        let mut buf = cbor_event::se::Serializer::new_vec();
+                        k.serialize(&mut buf, force_canonical)?;
+                        Ok((buf.finalize(), k, v))
+                    }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                    if force_canonical {
+                        key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                            match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                                std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                                diff_ord => diff_ord,
+                            }
+                        });
+                    }
+                    for (key_bytes, key, value) in key_order {
+                        serializer.write_raw_bytes(&key_bytes)?;
+                        let key_5_value_encoding = self.encodings.as_ref().and_then(|encs| encs.key_5_value_encodings.get(key)).map(|e| e.clone()).unwrap_or_else(|| None);
+                        serializer.write_unsigned_integer_sz(*value, fit_sz(*value, key_5_value_encoding, force_canonical))?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_5_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                6 => if let Some(field) = &self.key_6 {
+                    serializer.write_unsigned_integer_sz(6u64, fit_sz(6u64, self.encodings.as_ref().map(|encs| encs.key_6_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                7 => if let Some(field) = &self.key_7 {
+                    serializer.write_unsigned_integer_sz(7u64, fit_sz(7u64, self.encodings.as_ref().map(|encs| encs.key_7_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                8 => if let Some(field) = &self.key_8 {
+                    serializer.write_unsigned_integer_sz(8u64, fit_sz(8u64, self.encodings.as_ref().map(|encs| encs.key_8_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_8_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                9 => if let Some(field) = &self.key_9 {
+                    serializer.write_unsigned_integer_sz(9u64, fit_sz(9u64, self.encodings.as_ref().map(|encs| encs.key_9_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.key_9_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    let mut key_order = field.iter().map(|(k, v)| {
+                        let mut buf = cbor_event::se::Serializer::new_vec();
+                        k.serialize(&mut buf, force_canonical)?;
+                        Ok((buf.finalize(), k, v))
+                    }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                    if force_canonical {
+                        key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                            match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                                std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                                diff_ord => diff_ord,
+                            }
+                        });
+                    }
+                    for (key_bytes, key, value) in key_order {
+                        serializer.write_raw_bytes(&key_bytes)?;
+                        let (key_9_value_encoding, key_9_value_value_encodings) = self.encodings.as_ref().and_then(|encs| encs.key_9_value_encodings.get(key)).map(|e| e.clone()).unwrap_or_else(|| (LenEncoding::default(), BTreeMap::new()));
+                        serializer.write_map_sz(key_9_value_encoding.to_len_sz(value.len() as u64, force_canonical))?;
+                        let mut key_order = value.iter().map(|(k, v)| {
+                            let mut buf = cbor_event::se::Serializer::new_vec();
+                            k.serialize(&mut buf, force_canonical)?;
+                            Ok((buf.finalize(), k, v))
+                        }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                        if force_canonical {
+                            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                                    std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                                    diff_ord => diff_ord,
+                                }
+                            });
+                        }
+                        for (key_bytes, key, value) in key_order {
+                            serializer.write_raw_bytes(&key_bytes)?;
+                            let key_9_value_value_encoding = key_9_value_value_encodings.get(key).map(|e| e.clone()).unwrap_or_else(|| None);
+                            if *value >= 0 {
+                                serializer.write_unsigned_integer_sz(*value as u64, fit_sz(*value as u64, key_9_value_value_encoding, force_canonical))?;
+                            }
+                            else {
+                                serializer.write_negative_integer_sz(*value as i128, fit_sz((*value + 1).abs() as u64, key_9_value_value_encoding, force_canonical))?;
+                            }
+                        }
+                        key_9_value_encoding.end(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_9_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                10 => if let Some(field) = &self.key_11 {
+                    serializer.write_unsigned_integer_sz(11u64, fit_sz(11u64, self.encodings.as_ref().map(|encs| encs.key_11_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                11 => if let Some(field) = &self.key_13 {
+                    serializer.write_unsigned_integer_sz(13u64, fit_sz(13u64, self.encodings.as_ref().map(|encs| encs.key_13_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_13_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_13_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                12 => if let Some(field) = &self.key_14 {
+                    serializer.write_unsigned_integer_sz(14u64, fit_sz(14u64, self.encodings.as_ref().map(|encs| encs.key_14_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                13 => if let Some(field) = &self.key_15 {
+                    serializer.write_unsigned_integer_sz(15u64, fit_sz(15u64, self.encodings.as_ref().map(|encs| encs.key_15_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                14 => if let Some(field) = &self.key_16 {
+                    serializer.write_unsigned_integer_sz(16u64, fit_sz(16u64, self.encodings.as_ref().map(|encs| encs.key_16_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    field.serialize(serializer, force_canonical)?;
+                }
+                15 => if let Some(field) = &self.key_17 {
+                    serializer.write_unsigned_integer_sz(17u64, fit_sz(17u64, self.encodings.as_ref().map(|encs| encs.key_17_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_unsigned_integer_sz(*field, fit_sz(*field, self.encodings.as_ref().map(|encs| encs.key_17_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                }
+                16 => if let Some(field) = &self.key_18 {
+                    serializer.write_unsigned_integer_sz(18u64, fit_sz(18u64, self.encodings.as_ref().map(|encs| encs.key_18_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_18_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_18_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                _ => unreachable!()
+            };
+        }
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for TransactionBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(3)?;
+            let mut orig_deser_order = Vec::new();
+            let mut key_0_encoding = LenEncoding::default();
+            let mut key_0_key_encoding = None;
+            let mut key_0 = None;
+            let mut key_1_encoding = LenEncoding::default();
+            let mut key_1_key_encoding = None;
+            let mut key_1 = None;
+            let mut key_2_encoding = None;
+            let mut key_2_key_encoding = None;
+            let mut key_2 = None;
+            let mut key_3_encoding = None;
+            let mut key_3_key_encoding = None;
+            let mut key_3 = None;
+            let mut key_4_encoding = LenEncoding::default();
+            let mut key_4_key_encoding = None;
+            let mut key_4 = None;
+            let mut key_5_encoding = LenEncoding::default();
+            let mut key_5_value_encodings = BTreeMap::new();
+            let mut key_5_key_encoding = None;
+            let mut key_5 = None;
+            let mut key_6_key_encoding = None;
+            let mut key_6 = None;
+            let mut key_7_key_encoding = None;
+            let mut key_7 = None;
+            let mut key_8_encoding = None;
+            let mut key_8_key_encoding = None;
+            let mut key_8 = None;
+            let mut key_9_encoding = LenEncoding::default();
+            let mut key_9_value_encodings = BTreeMap::new();
+            let mut key_9_key_encoding = None;
+            let mut key_9 = None;
+            let mut key_11_key_encoding = None;
+            let mut key_11 = None;
+            let mut key_13_encoding = LenEncoding::default();
+            let mut key_13_key_encoding = None;
+            let mut key_13 = None;
+            let mut key_14_key_encoding = None;
+            let mut key_14 = None;
+            let mut key_15_key_encoding = None;
+            let mut key_15 = None;
+            let mut key_16_key_encoding = None;
+            let mut key_16 = None;
+            let mut key_17_encoding = None;
+            let mut key_17_key_encoding = None;
+            let mut key_17 = None;
+            let mut key_18_encoding = LenEncoding::default();
+            let mut key_18_key_encoding = None;
+            let mut key_18 = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if key_0.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_key_0, tmp_key_0_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut key_0_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_0_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_0_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_0_arr.push(TransactionInput::deserialize(raw)?);
+                                }
+                                Ok((key_0_arr, key_0_encoding))
+                            })().map_err(|e| e.annotate("key_0"))?;
+                            key_0 = Some(tmp_key_0);
+                            key_0_encoding = tmp_key_0_encoding;
+                            key_0_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if key_1.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_key_1, tmp_key_1_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut key_1_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_1_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_1_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_1_arr.push(TransactionOutput::deserialize(raw)?);
+                                }
+                                Ok((key_1_arr, key_1_encoding))
+                            })().map_err(|e| e.annotate("key_1"))?;
+                            key_1 = Some(tmp_key_1);
+                            key_1_encoding = tmp_key_1_encoding;
+                            key_1_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if key_2.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_key_2, tmp_key_2_encoding) = (|| -> Result<_, DeserializeError> {
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_2"))?;
+                            key_2 = Some(tmp_key_2);
+                            key_2_encoding = tmp_key_2_encoding;
+                            key_2_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if key_3.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_key_3, tmp_key_3_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_3"))?;
+                            key_3 = Some(tmp_key_3);
+                            key_3_encoding = tmp_key_3_encoding;
+                            key_3_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (4, key_enc) =>  {
+                            if key_4.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_key_4, tmp_key_4_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_4_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_4_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_4_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_4_arr.push(Certificate::deserialize(raw)?);
+                                }
+                                Ok((key_4_arr, key_4_encoding))
+                            })().map_err(|e| e.annotate("key_4"))?;
+                            key_4 = Some(tmp_key_4);
+                            key_4_encoding = tmp_key_4_encoding;
+                            key_4_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        },
+                        (5, key_enc) =>  {
+                            if key_5.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_key_5, tmp_key_5_encoding, tmp_key_5_value_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_5_table = OrderedHashMap::new();
+                                let key_5_len = raw.map_sz()?;
+                                let key_5_encoding = key_5_len.into();
+                                let mut key_5_value_encodings = BTreeMap::new();
+                                while match key_5_len { cbor_event::LenSz::Len(n, _) => key_5_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    let key_5_key = RewardAccount::deserialize(raw)?;
+                                    let (key_5_value, key_5_value_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                                    if key_5_table.insert(key_5_key.clone(), key_5_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    key_5_value_encodings.insert(key_5_key.clone(), key_5_value_encoding);
+                                }
+                                Ok((key_5_table, key_5_encoding, key_5_value_encodings))
+                            })().map_err(|e| e.annotate("key_5"))?;
+                            key_5 = Some(tmp_key_5);
+                            key_5_encoding = tmp_key_5_encoding;
+                            key_5_value_encodings = tmp_key_5_value_encodings;
+                            key_5_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        },
+                        (6, key_enc) =>  {
+                            if key_6.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let tmp_key_6 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(Update::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_6"))?;
+                            key_6 = Some(tmp_key_6);
+                            key_6_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        },
+                        (7, key_enc) =>  {
+                            if key_7.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let tmp_key_7 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(Hash32::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_7"))?;
+                            key_7 = Some(tmp_key_7);
+                            key_7_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        },
+                        (8, key_enc) =>  {
+                            if key_8.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(8)).into());
+                            }
+                            let (tmp_key_8, tmp_key_8_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_8"))?;
+                            key_8 = Some(tmp_key_8);
+                            key_8_encoding = tmp_key_8_encoding;
+                            key_8_key_encoding = Some(key_enc);
+                            orig_deser_order.push(8);
+                        },
+                        (9, key_enc) =>  {
+                            if key_9.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(9)).into());
+                            }
+                            let (tmp_key_9, tmp_key_9_encoding, tmp_key_9_value_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_9_table = OrderedHashMap::new();
+                                let key_9_len = raw.map_sz()?;
+                                let key_9_encoding = key_9_len.into();
+                                let mut key_9_value_encodings = BTreeMap::new();
+                                while match key_9_len { cbor_event::LenSz::Len(n, _) => key_9_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    let key_9_key = Hash28::deserialize(raw)?;
+                                    let mut key_9_value_table = OrderedHashMap::new();
+                                    let key_9_value_len = raw.map_sz()?;
+                                    let key_9_value_encoding = key_9_value_len.into();
+                                    let mut key_9_value_value_encodings = BTreeMap::new();
+                                    while match key_9_value_len { cbor_event::LenSz::Len(n, _) => key_9_value_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                        if raw.cbor_type()? == CBORType::Special {
+                                            assert_eq!(raw.special()?, CBORSpecial::Break);
+                                            break;
+                                        }
+                                        let key_9_value_key = AssetName::deserialize(raw)?;
+                                        let (key_9_value_value, key_9_value_value_encoding) = match raw.cbor_type()? {
+                                            cbor_event::Type::UnsignedInteger => {
+                                                let (x, enc) = raw.unsigned_integer_sz()?;
+                                                (x as i64, Some(enc))
+                                            },
+                                            _ => {
+                                                let (x, enc) = raw.negative_integer_sz()?;
+                                                (x as i64, Some(enc))
+                                            },
+                                        };
+                                        if key_9_value_table.insert(key_9_value_key.clone(), key_9_value_value).is_some() {
+                                            return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                        }
+                                        key_9_value_value_encodings.insert(key_9_value_key.clone(), key_9_value_value_encoding);
+                                    }
+                                    let (key_9_value, key_9_value_encoding, key_9_value_value_encodings) = (key_9_value_table, key_9_value_encoding, key_9_value_value_encodings);
+                                    if key_9_table.insert(key_9_key.clone(), key_9_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    key_9_value_encodings.insert(key_9_key.clone(), (key_9_value_encoding, key_9_value_value_encodings));
+                                }
+                                Ok((key_9_table, key_9_encoding, key_9_value_encodings))
+                            })().map_err(|e| e.annotate("key_9"))?;
+                            key_9 = Some(tmp_key_9);
+                            key_9_encoding = tmp_key_9_encoding;
+                            key_9_value_encodings = tmp_key_9_value_encodings;
+                            key_9_key_encoding = Some(key_enc);
+                            orig_deser_order.push(9);
+                        },
+                        (11, key_enc) =>  {
+                            if key_11.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(11)).into());
+                            }
+                            let tmp_key_11 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(Hash32::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_11"))?;
+                            key_11 = Some(tmp_key_11);
+                            key_11_key_encoding = Some(key_enc);
+                            orig_deser_order.push(10);
+                        },
+                        (13, key_enc) =>  {
+                            if key_13.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(13)).into());
+                            }
+                            let (tmp_key_13, tmp_key_13_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_13_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_13_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_13_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_13_arr.push(TransactionInput::deserialize(raw)?);
+                                }
+                                Ok((key_13_arr, key_13_encoding))
+                            })().map_err(|e| e.annotate("key_13"))?;
+                            key_13 = Some(tmp_key_13);
+                            key_13_encoding = tmp_key_13_encoding;
+                            key_13_key_encoding = Some(key_enc);
+                            orig_deser_order.push(11);
+                        },
+                        (14, key_enc) =>  {
+                            if key_14.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(14)).into());
+                            }
+                            let tmp_key_14 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(RequiredSigners::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_14"))?;
+                            key_14 = Some(tmp_key_14);
+                            key_14_key_encoding = Some(key_enc);
+                            orig_deser_order.push(12);
+                        },
+                        (15, key_enc) =>  {
+                            if key_15.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(15)).into());
+                            }
+                            let tmp_key_15 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(NetworkId::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_15"))?;
+                            key_15 = Some(tmp_key_15);
+                            key_15_key_encoding = Some(key_enc);
+                            orig_deser_order.push(13);
+                        },
+                        (16, key_enc) =>  {
+                            if key_16.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(16)).into());
+                            }
+                            let tmp_key_16 = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(TransactionOutput::deserialize(raw)?)
+                            })().map_err(|e| e.annotate("key_16"))?;
+                            key_16 = Some(tmp_key_16);
+                            key_16_key_encoding = Some(key_enc);
+                            orig_deser_order.push(14);
+                        },
+                        (17, key_enc) =>  {
+                            if key_17.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(17)).into());
+                            }
+                            let (tmp_key_17, tmp_key_17_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+                            })().map_err(|e| e.annotate("key_17"))?;
+                            key_17 = Some(tmp_key_17);
+                            key_17_encoding = tmp_key_17_encoding;
+                            key_17_key_encoding = Some(key_enc);
+                            orig_deser_order.push(15);
+                        },
+                        (18, key_enc) =>  {
+                            if key_18.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(18)).into());
+                            }
+                            let (tmp_key_18, tmp_key_18_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_18_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_18_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_18_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_18_arr.push(TransactionInput::deserialize(raw)?);
+                                }
+                                Ok((key_18_arr, key_18_encoding))
+                            })().map_err(|e| e.annotate("key_18"))?;
+                            key_18 = Some(tmp_key_18);
+                            key_18_encoding = tmp_key_18_encoding;
+                            key_18_key_encoding = Some(key_enc);
+                            orig_deser_order.push(16);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    CBORType::Text => {
+                        let (text_key, key_enc) = raw.text_sz()?;
+                        match text_key.as_str() {
+                            unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Str(unknown_key.to_owned())).into()),
+                        }
+                    },
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            let key_0 = match key_0 {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(0)).into()),
+            };
+            let key_1 = match key_1 {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(1)).into()),
+            };
+            let key_2 = match key_2 {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(2)).into()),
+            };
+            read_len.finish()?;
+            Ok(Self {
+                key_0,
+                key_1,
+                key_2,
+                key_3,
+                key_4,
+                key_5,
+                key_6,
+                key_7,
+                key_8,
+                key_9,
+                key_11,
+                key_13,
+                key_14,
+                key_15,
+                key_16,
+                key_17,
+                key_18,
+                encodings: Some(TransactionBodyEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    key_0_key_encoding,
+                    key_0_encoding,
+                    key_1_key_encoding,
+                    key_1_encoding,
+                    key_2_key_encoding,
+                    key_2_encoding,
+                    key_3_key_encoding,
+                    key_3_encoding,
+                    key_4_key_encoding,
+                    key_4_encoding,
+                    key_5_key_encoding,
+                    key_5_encoding,
+                    key_5_value_encodings,
+                    key_6_key_encoding,
+                    key_7_key_encoding,
+                    key_8_key_encoding,
+                    key_8_encoding,
+                    key_9_key_encoding,
+                    key_9_encoding,
+                    key_9_value_encodings,
+                    key_11_key_encoding,
+                    key_13_key_encoding,
+                    key_13_encoding,
+                    key_14_key_encoding,
+                    key_15_key_encoding,
+                    key_16_key_encoding,
+                    key_17_key_encoding,
+                    key_17_encoding,
+                    key_18_key_encoding,
+                    key_18_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("TransactionBody"))
+    }
+}
+
+impl Serialize for TransactionInput {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.transaction_id.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.index, fit_sz(self.index, self.encodings.as_ref().map(|encs| encs.index_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for TransactionInput {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let transaction_id = (|| -> Result<_, DeserializeError> {
+                Ok(Hash32::deserialize(raw)?)
+            })().map_err(|e| e.annotate("transaction_id"))?;
+            let (index, index_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("index"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(TransactionInput {
+                transaction_id,
+                index,
+                encodings: Some(TransactionInputEncoding {
+                    len_encoding,
+                    index_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("TransactionInput"))
+    }
+}
+
+impl Serialize for TransactionMetadatum {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            TransactionMetadatum::MapTransactionMetadatumToTransactionMetadatum{ map_transaction_metadatum_to_transaction_metadatum, map_transaction_metadatum_to_transaction_metadatum_encoding } => {
+                serializer.write_map_sz(map_transaction_metadatum_to_transaction_metadatum_encoding.to_len_sz(map_transaction_metadatum_to_transaction_metadatum.len() as u64, force_canonical))?;
+                let mut key_order = map_transaction_metadatum_to_transaction_metadatum.iter().map(|(k, v)| {
+                    let mut buf = cbor_event::se::Serializer::new_vec();
+                    k.serialize(&mut buf, force_canonical)?;
+                    Ok((buf.finalize(), k, v))
+                }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                if force_canonical {
+                    key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                        match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                            std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                            diff_ord => diff_ord,
+                        }
+                    });
+                }
+                for (key_bytes, key, value) in key_order {
+                    serializer.write_raw_bytes(&key_bytes)?;
+                    value.serialize(serializer, force_canonical)?;
+                }
+                map_transaction_metadatum_to_transaction_metadatum_encoding.end(serializer, force_canonical)
+            },
+            TransactionMetadatum::ArrTransactionMetadatum{ arr_transaction_metadatum, arr_transaction_metadatum_encoding } => {
+                serializer.write_array_sz(arr_transaction_metadatum_encoding.to_len_sz(arr_transaction_metadatum.len() as u64, force_canonical))?;
+                for element in arr_transaction_metadatum.iter() {
+                    element.serialize(serializer, force_canonical)?;
+                }
+                arr_transaction_metadatum_encoding.end(serializer, force_canonical)
+            },
+            TransactionMetadatum::Int(int) => {
+                int.serialize(serializer, force_canonical)
+            },
+            TransactionMetadatum::Bytes{ bytes, bytes_encoding } => {
+                serializer.write_bytes_sz(&bytes, bytes_encoding.to_str_len_sz(bytes.len() as u64, force_canonical))
+            },
+            TransactionMetadatum::Text{ text, text_encoding } => {
+                serializer.write_text_sz(&text, text_encoding.to_str_len_sz(text.len() as u64, force_canonical))
+            },
+        }
+    }
+}
+
+impl Deserialize for TransactionMetadatum {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut map_transaction_metadatum_to_transaction_metadatum_table = OrderedHashMap::new();
+                let map_transaction_metadatum_to_transaction_metadatum_len = raw.map_sz()?;
+                let map_transaction_metadatum_to_transaction_metadatum_encoding = map_transaction_metadatum_to_transaction_metadatum_len.into();
+                while match map_transaction_metadatum_to_transaction_metadatum_len { cbor_event::LenSz::Len(n, _) => map_transaction_metadatum_to_transaction_metadatum_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let map_transaction_metadatum_to_transaction_metadatum_key = TransactionMetadatum::deserialize(raw)?;
+                    let map_transaction_metadatum_to_transaction_metadatum_value = TransactionMetadatum::deserialize(raw)?;
+                    if map_transaction_metadatum_to_transaction_metadatum_table.insert(map_transaction_metadatum_to_transaction_metadatum_key.clone(), map_transaction_metadatum_to_transaction_metadatum_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                }
+                Ok((map_transaction_metadatum_to_transaction_metadatum_table, map_transaction_metadatum_to_transaction_metadatum_encoding))
+            })(raw)
+            {
+                Ok((map_transaction_metadatum_to_transaction_metadatum, map_transaction_metadatum_to_transaction_metadatum_encoding)) => return Ok(Self::MapTransactionMetadatumToTransactionMetadatum {
+                    map_transaction_metadatum_to_transaction_metadatum,
+                    map_transaction_metadatum_to_transaction_metadatum_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut arr_transaction_metadatum_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let arr_transaction_metadatum_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => arr_transaction_metadatum_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    arr_transaction_metadatum_arr.push(TransactionMetadatum::deserialize(raw)?);
+                }
+                Ok((arr_transaction_metadatum_arr, arr_transaction_metadatum_encoding))
+            })(raw)
+            {
+                Ok((arr_transaction_metadatum, arr_transaction_metadatum_encoding)) => return Ok(Self::ArrTransactionMetadatum {
+                    arr_transaction_metadatum,
+                    arr_transaction_metadatum_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(Int::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(int) => return Ok(Self::Int(int)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+            })(raw)
+            {
+                Ok((bytes, bytes_encoding)) => return Ok(Self::Bytes {
+                    bytes,
+                    bytes_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(raw.text_sz().map(|(s, enc)| (s, StringEncoding::from(enc)))?)
+            })(raw)
+            {
+                Ok((text, text_encoding)) => return Ok(Self::Text {
+                    text,
+                    text_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("TransactionMetadatum", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("TransactionMetadatum"))
+    }
+}
+
+impl Serialize for TransactionOutput {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            TransactionOutput::ShelleyTxOut(shelley_tx_out) => {
+                shelley_tx_out.serialize(serializer, force_canonical)
+            },
+            TransactionOutput::AlonzoTxOut(alonzo_tx_out) => {
+                alonzo_tx_out.serialize(serializer, force_canonical)
+            },
+            TransactionOutput::BabbageTxOut(babbage_tx_out) => {
+                babbage_tx_out.serialize(serializer, force_canonical)
+            },
+        }
+    }
+}
+
+impl Deserialize for TransactionOutput {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(ShelleyTxOut::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(shelley_tx_out) => return Ok(Self::ShelleyTxOut(shelley_tx_out)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(AlonzoTxOut::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(alonzo_tx_out) => return Ok(Self::AlonzoTxOut(alonzo_tx_out)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                Ok(BabbageTxOut::deserialize(raw)?)
+            })(raw)
+            {
+                Ok(babbage_tx_out) => return Ok(Self::BabbageTxOut(babbage_tx_out)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("TransactionOutput", DeserializeFailure::NoVariantMatched.into()))
+        })().map_err(|e| e.annotate("TransactionOutput"))
+    }
+}
+
+impl Serialize for TransactionWitnessSet {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 } + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 } + match &self.key_4 { Some(_) => 1, None => 0 } + match &self.key_5 { Some(_) => 1, None => 0 } + match &self.key_6 { Some(_) => 1, None => 0 }, force_canonical))?;
+        let deser_order = self.encodings.as_ref().filter(|encs| !force_canonical && encs.orig_deser_order.len() == match &self.key_0 { Some(_) => 1, None => 0 } + match &self.key_1 { Some(_) => 1, None => 0 } + match &self.key_2 { Some(_) => 1, None => 0 } + match &self.key_3 { Some(_) => 1, None => 0 } + match &self.key_4 { Some(_) => 1, None => 0 } + match &self.key_5 { Some(_) => 1, None => 0 } + match &self.key_6 { Some(_) => 1, None => 0 }).map(|encs| encs.orig_deser_order.clone()).unwrap_or_else(|| vec![0,1,2,3,4,5,6]);
+        for field_index in deser_order {
+            match field_index {
+                0 => if let Some(field) = &self.key_0 {
+                    serializer.write_unsigned_integer_sz(0u64, fit_sz(0u64, self.encodings.as_ref().map(|encs| encs.key_0_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_0_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                1 => if let Some(field) = &self.key_1 {
+                    serializer.write_unsigned_integer_sz(1u64, fit_sz(1u64, self.encodings.as_ref().map(|encs| encs.key_1_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_1_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                2 => if let Some(field) = &self.key_2 {
+                    serializer.write_unsigned_integer_sz(2u64, fit_sz(2u64, self.encodings.as_ref().map(|encs| encs.key_2_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_2_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_2_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                3 => if let Some(field) = &self.key_3 {
+                    serializer.write_unsigned_integer_sz(3u64, fit_sz(3u64, self.encodings.as_ref().map(|encs| encs.key_3_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_3_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for (i, element) in field.iter().enumerate() {
+                        let key_3_elem_encoding = self.encodings.as_ref().and_then(|encs| encs.key_3_elem_encodings.get(i)).map(|e| e.clone()).unwrap_or_else(|| StringEncoding::default());
+                        serializer.write_bytes_sz(&element, key_3_elem_encoding.to_str_len_sz(element.len() as u64, force_canonical))?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_3_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                4 => if let Some(field) = &self.key_4 {
+                    serializer.write_unsigned_integer_sz(4u64, fit_sz(4u64, self.encodings.as_ref().map(|encs| encs.key_4_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_4_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_4_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                5 => if let Some(field) = &self.key_5 {
+                    serializer.write_unsigned_integer_sz(5u64, fit_sz(5u64, self.encodings.as_ref().map(|encs| encs.key_5_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_5_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for element in field.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_5_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                6 => if let Some(field) = &self.key_6 {
+                    serializer.write_unsigned_integer_sz(6u64, fit_sz(6u64, self.encodings.as_ref().map(|encs| encs.key_6_key_encoding.clone()).unwrap_or_default(), force_canonical))?;
+                    serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.key_6_encoding.clone()).unwrap_or_default().to_len_sz(field.len() as u64, force_canonical))?;
+                    for (i, element) in field.iter().enumerate() {
+                        let key_6_elem_encoding = self.encodings.as_ref().and_then(|encs| encs.key_6_elem_encodings.get(i)).map(|e| e.clone()).unwrap_or_else(|| StringEncoding::default());
+                        serializer.write_bytes_sz(&element, key_6_elem_encoding.to_str_len_sz(element.len() as u64, force_canonical))?;
+                    }
+                    self.encodings.as_ref().map(|encs| encs.key_6_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+                }
+                _ => unreachable!()
+            };
+        }
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for TransactionWitnessSet {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            let mut orig_deser_order = Vec::new();
+            let mut key_0_encoding = LenEncoding::default();
+            let mut key_0_key_encoding = None;
+            let mut key_0 = None;
+            let mut key_1_encoding = LenEncoding::default();
+            let mut key_1_key_encoding = None;
+            let mut key_1 = None;
+            let mut key_2_encoding = LenEncoding::default();
+            let mut key_2_key_encoding = None;
+            let mut key_2 = None;
+            let mut key_3_encoding = LenEncoding::default();
+            let mut key_3_elem_encodings = Vec::new();
+            let mut key_3_key_encoding = None;
+            let mut key_3 = None;
+            let mut key_4_encoding = LenEncoding::default();
+            let mut key_4_key_encoding = None;
+            let mut key_4 = None;
+            let mut key_5_encoding = LenEncoding::default();
+            let mut key_5_key_encoding = None;
+            let mut key_5 = None;
+            let mut key_6_encoding = LenEncoding::default();
+            let mut key_6_elem_encodings = Vec::new();
+            let mut key_6_key_encoding = None;
+            let mut key_6 = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if key_0.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_key_0, tmp_key_0_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_0_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_0_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_0_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_0_arr.push(Vkeywitness::deserialize(raw)?);
+                                }
+                                Ok((key_0_arr, key_0_encoding))
+                            })().map_err(|e| e.annotate("key_0"))?;
+                            key_0 = Some(tmp_key_0);
+                            key_0_encoding = tmp_key_0_encoding;
+                            key_0_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if key_1.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_key_1, tmp_key_1_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_1_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_1_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_1_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_1_arr.push(NativeScript::deserialize(raw)?);
+                                }
+                                Ok((key_1_arr, key_1_encoding))
+                            })().map_err(|e| e.annotate("key_1"))?;
+                            key_1 = Some(tmp_key_1);
+                            key_1_encoding = tmp_key_1_encoding;
+                            key_1_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if key_2.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_key_2, tmp_key_2_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_2_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_2_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_2_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_2_arr.push(BootstrapWitness::deserialize(raw)?);
+                                }
+                                Ok((key_2_arr, key_2_encoding))
+                            })().map_err(|e| e.annotate("key_2"))?;
+                            key_2 = Some(tmp_key_2);
+                            key_2_encoding = tmp_key_2_encoding;
+                            key_2_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if key_3.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_key_3, tmp_key_3_encoding, tmp_key_3_elem_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_3_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_3_encoding = len.into();
+                                let mut key_3_elem_encodings = Vec::new();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_3_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    let (key_3_elem, key_3_elem_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+                                    key_3_arr.push(key_3_elem);
+                                    key_3_elem_encodings.push(key_3_elem_encoding);
+                                }
+                                Ok((key_3_arr, key_3_encoding, key_3_elem_encodings))
+                            })().map_err(|e| e.annotate("key_3"))?;
+                            key_3 = Some(tmp_key_3);
+                            key_3_encoding = tmp_key_3_encoding;
+                            key_3_elem_encodings = tmp_key_3_elem_encodings;
+                            key_3_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (4, key_enc) =>  {
+                            if key_4.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_key_4, tmp_key_4_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_4_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_4_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_4_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_4_arr.push(PlutusData::deserialize(raw)?);
+                                }
+                                Ok((key_4_arr, key_4_encoding))
+                            })().map_err(|e| e.annotate("key_4"))?;
+                            key_4 = Some(tmp_key_4);
+                            key_4_encoding = tmp_key_4_encoding;
+                            key_4_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        },
+                        (5, key_enc) =>  {
+                            if key_5.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_key_5, tmp_key_5_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_5_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_5_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_5_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    key_5_arr.push(Redeemer::deserialize(raw)?);
+                                }
+                                Ok((key_5_arr, key_5_encoding))
+                            })().map_err(|e| e.annotate("key_5"))?;
+                            key_5 = Some(tmp_key_5);
+                            key_5_encoding = tmp_key_5_encoding;
+                            key_5_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        },
+                        (6, key_enc) =>  {
+                            if key_6.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let (tmp_key_6, tmp_key_6_encoding, tmp_key_6_elem_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut key_6_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let key_6_encoding = len.into();
+                                let mut key_6_elem_encodings = Vec::new();
+                                while match len { cbor_event::LenSz::Len(n, _) => key_6_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == CBORType::Special {
+                                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                                        break;
+                                    }
+                                    let (key_6_elem, key_6_elem_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+                                    key_6_arr.push(key_6_elem);
+                                    key_6_elem_encodings.push(key_6_elem_encoding);
+                                }
+                                Ok((key_6_arr, key_6_encoding, key_6_elem_encodings))
+                            })().map_err(|e| e.annotate("key_6"))?;
+                            key_6 = Some(tmp_key_6);
+                            key_6_encoding = tmp_key_6_encoding;
+                            key_6_elem_encodings = tmp_key_6_elem_encodings;
+                            key_6_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    CBORType::Text => {
+                        let (text_key, key_enc) = raw.text_sz()?;
+                        match text_key.as_str() {
+                            unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Str(unknown_key.to_owned())).into()),
+                        }
+                    },
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                key_0,
+                key_1,
+                key_2,
+                key_3,
+                key_4,
+                key_5,
+                key_6,
+                encodings: Some(TransactionWitnessSetEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    key_0_key_encoding,
+                    key_0_encoding,
+                    key_1_key_encoding,
+                    key_1_encoding,
+                    key_2_key_encoding,
+                    key_2_encoding,
+                    key_3_key_encoding,
+                    key_3_encoding,
+                    key_3_elem_encodings,
+                    key_4_key_encoding,
+                    key_4_encoding,
+                    key_5_key_encoding,
+                    key_5_encoding,
+                    key_6_key_encoding,
+                    key_6_encoding,
+                    key_6_elem_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("TransactionWitnessSet"))
+    }
+}
+
+impl Serialize for UnitInterval {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_tag_sz(30u64, fit_sz(30u64, self.encodings.as_ref().map(|encs| encs.tag_encoding).unwrap_or_default(), force_canonical))?;
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.index_0, fit_sz(self.index_0, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.index_1, fit_sz(self.index_1, self.encodings.as_ref().map(|encs| encs.index_1_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for UnitInterval {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let (tag, tag_encoding) = raw.tag_sz()?;
+            if tag != 30 {
+                return Err(DeserializeError::new("UnitInterval", DeserializeFailure::TagMismatch{ found: tag, expected: 30 }));
+            }
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (index_0, index_0_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("index_0"))?;
+            let (index_1, index_1_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("index_1"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(UnitInterval {
+                index_0,
+                index_1,
+                encodings: Some(UnitIntervalEncoding {
+                    len_encoding,
+                    tag_encoding: Some(tag_encoding),
+                    index_0_encoding,
+                    index_1_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("UnitInterval"))
+    }
+}
+
+impl Serialize for Update {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.proposed_protocol_parameter_updates_encoding.clone()).unwrap_or_default().to_len_sz(self.proposed_protocol_parameter_updates.len() as u64, force_canonical))?;
+        let mut key_order = self.proposed_protocol_parameter_updates.iter().map(|(k, v)| {
+            let mut buf = cbor_event::se::Serializer::new_vec();
+            k.serialize(&mut buf, force_canonical)?;
+            Ok((buf.finalize(), k, v))
+        }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.proposed_protocol_parameter_updates_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(self.epoch, fit_sz(self.epoch, self.encodings.as_ref().map(|encs| encs.epoch_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Update {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (proposed_protocol_parameter_updates, proposed_protocol_parameter_updates_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut proposed_protocol_parameter_updates_table = OrderedHashMap::new();
+                let proposed_protocol_parameter_updates_len = raw.map_sz()?;
+                let proposed_protocol_parameter_updates_encoding = proposed_protocol_parameter_updates_len.into();
+                while match proposed_protocol_parameter_updates_len { cbor_event::LenSz::Len(n, _) => proposed_protocol_parameter_updates_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let proposed_protocol_parameter_updates_key = Hash28::deserialize(raw)?;
+                    let proposed_protocol_parameter_updates_value = ProtocolParamUpdate::deserialize(raw)?;
+                    if proposed_protocol_parameter_updates_table.insert(proposed_protocol_parameter_updates_key.clone(), proposed_protocol_parameter_updates_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                }
+                Ok((proposed_protocol_parameter_updates_table, proposed_protocol_parameter_updates_encoding))
+            })().map_err(|e| e.annotate("proposed_protocol_parameter_updates"))?;
+            let (epoch, epoch_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("epoch"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Update {
+                proposed_protocol_parameter_updates,
+                epoch,
+                encodings: Some(UpdateEncoding {
+                    len_encoding,
+                    proposed_protocol_parameter_updates_encoding,
+                    epoch_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Update"))
+    }
+}
+
+impl Serialize for Url {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_text_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for Url {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.text_sz().map(|(s, enc)| (s, StringEncoding::from(enc)))?;
+        if inner.len() > 64 {
+            return Err(DeserializeError::new("Url", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(0), max: Some(64) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(UrlEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Value {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_unsigned_integer_sz(self.coin, fit_sz(self.coin, self.encodings.as_ref().map(|encs| encs.coin_encoding.clone()).unwrap_or_default(), force_canonical))?;
+        serializer.write_map_sz(self.encodings.as_ref().map(|encs| encs.multiasset_encoding.clone()).unwrap_or_default().to_len_sz(self.multiasset.len() as u64, force_canonical))?;
+        let mut key_order = self.multiasset.iter().map(|(k, v)| {
+            let mut buf = cbor_event::se::Serializer::new_vec();
+            k.serialize(&mut buf, force_canonical)?;
+            Ok((buf.finalize(), k, v))
+        }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            let (multiasset_value_encoding, multiasset_value_value_encodings) = self.encodings.as_ref().and_then(|encs| encs.multiasset_value_encodings.get(key)).map(|e| e.clone()).unwrap_or_else(|| (LenEncoding::default(), BTreeMap::new()));
+            serializer.write_map_sz(multiasset_value_encoding.to_len_sz(value.len() as u64, force_canonical))?;
+            let mut key_order = value.iter().map(|(k, v)| {
+                let mut buf = cbor_event::se::Serializer::new_vec();
+                k.serialize(&mut buf, force_canonical)?;
+                Ok((buf.finalize(), k, v))
+            }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+            if force_canonical {
+                key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                    match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                        std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
+                        diff_ord => diff_ord,
+                    }
+                });
+            }
+            for (key_bytes, key, value) in key_order {
+                serializer.write_raw_bytes(&key_bytes)?;
+                let multiasset_value_value_encoding = multiasset_value_value_encodings.get(key).map(|e| e.clone()).unwrap_or_else(|| None);
+                serializer.write_unsigned_integer_sz(*value, fit_sz(*value, multiasset_value_value_encoding, force_canonical))?;
+            }
+            multiasset_value_encoding.end(serializer, force_canonical)?;
+        }
+        self.encodings.as_ref().map(|encs| encs.multiasset_encoding.clone()).unwrap_or_default().end(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Value {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (coin, coin_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?)
+            })().map_err(|e| e.annotate("coin"))?;
+            let (multiasset, multiasset_encoding, multiasset_value_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut multiasset_table = OrderedHashMap::new();
+                let multiasset_len = raw.map_sz()?;
+                let multiasset_encoding = multiasset_len.into();
+                let mut multiasset_value_encodings = BTreeMap::new();
+                while match multiasset_len { cbor_event::LenSz::Len(n, _) => multiasset_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == CBORType::Special {
+                        assert_eq!(raw.special()?, CBORSpecial::Break);
+                        break;
+                    }
+                    let multiasset_key = Hash28::deserialize(raw)?;
+                    let mut multiasset_value_table = OrderedHashMap::new();
+                    let multiasset_value_len = raw.map_sz()?;
+                    let multiasset_value_encoding = multiasset_value_len.into();
+                    let mut multiasset_value_value_encodings = BTreeMap::new();
+                    while match multiasset_value_len { cbor_event::LenSz::Len(n, _) => multiasset_value_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
+                        if raw.cbor_type()? == CBORType::Special {
+                            assert_eq!(raw.special()?, CBORSpecial::Break);
+                            break;
+                        }
+                        let multiasset_value_key = AssetName::deserialize(raw)?;
+                        let (multiasset_value_value, multiasset_value_value_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                        if multiasset_value_table.insert(multiasset_value_key.clone(), multiasset_value_value).is_some() {
+                            return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                        }
+                        multiasset_value_value_encodings.insert(multiasset_value_key.clone(), multiasset_value_value_encoding);
+                    }
+                    let (multiasset_value, multiasset_value_encoding, multiasset_value_value_encodings) = (multiasset_value_table, multiasset_value_encoding, multiasset_value_value_encodings);
+                    if multiasset_table.insert(multiasset_key.clone(), multiasset_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                    multiasset_value_encodings.insert(multiasset_key.clone(), (multiasset_value_encoding, multiasset_value_value_encodings));
+                }
+                Ok((multiasset_table, multiasset_encoding, multiasset_value_encodings))
+            })().map_err(|e| e.annotate("multiasset"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Value {
+                coin,
+                multiasset,
+                encodings: Some(ValueEncoding {
+                    len_encoding,
+                    coin_encoding,
+                    multiasset_encoding,
+                    multiasset_value_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("Value"))
+    }
+}
+
+impl Serialize for Vkey {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for Vkey {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 8 {
+            return Err(DeserializeError::new("Vkey", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(8), max: Some(8) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(VkeyEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}
+
+impl Serialize for Vkeywitness {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        self.vkey.serialize(serializer, force_canonical)?;
+        self.signature.serialize(serializer, force_canonical)?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for Vkeywitness {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let vkey = (|| -> Result<_, DeserializeError> {
+                Ok(Vkey::deserialize(raw)?)
+            })().map_err(|e| e.annotate("vkey"))?;
+            let signature = (|| -> Result<_, DeserializeError> {
+                Ok(Signature::deserialize(raw)?)
+            })().map_err(|e| e.annotate("signature"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(Vkeywitness {
+                vkey,
+                signature,
+                encodings: Some(VkeywitnessEncoding {
+                    len_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("Vkeywitness"))
+    }
+}
+
+impl Serialize for VrfCert {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().to_len_sz(2, force_canonical))?;
+        serializer.write_bytes_sz(&self.index_0, self.encodings.as_ref().map(|encs| encs.index_0_encoding.clone()).unwrap_or_default().to_str_len_sz(self.index_0.len() as u64, force_canonical))?;
+        serializer.write_bytes_sz(&self.bytes, self.encodings.as_ref().map(|encs| encs.bytes_encoding.clone()).unwrap_or_default().to_str_len_sz(self.bytes.len() as u64, force_canonical))?;
+        self.encodings.as_ref().map(|encs| encs.len_encoding).unwrap_or_default().end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for VrfCert {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let len_encoding: LenEncoding = len.into();
+            let mut read_len = CBORReadLen::new(len);
+            read_len.read_elems(2)?;
+            let (index_0, index_0_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+            })().map_err(|e| e.annotate("index_0"))?;
+            let (bytes, bytes_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
+            })().map_err(|e| e.annotate("bytes"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(VrfCert {
+                index_0,
+                bytes,
+                encodings: Some(VrfCertEncoding {
+                    len_encoding,
+                    index_0_encoding,
+                    bytes_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("VrfCert"))
+    }
+}
+
+impl Serialize for VrfVkey {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes_sz(&self.inner, self.encodings.as_ref().map(|encs| encs.inner_encoding.clone()).unwrap_or_default().to_str_len_sz(self.inner.len() as u64, force_canonical))
+    }
+}
+
+impl Deserialize for VrfVkey {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (inner, inner_encoding) = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?;
+        if inner.len() != 8 {
+            return Err(DeserializeError::new("VrfVkey", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(8), max: Some(8) }));
+        }
+        Ok(Self {
+            inner,
+            encodings: Some(VrfVkeyEncoding {
+                inner_encoding,
+            }),
+        })
+    }
+}

--- a/rust/core/src/transaction.rs
+++ b/rust/core/src/transaction.rs
@@ -1,0 +1,385 @@
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoTxOut {
+    pub address: Address,
+    pub amount: Value,
+    pub datum_hash: Hash32,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoTxOutEncoding>,
+}
+
+impl AlonzoTxOut {
+    pub fn new(address: Address, amount: Value, datum_hash: Hash32) -> Self {
+        Self {
+            address,
+            amount,
+            datum_hash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct BabbageTxOut {
+    pub key_0: Address,
+    pub key_1: Value,
+    pub key_2: Option<DatumOption>,
+    pub key_3: Option<ScriptRef>,
+    #[serde(skip)]
+    pub encodings: Option<BabbageTxOutEncoding>,
+}
+
+impl BabbageTxOut {
+    pub fn new(key_0: Address, key_1: Value) -> Self {
+        Self {
+            key_0,
+            key_1,
+            key_2: None,
+            key_3: None,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum DatumOption {
+    DatumOption0(DatumOption0),
+    DatumOption1(DatumOption1),
+}
+
+impl DatumOption {
+    pub fn new_datum_option0(hash32: Hash32) -> Self {
+        Self::DatumOption0(DatumOption0::new(hash32))
+    }
+
+    pub fn new_datum_option1(data: Data) -> Self {
+        Self::DatumOption1(DatumOption1::new(data))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct InvalidBefore {
+    pub index_1: u64,
+    #[serde(skip)]
+    pub encodings: Option<InvalidBeforeEncoding>,
+}
+
+impl InvalidBefore {
+    pub fn new(index_1: u64) -> Self {
+        Self {
+            index_1,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct InvalidHereafter {
+    pub index_1: u64,
+    #[serde(skip)]
+    pub encodings: Option<InvalidHereafterEncoding>,
+}
+
+impl InvalidHereafter {
+    pub fn new(index_1: u64) -> Self {
+        Self {
+            index_1,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum NativeScript {
+    ScriptPubkey(ScriptPubkey),
+    ScriptAll(ScriptAll),
+    ScriptAny(ScriptAny),
+    ScriptNOfK(ScriptNOfK),
+    InvalidBefore(InvalidBefore),
+    InvalidHereafter(InvalidHereafter),
+}
+
+impl NativeScript {
+    pub fn new_script_pubkey(addr_keyhash: AddrKeyhash) -> Self {
+        Self::ScriptPubkey(ScriptPubkey::new(addr_keyhash))
+    }
+
+    pub fn new_script_all(native_scripts: Vec<NativeScript>) -> Self {
+        Self::ScriptAll(ScriptAll::new(native_scripts))
+    }
+
+    pub fn new_script_any(native_scripts: Vec<NativeScript>) -> Self {
+        Self::ScriptAny(ScriptAny::new(native_scripts))
+    }
+
+    pub fn new_script_n_of_k(n: u64, native_scripts: Vec<NativeScript>) -> Self {
+        Self::ScriptNOfK(ScriptNOfK::new(n, native_scripts))
+    }
+
+    pub fn new_invalid_before(index_1: u64) -> Self {
+        Self::InvalidBefore(InvalidBefore::new(index_1))
+    }
+
+    pub fn new_invalid_hereafter(index_1: u64) -> Self {
+        Self::InvalidHereafter(InvalidHereafter::new(index_1))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct RequiredSigners {
+    pub addr_keyhash: AddrKeyhash,
+    #[serde(skip)]
+    pub encodings: Option<RequiredSignersEncoding>,
+}
+
+impl RequiredSigners {
+    pub fn new(addr_keyhash: AddrKeyhash) -> Self {
+        Self {
+            addr_keyhash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum Script {
+    Script0(Script0),
+    Script1(Script1),
+    Script2(Script2),
+}
+
+impl Script {
+    pub fn new_script0(native_script: NativeScript) -> Self {
+        Self::Script0(Script0::new(native_script))
+    }
+
+    pub fn new_script1(plutus_v1_script: PlutusV1Script) -> Self {
+        Self::Script1(Script1::new(plutus_v1_script))
+    }
+
+    pub fn new_script2(plutus_v2_script: PlutusV2Script) -> Self {
+        Self::Script2(Script2::new(plutus_v2_script))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ScriptAll {
+    pub native_scripts: Vec<NativeScript>,
+    #[serde(skip)]
+    pub encodings: Option<ScriptAllEncoding>,
+}
+
+impl ScriptAll {
+    pub fn new(native_scripts: Vec<NativeScript>) -> Self {
+        Self {
+            native_scripts,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ScriptAny {
+    pub native_scripts: Vec<NativeScript>,
+    #[serde(skip)]
+    pub encodings: Option<ScriptAnyEncoding>,
+}
+
+impl ScriptAny {
+    pub fn new(native_scripts: Vec<NativeScript>) -> Self {
+        Self {
+            native_scripts,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ScriptNOfK {
+    pub n: u64,
+    pub native_scripts: Vec<NativeScript>,
+    #[serde(skip)]
+    pub encodings: Option<ScriptNOfKEncoding>,
+}
+
+impl ScriptNOfK {
+    pub fn new(n: u64, native_scripts: Vec<NativeScript>) -> Self {
+        Self {
+            n,
+            native_scripts,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ScriptPubkey {
+    pub addr_keyhash: AddrKeyhash,
+    #[serde(skip)]
+    pub encodings: Option<ScriptPubkeyEncoding>,
+}
+
+impl ScriptPubkey {
+    pub fn new(addr_keyhash: AddrKeyhash) -> Self {
+        Self {
+            addr_keyhash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyTxOut {
+    pub address: Address,
+    pub amount: Value,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyTxOutEncoding>,
+}
+
+impl ShelleyTxOut {
+    pub fn new(address: Address, amount: Value) -> Self {
+        Self {
+            address,
+            amount,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct Transaction {
+    pub transaction_body: TransactionBody,
+    pub transaction_witness_set: TransactionWitnessSet,
+    pub index_2: bool,
+    pub auxiliary_data: Option<AuxiliaryData>,
+    #[serde(skip)]
+    pub encodings: Option<TransactionEncoding>,
+}
+
+impl Transaction {
+    pub fn new(transaction_body: TransactionBody, transaction_witness_set: TransactionWitnessSet, index_2: bool, auxiliary_data: Option<AuxiliaryData>) -> Self {
+        Self {
+            transaction_body,
+            transaction_witness_set,
+            index_2,
+            auxiliary_data,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct TransactionBody {
+    pub key_0: Vec<TransactionInput>,
+    pub key_1: Vec<TransactionOutput>,
+    pub key_2: Coin,
+    pub key_3: Option<u64>,
+    pub key_4: Option<Vec<Certificate>>,
+    pub key_5: Option<Withdrawals>,
+    pub key_6: Option<Update>,
+    pub key_7: Option<AuxiliaryDataHash>,
+    pub key_8: Option<u64>,
+    pub key_9: Option<Mint>,
+    pub key_11: Option<ScriptDataHash>,
+    pub key_13: Option<Vec<TransactionInput>>,
+    pub key_14: Option<RequiredSigners>,
+    pub key_15: Option<NetworkId>,
+    pub key_16: Option<TransactionOutput>,
+    pub key_17: Option<Coin>,
+    pub key_18: Option<Vec<TransactionInput>>,
+    #[serde(skip)]
+    pub encodings: Option<TransactionBodyEncoding>,
+}
+
+impl TransactionBody {
+    pub fn new(key_0: Vec<TransactionInput>, key_1: Vec<TransactionOutput>, key_2: Coin) -> Self {
+        Self {
+            key_0,
+            key_1,
+            key_2,
+            key_3: None,
+            key_4: None,
+            key_5: None,
+            key_6: None,
+            key_7: None,
+            key_8: None,
+            key_9: None,
+            key_11: None,
+            key_13: None,
+            key_14: None,
+            key_15: None,
+            key_16: None,
+            key_17: None,
+            key_18: None,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct TransactionInput {
+    pub transaction_id: Hash32,
+    pub index: u64,
+    #[serde(skip)]
+    pub encodings: Option<TransactionInputEncoding>,
+}
+
+impl TransactionInput {
+    pub fn new(transaction_id: Hash32, index: u64) -> Self {
+        Self {
+            transaction_id,
+            index,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum TransactionOutput {
+    ShelleyTxOut(ShelleyTxOut),
+    AlonzoTxOut(AlonzoTxOut),
+    BabbageTxOut(BabbageTxOut),
+}
+
+impl TransactionOutput {
+    pub fn new_shelley_tx_out(shelley_tx_out: ShelleyTxOut) -> Self {
+        Self::ShelleyTxOut(shelley_tx_out)
+    }
+
+    pub fn new_alonzo_tx_out(alonzo_tx_out: AlonzoTxOut) -> Self {
+        Self::AlonzoTxOut(alonzo_tx_out)
+    }
+
+    pub fn new_babbage_tx_out(babbage_tx_out: BabbageTxOut) -> Self {
+        Self::BabbageTxOut(babbage_tx_out)
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct TransactionWitnessSet {
+    pub key_0: Option<Vec<Vkeywitness>>,
+    pub key_1: Option<Vec<NativeScript>>,
+    pub key_2: Option<Vec<BootstrapWitness>>,
+    pub key_3: Option<Vec<PlutusV1Script>>,
+    pub key_4: Option<Vec<PlutusData>>,
+    pub key_5: Option<Vec<Redeemer>>,
+    pub key_6: Option<Vec<PlutusV2Script>>,
+    #[serde(skip)]
+    pub encodings: Option<TransactionWitnessSetEncoding>,
+}
+
+impl TransactionWitnessSet {
+    pub fn new() -> Self {
+        Self {
+            key_0: None,
+            key_1: None,
+            key_2: None,
+            key_3: None,
+            key_4: None,
+            key_5: None,
+            key_6: None,
+            encodings: None,
+        }
+    }
+}
+
+use super::*;

--- a/rust/json-gen-split/Cargo.toml
+++ b/rust/json-gen-split/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cddl-lib-json-schema-gen"
+version = "0.0.1"
+edition = "2018"
+
+
+[dependencies]
+serde_json = "1.0.57"
+schemars = "0.8.8"
+cddl-lib-core = { path = "../core" }

--- a/rust/json-gen-split/src/main.rs
+++ b/rust/json-gen-split/src/main.rs
@@ -1,0 +1,103 @@
+use cddl_lib_core::*;
+
+fn main() {
+    macro_rules! gen_json_schema {
+        ($name:ident) =>  {
+            let dest_path = std::path::Path::new(&"schemas").join(&format!("{}.json", stringify!($name)));
+            std::fs::write(&dest_path, serde_json::to_string_pretty(&schemars::schema_for!($name)).unwrap()).unwrap();
+        }
+    }
+    let schema_path = std::path::Path::new(&"schemas");
+    if !schema_path.exists() {
+        std::fs::create_dir(schema_path).unwrap();
+    }
+    gen_json_schema!(Address);
+    gen_json_schema!(AlonzoAuxData);
+    gen_json_schema!(AlonzoTxOut);
+    gen_json_schema!(AssetName);
+    gen_json_schema!(AuxiliaryData);
+    gen_json_schema!(BabbageTxOut);
+    gen_json_schema!(BigInt);
+    gen_json_schema!(Block);
+    gen_json_schema!(BootstrapWitness);
+    gen_json_schema!(Certificate);
+    gen_json_schema!(ConstrPlutusData);
+    gen_json_schema!(Costmdls);
+    gen_json_schema!(DatumOption);
+    gen_json_schema!(DatumOption0);
+    gen_json_schema!(DatumOption1);
+    gen_json_schema!(DnsName);
+    gen_json_schema!(ExUnitPrices);
+    gen_json_schema!(ExUnits);
+    gen_json_schema!(GenesisKeyDelegation);
+    gen_json_schema!(Hash28);
+    gen_json_schema!(Hash32);
+    gen_json_schema!(Header);
+    gen_json_schema!(HeaderBody);
+    gen_json_schema!(I0OrI1);
+    gen_json_schema!(Int);
+    gen_json_schema!(InvalidBefore);
+    gen_json_schema!(InvalidHereafter);
+    gen_json_schema!(Ipv4);
+    gen_json_schema!(Ipv6);
+    gen_json_schema!(KesSignature);
+    gen_json_schema!(KesVkey);
+    gen_json_schema!(Language);
+    gen_json_schema!(MoveInstantaneousReward);
+    gen_json_schema!(MoveInstantaneousRewardsCert);
+    gen_json_schema!(MultiHostName);
+    gen_json_schema!(NativeScript);
+    gen_json_schema!(NetworkId);
+    gen_json_schema!(Nonce);
+    gen_json_schema!(Nonce1);
+    gen_json_schema!(OperationalCert);
+    gen_json_schema!(PlutusData);
+    gen_json_schema!(PoolMetadata);
+    gen_json_schema!(PoolParams);
+    gen_json_schema!(PoolRegistration);
+    gen_json_schema!(PoolRetirement);
+    gen_json_schema!(PositiveInterval);
+    gen_json_schema!(ProtocolParamUpdate);
+    gen_json_schema!(ProtocolVersion);
+    gen_json_schema!(ProtocolVersionStruct);
+    gen_json_schema!(Rational);
+    gen_json_schema!(Redeemer);
+    gen_json_schema!(RedeemerTag);
+    gen_json_schema!(Relay);
+    gen_json_schema!(RequiredSigners);
+    gen_json_schema!(RewardAccount);
+    gen_json_schema!(Script);
+    gen_json_schema!(Script0);
+    gen_json_schema!(Script1);
+    gen_json_schema!(Script2);
+    gen_json_schema!(ScriptAll);
+    gen_json_schema!(ScriptAny);
+    gen_json_schema!(ScriptNOfK);
+    gen_json_schema!(ScriptPubkey);
+    gen_json_schema!(ShelleyMaAuxData);
+    gen_json_schema!(ShelleyTxOut);
+    gen_json_schema!(Signature);
+    gen_json_schema!(SignkeyKES);
+    gen_json_schema!(SingleHostAddr);
+    gen_json_schema!(SingleHostName);
+    gen_json_schema!(StakeCredential);
+    gen_json_schema!(StakeCredential0);
+    gen_json_schema!(StakeCredential1);
+    gen_json_schema!(StakeDelegation);
+    gen_json_schema!(StakeDeregistration);
+    gen_json_schema!(StakeRegistration);
+    gen_json_schema!(Transaction);
+    gen_json_schema!(TransactionBody);
+    gen_json_schema!(TransactionInput);
+    gen_json_schema!(TransactionMetadatum);
+    gen_json_schema!(TransactionOutput);
+    gen_json_schema!(TransactionWitnessSet);
+    gen_json_schema!(UnitInterval);
+    gen_json_schema!(Update);
+    gen_json_schema!(Url);
+    gen_json_schema!(Value);
+    gen_json_schema!(Vkey);
+    gen_json_schema!(Vkeywitness);
+    gen_json_schema!(VrfCert);
+    gen_json_schema!(VrfVkey);
+}

--- a/rust/wasm/Cargo.toml
+++ b/rust/wasm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cddl-lib-wasm"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+core = { path = "../core", package = "cddl-lib-core" }
+cbor_event = "2.2.0"
+wasm-bindgen = { version = "0.2", features=["serde-serialize"] }
+linked-hash-map = "0.5.3"
+serde_json = "1.0.57"

--- a/rust/wasm/src/address.rs
+++ b/rust/wasm/src/address.rs
@@ -1,0 +1,95 @@
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Address(pub(crate) core::Address);
+
+#[wasm_bindgen]
+
+impl Address {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Address, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Address, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new() -> Self {
+        Self(core::Address::new())
+    }
+}
+
+impl From<core::Address> for Address {
+    fn from(native: core::Address) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Address> for core::Address {
+    fn from(wasm: Address) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct RewardAccount(pub(crate) core::RewardAccount);
+
+#[wasm_bindgen]
+
+impl RewardAccount {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<RewardAccount, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<RewardAccount, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new() -> Self {
+        Self(core::RewardAccount::new())
+    }
+}
+
+impl From<core::RewardAccount> for RewardAccount {
+    fn from(native: core::RewardAccount) -> Self {
+        Self(native)
+    }
+}
+
+impl From<RewardAccount> for core::RewardAccount {
+    fn from(wasm: RewardAccount) -> Self {
+        wasm.0
+    }
+}
+
+use super::*;

--- a/rust/wasm/src/block.rs
+++ b/rust/wasm/src/block.rs
@@ -1,0 +1,328 @@
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Block(pub(crate) core::Block);
+
+#[wasm_bindgen]
+
+impl Block {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Block, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Block, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn header(&self) -> Header {
+        self.0.header.clone().into()
+    }
+
+    pub fn transaction_bodies(&self) -> TransactionBodys {
+        self.0.transaction_bodies.clone().into()
+    }
+
+    pub fn transaction_witness_sets(&self) -> TransactionWitnessSets {
+        self.0.transaction_witness_sets.clone().into()
+    }
+
+    pub fn auxiliary_data_set(&self) -> MapTransactionIndexToAuxiliaryData {
+        self.0.auxiliary_data_set.clone().into()
+    }
+
+    pub fn invalid_transactions(&self) -> Vec<TransactionIndex> {
+        self.0.invalid_transactions.clone().into()
+    }
+
+    pub fn new(header: &Header, transaction_bodies: &TransactionBodys, transaction_witness_sets: &TransactionWitnessSets, auxiliary_data_set: &MapTransactionIndexToAuxiliaryData, invalid_transactions: Vec<TransactionIndex>) -> Self {
+        Self(core::Block::new(header.clone().into(), transaction_bodies.clone().into(), transaction_witness_sets.clone().into(), auxiliary_data_set.clone().into(), invalid_transactions))
+    }
+}
+
+impl From<core::Block> for Block {
+    fn from(native: core::Block) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Block> for core::Block {
+    fn from(wasm: Block) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Header(pub(crate) core::Header);
+
+#[wasm_bindgen]
+
+impl Header {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Header, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Header, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn header_body(&self) -> HeaderBody {
+        self.0.header_body.clone().into()
+    }
+
+    pub fn body_signature(&self) -> KesSignature {
+        self.0.body_signature.clone().into()
+    }
+
+    pub fn new(header_body: &HeaderBody, body_signature: &KesSignature) -> Self {
+        Self(core::Header::new(header_body.clone().into(), body_signature.clone().into()))
+    }
+}
+
+impl From<core::Header> for Header {
+    fn from(native: core::Header) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Header> for core::Header {
+    fn from(wasm: Header) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct HeaderBody(pub(crate) core::HeaderBody);
+
+#[wasm_bindgen]
+
+impl HeaderBody {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<HeaderBody, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<HeaderBody, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn block_number(&self) -> u64 {
+        self.0.block_number
+    }
+
+    pub fn slot(&self) -> u64 {
+        self.0.slot
+    }
+
+    pub fn prev_hash(&self) -> Option<Hash32> {
+        self.0.prev_hash.clone().map(std::convert::Into::into)
+    }
+
+    pub fn issuer_vkey(&self) -> Vkey {
+        self.0.issuer_vkey.clone().into()
+    }
+
+    pub fn vrf_vkey(&self) -> VrfVkey {
+        self.0.vrf_vkey.clone().into()
+    }
+
+    pub fn vrf_result(&self) -> VrfCert {
+        self.0.vrf_result.clone().into()
+    }
+
+    pub fn block_body_size(&self) -> u64 {
+        self.0.block_body_size
+    }
+
+    pub fn block_body_hash(&self) -> Hash32 {
+        self.0.block_body_hash.clone().into()
+    }
+
+    pub fn operational_cert(&self) -> OperationalCert {
+        self.0.operational_cert.clone().into()
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.0.protocol_version.clone().into()
+    }
+
+    pub fn new(block_number: u64, slot: u64, prev_hash: Option<Hash32>, issuer_vkey: &Vkey, vrf_vkey: &VrfVkey, vrf_result: &VrfCert, block_body_size: u64, block_body_hash: &Hash32, operational_cert: &OperationalCert, protocol_version: &ProtocolVersion) -> Self {
+        Self(core::HeaderBody::new(block_number, slot, prev_hash.map(Into::into), issuer_vkey.clone().into(), vrf_vkey.clone().into(), vrf_result.clone().into(), block_body_size, block_body_hash.clone().into(), operational_cert.clone().into(), protocol_version.clone().into()))
+    }
+}
+
+impl From<core::HeaderBody> for HeaderBody {
+    fn from(native: core::HeaderBody) -> Self {
+        Self(native)
+    }
+}
+
+impl From<HeaderBody> for core::HeaderBody {
+    fn from(wasm: HeaderBody) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct OperationalCert(pub(crate) core::OperationalCert);
+
+#[wasm_bindgen]
+
+impl OperationalCert {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<OperationalCert, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<OperationalCert, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn hot_vkey(&self) -> KesVkey {
+        self.0.hot_vkey.clone().into()
+    }
+
+    pub fn sequence_number(&self) -> u64 {
+        self.0.sequence_number
+    }
+
+    pub fn kes_period(&self) -> u64 {
+        self.0.kes_period
+    }
+
+    pub fn sigma(&self) -> Signature {
+        self.0.sigma.clone().into()
+    }
+
+    pub fn new(hot_vkey: &KesVkey, sequence_number: u64, kes_period: u64, sigma: &Signature) -> Self {
+        Self(core::OperationalCert::new(hot_vkey.clone().into(), sequence_number, kes_period, sigma.clone().into()))
+    }
+}
+
+impl From<core::OperationalCert> for OperationalCert {
+    fn from(native: core::OperationalCert) -> Self {
+        Self(native)
+    }
+}
+
+impl From<OperationalCert> for core::OperationalCert {
+    fn from(wasm: OperationalCert) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ProtocolVersion(pub(crate) core::ProtocolVersion);
+
+#[wasm_bindgen]
+
+impl ProtocolVersion {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ProtocolVersion, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ProtocolVersion, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn index_0(&self) -> u64 {
+        self.0.index_0
+    }
+
+    pub fn index_1(&self) -> u64 {
+        self.0.index_1
+    }
+
+    pub fn new(index_0: u64, index_1: u64) -> Self {
+        Self(core::ProtocolVersion::new(index_0, index_1))
+    }
+}
+
+impl From<core::ProtocolVersion> for ProtocolVersion {
+    fn from(native: core::ProtocolVersion) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ProtocolVersion> for core::ProtocolVersion {
+    fn from(wasm: ProtocolVersion) -> Self {
+        wasm.0
+    }
+}
+
+use super::*;

--- a/rust/wasm/src/certs.rs
+++ b/rust/wasm/src/certs.rs
@@ -1,0 +1,1239 @@
+#[wasm_bindgen]
+
+pub enum CertificateKind {
+    StakeRegistration,
+    StakeDeregistration,
+    StakeDelegation,
+    PoolRegistration,
+    PoolRetirement,
+    GenesisKeyDelegation,
+    MoveInstantaneousRewardsCert,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Certificate(pub(crate) core::Certificate);
+
+#[wasm_bindgen]
+
+impl Certificate {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Certificate, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Certificate, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_stake_registration(stake_credential: &StakeCredential) -> Self {
+        Self(core::Certificate::new_stake_registration(stake_credential.clone().into()))
+    }
+
+    pub fn new_stake_deregistration(stake_credential: &StakeCredential) -> Self {
+        Self(core::Certificate::new_stake_deregistration(stake_credential.clone().into()))
+    }
+
+    pub fn new_stake_delegation(stake_credential: &StakeCredential, pool_keyhash: &PoolKeyhash) -> Self {
+        Self(core::Certificate::new_stake_delegation(stake_credential.clone().into(), pool_keyhash.clone().into()))
+    }
+
+    pub fn new_pool_registration(pool_params: &PoolParams) -> Self {
+        Self(core::Certificate::new_pool_registration(pool_params.clone().into()))
+    }
+
+    pub fn new_pool_retirement(pool_keyhash: &PoolKeyhash, epoch: Epoch) -> Self {
+        Self(core::Certificate::new_pool_retirement(pool_keyhash.clone().into(), epoch))
+    }
+
+    pub fn new_genesis_key_delegation(genesishash: &Genesishash, genesis_delegate_hash: &GenesisDelegateHash, vrf_keyhash: &VrfKeyhash) -> Self {
+        Self(core::Certificate::new_genesis_key_delegation(genesishash.clone().into(), genesis_delegate_hash.clone().into(), vrf_keyhash.clone().into()))
+    }
+
+    pub fn new_move_instantaneous_rewards_cert(move_instantaneous_reward: &MoveInstantaneousReward) -> Self {
+        Self(core::Certificate::new_move_instantaneous_rewards_cert(move_instantaneous_reward.clone().into()))
+    }
+
+    pub fn kind(&self) -> CertificateKind {
+        match &self.0 {
+            core::Certificate::StakeRegistration(_) => CertificateKind::StakeRegistration,
+            core::Certificate::StakeDeregistration(_) => CertificateKind::StakeDeregistration,
+            core::Certificate::StakeDelegation(_) => CertificateKind::StakeDelegation,
+            core::Certificate::PoolRegistration(_) => CertificateKind::PoolRegistration,
+            core::Certificate::PoolRetirement(_) => CertificateKind::PoolRetirement,
+            core::Certificate::GenesisKeyDelegation(_) => CertificateKind::GenesisKeyDelegation,
+            core::Certificate::MoveInstantaneousRewardsCert(_) => CertificateKind::MoveInstantaneousRewardsCert,
+        }
+    }
+
+    pub fn as_stake_registration(&self) -> Option<StakeRegistration> {
+        match &self.0 {
+            core::Certificate::StakeRegistration(stake_registration) => Some(stake_registration.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_stake_deregistration(&self) -> Option<StakeDeregistration> {
+        match &self.0 {
+            core::Certificate::StakeDeregistration(stake_deregistration) => Some(stake_deregistration.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_stake_delegation(&self) -> Option<StakeDelegation> {
+        match &self.0 {
+            core::Certificate::StakeDelegation(stake_delegation) => Some(stake_delegation.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_pool_registration(&self) -> Option<PoolRegistration> {
+        match &self.0 {
+            core::Certificate::PoolRegistration(pool_registration) => Some(pool_registration.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_pool_retirement(&self) -> Option<PoolRetirement> {
+        match &self.0 {
+            core::Certificate::PoolRetirement(pool_retirement) => Some(pool_retirement.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_genesis_key_delegation(&self) -> Option<GenesisKeyDelegation> {
+        match &self.0 {
+            core::Certificate::GenesisKeyDelegation(genesis_key_delegation) => Some(genesis_key_delegation.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_move_instantaneous_rewards_cert(&self) -> Option<MoveInstantaneousRewardsCert> {
+        match &self.0 {
+            core::Certificate::MoveInstantaneousRewardsCert(move_instantaneous_rewards_cert) => Some(move_instantaneous_rewards_cert.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::Certificate> for Certificate {
+    fn from(native: core::Certificate) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Certificate> for core::Certificate {
+    fn from(wasm: Certificate) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct DnsName(pub(crate) core::DnsName);
+
+#[wasm_bindgen]
+
+impl DnsName {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<DnsName, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<DnsName, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> String {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::DnsName> for DnsName {
+    fn from(native: core::DnsName) -> Self {
+        Self(native)
+    }
+}
+
+impl From<DnsName> for core::DnsName {
+    fn from(wasm: DnsName) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct GenesisKeyDelegation(pub(crate) core::GenesisKeyDelegation);
+
+#[wasm_bindgen]
+
+impl GenesisKeyDelegation {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<GenesisKeyDelegation, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<GenesisKeyDelegation, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn genesishash(&self) -> Genesishash {
+        self.0.genesishash.clone().into()
+    }
+
+    pub fn genesis_delegate_hash(&self) -> GenesisDelegateHash {
+        self.0.genesis_delegate_hash.clone().into()
+    }
+
+    pub fn vrf_keyhash(&self) -> VrfKeyhash {
+        self.0.vrf_keyhash.clone().into()
+    }
+
+    pub fn new(genesishash: &Genesishash, genesis_delegate_hash: &GenesisDelegateHash, vrf_keyhash: &VrfKeyhash) -> Self {
+        Self(core::GenesisKeyDelegation::new(genesishash.clone().into(), genesis_delegate_hash.clone().into(), vrf_keyhash.clone().into()))
+    }
+}
+
+impl From<core::GenesisKeyDelegation> for GenesisKeyDelegation {
+    fn from(native: core::GenesisKeyDelegation) -> Self {
+        Self(native)
+    }
+}
+
+impl From<GenesisKeyDelegation> for core::GenesisKeyDelegation {
+    fn from(wasm: GenesisKeyDelegation) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Ipv4(pub(crate) core::Ipv4);
+
+#[wasm_bindgen]
+
+impl Ipv4 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Ipv4, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Ipv4, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::Ipv4> for Ipv4 {
+    fn from(native: core::Ipv4) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Ipv4> for core::Ipv4 {
+    fn from(wasm: Ipv4) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Ipv6(pub(crate) core::Ipv6);
+
+#[wasm_bindgen]
+
+impl Ipv6 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Ipv6, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Ipv6, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::Ipv6> for Ipv6 {
+    fn from(native: core::Ipv6) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Ipv6> for core::Ipv6 {
+    fn from(wasm: Ipv6) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MoveInstantaneousReward(pub(crate) core::MoveInstantaneousReward);
+
+#[wasm_bindgen]
+
+impl MoveInstantaneousReward {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousReward, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MoveInstantaneousReward, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn index_0(&self) -> I0OrI1 {
+        self.0.index_0.clone().into()
+    }
+
+    pub fn index_1(&self) -> MapStakeCredentialToDeltaCoin {
+        self.0.index_1.clone().into()
+    }
+
+    pub fn coin(&self) -> Coin {
+        self.0.coin
+    }
+
+    pub fn new(index_0: &I0OrI1, index_1: &MapStakeCredentialToDeltaCoin, coin: Coin) -> Self {
+        Self(core::MoveInstantaneousReward::new(index_0.clone().into(), index_1.clone().into(), coin))
+    }
+}
+
+impl From<core::MoveInstantaneousReward> for MoveInstantaneousReward {
+    fn from(native: core::MoveInstantaneousReward) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MoveInstantaneousReward> for core::MoveInstantaneousReward {
+    fn from(wasm: MoveInstantaneousReward) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MoveInstantaneousRewardsCert(pub(crate) core::MoveInstantaneousRewardsCert);
+
+#[wasm_bindgen]
+
+impl MoveInstantaneousRewardsCert {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousRewardsCert, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MoveInstantaneousRewardsCert, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn move_instantaneous_reward(&self) -> MoveInstantaneousReward {
+        self.0.move_instantaneous_reward.clone().into()
+    }
+
+    pub fn new(move_instantaneous_reward: &MoveInstantaneousReward) -> Self {
+        Self(core::MoveInstantaneousRewardsCert::new(move_instantaneous_reward.clone().into()))
+    }
+}
+
+impl From<core::MoveInstantaneousRewardsCert> for MoveInstantaneousRewardsCert {
+    fn from(native: core::MoveInstantaneousRewardsCert) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MoveInstantaneousRewardsCert> for core::MoveInstantaneousRewardsCert {
+    fn from(wasm: MoveInstantaneousRewardsCert) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MultiHostName(pub(crate) core::MultiHostName);
+
+#[wasm_bindgen]
+
+impl MultiHostName {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MultiHostName, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MultiHostName, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn dns_name(&self) -> DnsName {
+        self.0.dns_name.clone().into()
+    }
+
+    pub fn new(dns_name: &DnsName) -> Self {
+        Self(core::MultiHostName::new(dns_name.clone().into()))
+    }
+}
+
+impl From<core::MultiHostName> for MultiHostName {
+    fn from(native: core::MultiHostName) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultiHostName> for core::MultiHostName {
+    fn from(wasm: MultiHostName) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PoolMetadata(pub(crate) core::PoolMetadata);
+
+#[wasm_bindgen]
+
+impl PoolMetadata {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PoolMetadata, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<PoolMetadata, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn url(&self) -> Url {
+        self.0.url.clone().into()
+    }
+
+    pub fn pool_metadata_hash(&self) -> PoolMetadataHash {
+        self.0.pool_metadata_hash.clone().into()
+    }
+
+    pub fn new(url: &Url, pool_metadata_hash: &PoolMetadataHash) -> Self {
+        Self(core::PoolMetadata::new(url.clone().into(), pool_metadata_hash.clone().into()))
+    }
+}
+
+impl From<core::PoolMetadata> for PoolMetadata {
+    fn from(native: core::PoolMetadata) -> Self {
+        Self(native)
+    }
+}
+
+impl From<PoolMetadata> for core::PoolMetadata {
+    fn from(wasm: PoolMetadata) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PoolParams(pub(crate) core::PoolParams);
+
+#[wasm_bindgen]
+
+impl PoolParams {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PoolParams, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<PoolParams, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn operator(&self) -> PoolKeyhash {
+        self.0.operator.clone().into()
+    }
+
+    pub fn vrf_keyhash(&self) -> VrfKeyhash {
+        self.0.vrf_keyhash.clone().into()
+    }
+
+    pub fn pledge(&self) -> Coin {
+        self.0.pledge
+    }
+
+    pub fn cost(&self) -> Coin {
+        self.0.cost
+    }
+
+    pub fn margin(&self) -> UnitInterval {
+        self.0.margin.clone().into()
+    }
+
+    pub fn reward_account(&self) -> RewardAccount {
+        self.0.reward_account.clone().into()
+    }
+
+    pub fn pool_owners(&self) -> AddrKeyhashs {
+        self.0.pool_owners.clone().into()
+    }
+
+    pub fn relays(&self) -> Relays {
+        self.0.relays.clone().into()
+    }
+
+    pub fn pool_metadata(&self) -> Option<PoolMetadata> {
+        self.0.pool_metadata.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(operator: &PoolKeyhash, vrf_keyhash: &VrfKeyhash, pledge: Coin, cost: Coin, margin: &UnitInterval, reward_account: &RewardAccount, pool_owners: &AddrKeyhashs, relays: &Relays, pool_metadata: Option<PoolMetadata>) -> Self {
+        Self(core::PoolParams::new(operator.clone().into(), vrf_keyhash.clone().into(), pledge, cost, margin.clone().into(), reward_account.clone().into(), pool_owners.clone().into(), relays.clone().into(), pool_metadata.map(Into::into)))
+    }
+}
+
+impl From<core::PoolParams> for PoolParams {
+    fn from(native: core::PoolParams) -> Self {
+        Self(native)
+    }
+}
+
+impl From<PoolParams> for core::PoolParams {
+    fn from(wasm: PoolParams) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PoolRegistration(pub(crate) core::PoolRegistration);
+
+#[wasm_bindgen]
+
+impl PoolRegistration {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRegistration, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<PoolRegistration, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn pool_params(&self) -> PoolParams {
+        self.0.pool_params.clone().into()
+    }
+
+    pub fn new(pool_params: &PoolParams) -> Self {
+        Self(core::PoolRegistration::new(pool_params.clone().into()))
+    }
+}
+
+impl From<core::PoolRegistration> for PoolRegistration {
+    fn from(native: core::PoolRegistration) -> Self {
+        Self(native)
+    }
+}
+
+impl From<PoolRegistration> for core::PoolRegistration {
+    fn from(wasm: PoolRegistration) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PoolRetirement(pub(crate) core::PoolRetirement);
+
+#[wasm_bindgen]
+
+impl PoolRetirement {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRetirement, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<PoolRetirement, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn pool_keyhash(&self) -> PoolKeyhash {
+        self.0.pool_keyhash.clone().into()
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.0.epoch
+    }
+
+    pub fn new(pool_keyhash: &PoolKeyhash, epoch: Epoch) -> Self {
+        Self(core::PoolRetirement::new(pool_keyhash.clone().into(), epoch))
+    }
+}
+
+impl From<core::PoolRetirement> for PoolRetirement {
+    fn from(native: core::PoolRetirement) -> Self {
+        Self(native)
+    }
+}
+
+impl From<PoolRetirement> for core::PoolRetirement {
+    fn from(wasm: PoolRetirement) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum RelayKind {
+    SingleHostAddr,
+    SingleHostName,
+    MultiHostName,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Relay(pub(crate) core::Relay);
+
+#[wasm_bindgen]
+
+impl Relay {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Relay, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Relay, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_single_host_addr(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
+        Self(core::Relay::new_single_host_addr(port, ipv4.map(Into::into), ipv6.map(Into::into)))
+    }
+
+    pub fn new_single_host_name(port: Option<Port>, dns_name: &DnsName) -> Self {
+        Self(core::Relay::new_single_host_name(port, dns_name.clone().into()))
+    }
+
+    pub fn new_multi_host_name(dns_name: &DnsName) -> Self {
+        Self(core::Relay::new_multi_host_name(dns_name.clone().into()))
+    }
+
+    pub fn kind(&self) -> RelayKind {
+        match &self.0 {
+            core::Relay::SingleHostAddr(_) => RelayKind::SingleHostAddr,
+            core::Relay::SingleHostName(_) => RelayKind::SingleHostName,
+            core::Relay::MultiHostName(_) => RelayKind::MultiHostName,
+        }
+    }
+
+    pub fn as_single_host_addr(&self) -> Option<SingleHostAddr> {
+        match &self.0 {
+            core::Relay::SingleHostAddr(single_host_addr) => Some(single_host_addr.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_single_host_name(&self) -> Option<SingleHostName> {
+        match &self.0 {
+            core::Relay::SingleHostName(single_host_name) => Some(single_host_name.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_multi_host_name(&self) -> Option<MultiHostName> {
+        match &self.0 {
+            core::Relay::MultiHostName(multi_host_name) => Some(multi_host_name.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::Relay> for Relay {
+    fn from(native: core::Relay) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Relay> for core::Relay {
+    fn from(wasm: Relay) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct SingleHostAddr(pub(crate) core::SingleHostAddr);
+
+#[wasm_bindgen]
+
+impl SingleHostAddr {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostAddr, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<SingleHostAddr, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn port(&self) -> Option<Port> {
+        self.0.port
+    }
+
+    pub fn ipv4(&self) -> Option<Ipv4> {
+        self.0.ipv4.clone().map(std::convert::Into::into)
+    }
+
+    pub fn ipv6(&self) -> Option<Ipv6> {
+        self.0.ipv6.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
+        Self(core::SingleHostAddr::new(port, ipv4.map(Into::into), ipv6.map(Into::into)))
+    }
+}
+
+impl From<core::SingleHostAddr> for SingleHostAddr {
+    fn from(native: core::SingleHostAddr) -> Self {
+        Self(native)
+    }
+}
+
+impl From<SingleHostAddr> for core::SingleHostAddr {
+    fn from(wasm: SingleHostAddr) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct SingleHostName(pub(crate) core::SingleHostName);
+
+#[wasm_bindgen]
+
+impl SingleHostName {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostName, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<SingleHostName, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn port(&self) -> Option<Port> {
+        self.0.port
+    }
+
+    pub fn dns_name(&self) -> DnsName {
+        self.0.dns_name.clone().into()
+    }
+
+    pub fn new(port: Option<Port>, dns_name: &DnsName) -> Self {
+        Self(core::SingleHostName::new(port, dns_name.clone().into()))
+    }
+}
+
+impl From<core::SingleHostName> for SingleHostName {
+    fn from(native: core::SingleHostName) -> Self {
+        Self(native)
+    }
+}
+
+impl From<SingleHostName> for core::SingleHostName {
+    fn from(wasm: SingleHostName) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum StakeCredentialKind {
+    StakeCredential0,
+    StakeCredential1,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct StakeCredential(pub(crate) core::StakeCredential);
+
+#[wasm_bindgen]
+
+impl StakeCredential {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeCredential, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<StakeCredential, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_stake_credential0(addr_keyhash: &AddrKeyhash) -> Self {
+        Self(core::StakeCredential::new_stake_credential0(addr_keyhash.clone().into()))
+    }
+
+    pub fn new_stake_credential1(scripthash: &Scripthash) -> Self {
+        Self(core::StakeCredential::new_stake_credential1(scripthash.clone().into()))
+    }
+
+    pub fn kind(&self) -> StakeCredentialKind {
+        match &self.0 {
+            core::StakeCredential::StakeCredential0(_) => StakeCredentialKind::StakeCredential0,
+            core::StakeCredential::StakeCredential1(_) => StakeCredentialKind::StakeCredential1,
+        }
+    }
+
+    pub fn as_stake_credential0(&self) -> Option<StakeCredential0> {
+        match &self.0 {
+            core::StakeCredential::StakeCredential0(stake_credential0) => Some(stake_credential0.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_stake_credential1(&self) -> Option<StakeCredential1> {
+        match &self.0 {
+            core::StakeCredential::StakeCredential1(stake_credential1) => Some(stake_credential1.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::StakeCredential> for StakeCredential {
+    fn from(native: core::StakeCredential) -> Self {
+        Self(native)
+    }
+}
+
+impl From<StakeCredential> for core::StakeCredential {
+    fn from(wasm: StakeCredential) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct StakeDelegation(pub(crate) core::StakeDelegation);
+
+#[wasm_bindgen]
+
+impl StakeDelegation {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDelegation, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<StakeDelegation, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn stake_credential(&self) -> StakeCredential {
+        self.0.stake_credential.clone().into()
+    }
+
+    pub fn pool_keyhash(&self) -> PoolKeyhash {
+        self.0.pool_keyhash.clone().into()
+    }
+
+    pub fn new(stake_credential: &StakeCredential, pool_keyhash: &PoolKeyhash) -> Self {
+        Self(core::StakeDelegation::new(stake_credential.clone().into(), pool_keyhash.clone().into()))
+    }
+}
+
+impl From<core::StakeDelegation> for StakeDelegation {
+    fn from(native: core::StakeDelegation) -> Self {
+        Self(native)
+    }
+}
+
+impl From<StakeDelegation> for core::StakeDelegation {
+    fn from(wasm: StakeDelegation) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct StakeDeregistration(pub(crate) core::StakeDeregistration);
+
+#[wasm_bindgen]
+
+impl StakeDeregistration {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDeregistration, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<StakeDeregistration, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn stake_credential(&self) -> StakeCredential {
+        self.0.stake_credential.clone().into()
+    }
+
+    pub fn new(stake_credential: &StakeCredential) -> Self {
+        Self(core::StakeDeregistration::new(stake_credential.clone().into()))
+    }
+}
+
+impl From<core::StakeDeregistration> for StakeDeregistration {
+    fn from(native: core::StakeDeregistration) -> Self {
+        Self(native)
+    }
+}
+
+impl From<StakeDeregistration> for core::StakeDeregistration {
+    fn from(wasm: StakeDeregistration) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct StakeRegistration(pub(crate) core::StakeRegistration);
+
+#[wasm_bindgen]
+
+impl StakeRegistration {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeRegistration, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<StakeRegistration, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn stake_credential(&self) -> StakeCredential {
+        self.0.stake_credential.clone().into()
+    }
+
+    pub fn new(stake_credential: &StakeCredential) -> Self {
+        Self(core::StakeRegistration::new(stake_credential.clone().into()))
+    }
+}
+
+impl From<core::StakeRegistration> for StakeRegistration {
+    fn from(native: core::StakeRegistration) -> Self {
+        Self(native)
+    }
+}
+
+impl From<StakeRegistration> for core::StakeRegistration {
+    fn from(wasm: StakeRegistration) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Url(pub(crate) core::Url);
+
+#[wasm_bindgen]
+
+impl Url {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Url, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Url, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> String {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::Url> for Url {
+    fn from(native: core::Url) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Url> for core::Url {
+    fn from(wasm: Url) -> Self {
+        wasm.0
+    }
+}
+
+use super::*;

--- a/rust/wasm/src/crypto.rs
+++ b/rust/wasm/src/crypto.rs
@@ -1,0 +1,524 @@
+pub type AddrKeyhash = Hash28;
+
+pub type AuxiliaryDataHash = Hash32;
+
+pub type DatumHash = Hash32;
+
+pub type GenesisDelegateHash = Hash28;
+
+pub type Genesishash = Hash28;
+
+pub type Natural = Vec<u8>;
+
+pub type PoolKeyhash = Hash28;
+
+pub type PoolMetadataHash = Hash32;
+
+pub type Scripthash = Hash28;
+
+pub type VrfKeyhash = Hash32;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Hash28(pub(crate) core::Hash28);
+
+#[wasm_bindgen]
+
+impl Hash28 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Hash28, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Hash28, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::Hash28> for Hash28 {
+    fn from(native: core::Hash28) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Hash28> for core::Hash28 {
+    fn from(wasm: Hash28) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Hash32(pub(crate) core::Hash32);
+
+#[wasm_bindgen]
+
+impl Hash32 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Hash32, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Hash32, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::Hash32> for Hash32 {
+    fn from(native: core::Hash32) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Hash32> for core::Hash32 {
+    fn from(wasm: Hash32) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct KesSignature(pub(crate) core::KesSignature);
+
+#[wasm_bindgen]
+
+impl KesSignature {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<KesSignature, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<KesSignature, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::KesSignature> for KesSignature {
+    fn from(native: core::KesSignature) -> Self {
+        Self(native)
+    }
+}
+
+impl From<KesSignature> for core::KesSignature {
+    fn from(wasm: KesSignature) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct KesVkey(pub(crate) core::KesVkey);
+
+#[wasm_bindgen]
+
+impl KesVkey {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<KesVkey, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<KesVkey, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::KesVkey> for KesVkey {
+    fn from(native: core::KesVkey) -> Self {
+        Self(native)
+    }
+}
+
+impl From<KesVkey> for core::KesVkey {
+    fn from(wasm: KesVkey) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum NonceKind {
+    I0,
+    Nonce1,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Nonce(pub(crate) core::Nonce);
+
+#[wasm_bindgen]
+
+impl Nonce {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Nonce, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Nonce, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_i0() -> Self {
+        Self(core::Nonce::new_i0())
+    }
+
+    pub fn new_nonce1(bytes: Vec<u8>) -> Self {
+        Self(core::Nonce::new_nonce1(bytes))
+    }
+
+    pub fn kind(&self) -> NonceKind {
+        match &self.0 {
+            core::Nonce::I0{ .. } => NonceKind::I0,
+            core::Nonce::Nonce1(_) => NonceKind::Nonce1,
+        }
+    }
+
+    pub fn as_nonce1(&self) -> Option<Nonce1> {
+        match &self.0 {
+            core::Nonce::Nonce1(nonce1) => Some(nonce1.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::Nonce> for Nonce {
+    fn from(native: core::Nonce) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Nonce> for core::Nonce {
+    fn from(wasm: Nonce) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Signature(pub(crate) core::Signature);
+
+#[wasm_bindgen]
+
+impl Signature {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Signature, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Signature, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::Signature> for Signature {
+    fn from(native: core::Signature) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Signature> for core::Signature {
+    fn from(wasm: Signature) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct SignkeyKES(pub(crate) core::SignkeyKES);
+
+#[wasm_bindgen]
+
+impl SignkeyKES {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<SignkeyKES, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<SignkeyKES, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::SignkeyKES> for SignkeyKES {
+    fn from(native: core::SignkeyKES) -> Self {
+        Self(native)
+    }
+}
+
+impl From<SignkeyKES> for core::SignkeyKES {
+    fn from(wasm: SignkeyKES) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Vkey(pub(crate) core::Vkey);
+
+#[wasm_bindgen]
+
+impl Vkey {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Vkey, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Vkey, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::Vkey> for Vkey {
+    fn from(native: core::Vkey) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Vkey> for core::Vkey {
+    fn from(wasm: Vkey) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct VrfCert(pub(crate) core::VrfCert);
+
+#[wasm_bindgen]
+
+impl VrfCert {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<VrfCert, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<VrfCert, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn index_0(&self) -> Vec<u8> {
+        self.0.index_0.clone()
+    }
+
+    pub fn bytes(&self) -> Vec<u8> {
+        self.0.bytes.clone()
+    }
+
+    pub fn new(index_0: Vec<u8>, bytes: Vec<u8>) -> Self {
+        Self(core::VrfCert::new(index_0, bytes))
+    }
+}
+
+impl From<core::VrfCert> for VrfCert {
+    fn from(native: core::VrfCert) -> Self {
+        Self(native)
+    }
+}
+
+impl From<VrfCert> for core::VrfCert {
+    fn from(wasm: VrfCert) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct VrfVkey(pub(crate) core::VrfVkey);
+
+#[wasm_bindgen]
+
+impl VrfVkey {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<VrfVkey, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<VrfVkey, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::VrfVkey> for VrfVkey {
+    fn from(native: core::VrfVkey) -> Self {
+        Self(native)
+    }
+}
+
+impl From<VrfVkey> for core::VrfVkey {
+    fn from(wasm: VrfVkey) -> Self {
+        wasm.0
+    }
+}
+
+use super::*;

--- a/rust/wasm/src/lib.rs
+++ b/rust/wasm/src/lib.rs
@@ -1,0 +1,2602 @@
+use wasm_bindgen::prelude::*;
+
+use std::collections::BTreeMap;
+
+use core::ordered_hash_map::OrderedHashMap;
+
+use core::serialization::{LenEncoding, StringEncoding};
+
+impl From<OrderedHashMap<core::TransactionMetadatumLabel, core::TransactionMetadatum>> for MapTransactionMetadatumLabelToTransactionMetadatum {
+    fn from(native: OrderedHashMap<core::TransactionMetadatumLabel, core::TransactionMetadatum>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::TransactionMetadatumLabel, core::TransactionMetadatum>> for MapTransactionMetadatumLabelToTransactionMetadatum {
+    fn into(self) -> OrderedHashMap<core::TransactionMetadatumLabel, core::TransactionMetadatum> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum>> for MapTransactionMetadatumToTransactionMetadatum {
+    fn from(native: OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum>> for MapTransactionMetadatumToTransactionMetadatum {
+    fn into(self) -> OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionMetadatums(pub(crate) Vec<core::TransactionMetadatum>);
+
+#[wasm_bindgen]
+
+impl TransactionMetadatums {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionMetadatum {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &TransactionMetadatum) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::TransactionMetadatum>> for TransactionMetadatums {
+    fn from(native: Vec<core::TransactionMetadatum>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::TransactionMetadatum>> for TransactionMetadatums {
+    fn into(self) -> Vec<core::TransactionMetadatum> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct NativeScripts(pub(crate) Vec<core::NativeScript>);
+
+#[wasm_bindgen]
+
+impl NativeScripts {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> NativeScript {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &NativeScript) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::NativeScript>> for NativeScripts {
+    fn from(native: Vec<core::NativeScript>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::NativeScript>> for NativeScripts {
+    fn into(self) -> Vec<core::NativeScript> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PlutusV1Scripts(pub(crate) Vec<core::PlutusV1Script>);
+
+#[wasm_bindgen]
+
+impl PlutusV1Scripts {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> PlutusV1Script {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: PlutusV1Script) {
+        self.0.push(elem);
+    }
+}
+
+impl From<Vec<core::PlutusV1Script>> for PlutusV1Scripts {
+    fn from(native: Vec<core::PlutusV1Script>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::PlutusV1Script>> for PlutusV1Scripts {
+    fn into(self) -> Vec<core::PlutusV1Script> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PlutusV2Scripts(pub(crate) Vec<core::PlutusV2Script>);
+
+#[wasm_bindgen]
+
+impl PlutusV2Scripts {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> PlutusV2Script {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: PlutusV2Script) {
+        self.0.push(elem);
+    }
+}
+
+impl From<Vec<core::PlutusV2Script>> for PlutusV2Scripts {
+    fn from(native: Vec<core::PlutusV2Script>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::PlutusV2Script>> for PlutusV2Scripts {
+    fn into(self) -> Vec<core::PlutusV2Script> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, u64>>> for MapPolicyIdToMapAssetNameToU64 {
+    fn from(native: OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, u64>>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, u64>>> for MapPolicyIdToMapAssetNameToU64 {
+    fn into(self) -> OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, u64>> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PolicyIds(pub(crate) Vec<core::PolicyId>);
+
+#[wasm_bindgen]
+
+impl PolicyIds {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> PolicyId {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &PolicyId) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::PolicyId>> for PolicyIds {
+    fn from(native: Vec<core::PolicyId>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::PolicyId>> for PolicyIds {
+    fn into(self) -> Vec<core::PolicyId> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::AssetName, u64>> for MapAssetNameToU64 {
+    fn from(native: OrderedHashMap<core::AssetName, u64>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::AssetName, u64>> for MapAssetNameToU64 {
+    fn into(self) -> OrderedHashMap<core::AssetName, u64> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct AssetNames(pub(crate) Vec<core::AssetName>);
+
+#[wasm_bindgen]
+
+impl AssetNames {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AssetName {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &AssetName) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::AssetName>> for AssetNames {
+    fn from(native: Vec<core::AssetName>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::AssetName>> for AssetNames {
+    fn into(self) -> Vec<core::AssetName> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionBodys(pub(crate) Vec<core::TransactionBody>);
+
+#[wasm_bindgen]
+
+impl TransactionBodys {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionBody {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &TransactionBody) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::TransactionBody>> for TransactionBodys {
+    fn from(native: Vec<core::TransactionBody>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::TransactionBody>> for TransactionBodys {
+    fn into(self) -> Vec<core::TransactionBody> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionInputs(pub(crate) Vec<core::TransactionInput>);
+
+#[wasm_bindgen]
+
+impl TransactionInputs {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionInput {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &TransactionInput) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::TransactionInput>> for TransactionInputs {
+    fn from(native: Vec<core::TransactionInput>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::TransactionInput>> for TransactionInputs {
+    fn into(self) -> Vec<core::TransactionInput> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionOutputs(pub(crate) Vec<core::TransactionOutput>);
+
+#[wasm_bindgen]
+
+impl TransactionOutputs {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionOutput {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &TransactionOutput) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::TransactionOutput>> for TransactionOutputs {
+    fn from(native: Vec<core::TransactionOutput>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::TransactionOutput>> for TransactionOutputs {
+    fn into(self) -> Vec<core::TransactionOutput> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Certificates(pub(crate) Vec<core::Certificate>);
+
+#[wasm_bindgen]
+
+impl Certificates {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Certificate {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &Certificate) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::Certificate>> for Certificates {
+    fn from(native: Vec<core::Certificate>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::Certificate>> for Certificates {
+    fn into(self) -> Vec<core::Certificate> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct AddrKeyhashs(pub(crate) Vec<core::AddrKeyhash>);
+
+#[wasm_bindgen]
+
+impl AddrKeyhashs {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AddrKeyhash {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &AddrKeyhash) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::AddrKeyhash>> for AddrKeyhashs {
+    fn from(native: Vec<core::AddrKeyhash>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::AddrKeyhash>> for AddrKeyhashs {
+    fn into(self) -> Vec<core::AddrKeyhash> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Relays(pub(crate) Vec<core::Relay>);
+
+#[wasm_bindgen]
+
+impl Relays {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Relay {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &Relay) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::Relay>> for Relays {
+    fn from(native: Vec<core::Relay>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::Relay>> for Relays {
+    fn into(self) -> Vec<core::Relay> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::StakeCredential, core::DeltaCoin>> for MapStakeCredentialToDeltaCoin {
+    fn from(native: OrderedHashMap<core::StakeCredential, core::DeltaCoin>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::StakeCredential, core::DeltaCoin>> for MapStakeCredentialToDeltaCoin {
+    fn into(self) -> OrderedHashMap<core::StakeCredential, core::DeltaCoin> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct StakeCredentials(pub(crate) Vec<core::StakeCredential>);
+
+#[wasm_bindgen]
+
+impl StakeCredentials {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> StakeCredential {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &StakeCredential) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::StakeCredential>> for StakeCredentials {
+    fn from(native: Vec<core::StakeCredential>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::StakeCredential>> for StakeCredentials {
+    fn into(self) -> Vec<core::StakeCredential> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::RewardAccount, core::Coin>> for MapRewardAccountToCoin {
+    fn from(native: OrderedHashMap<core::RewardAccount, core::Coin>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::RewardAccount, core::Coin>> for MapRewardAccountToCoin {
+    fn into(self) -> OrderedHashMap<core::RewardAccount, core::Coin> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct RewardAccounts(pub(crate) Vec<core::RewardAccount>);
+
+#[wasm_bindgen]
+
+impl RewardAccounts {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> RewardAccount {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &RewardAccount) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::RewardAccount>> for RewardAccounts {
+    fn from(native: Vec<core::RewardAccount>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::RewardAccount>> for RewardAccounts {
+    fn into(self) -> Vec<core::RewardAccount> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::Genesishash, core::ProtocolParamUpdate>> for MapGenesishashToProtocolParamUpdate {
+    fn from(native: OrderedHashMap<core::Genesishash, core::ProtocolParamUpdate>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::Genesishash, core::ProtocolParamUpdate>> for MapGenesishashToProtocolParamUpdate {
+    fn into(self) -> OrderedHashMap<core::Genesishash, core::ProtocolParamUpdate> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Genesishashs(pub(crate) Vec<core::Genesishash>);
+
+#[wasm_bindgen]
+
+impl Genesishashs {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Genesishash {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &Genesishash) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::Genesishash>> for Genesishashs {
+    fn from(native: Vec<core::Genesishash>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::Genesishash>> for Genesishashs {
+    fn into(self) -> Vec<core::Genesishash> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Ints(pub(crate) Vec<core::Int>);
+
+#[wasm_bindgen]
+
+impl Ints {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Int {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &Int) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::Int>> for Ints {
+    fn from(native: Vec<core::Int>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::Int>> for Ints {
+    fn into(self) -> Vec<core::Int> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, core::Int64>>> for MapPolicyIdToMapAssetNameToInt64 {
+    fn from(native: OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, core::Int64>>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, core::Int64>>> for MapPolicyIdToMapAssetNameToInt64 {
+    fn into(self) -> OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, core::Int64>> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::AssetName, core::Int64>> for MapAssetNameToInt64 {
+    fn from(native: OrderedHashMap<core::AssetName, core::Int64>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::AssetName, core::Int64>> for MapAssetNameToInt64 {
+    fn into(self) -> OrderedHashMap<core::AssetName, core::Int64> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionWitnessSets(pub(crate) Vec<core::TransactionWitnessSet>);
+
+#[wasm_bindgen]
+
+impl TransactionWitnessSets {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionWitnessSet {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &TransactionWitnessSet) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::TransactionWitnessSet>> for TransactionWitnessSets {
+    fn from(native: Vec<core::TransactionWitnessSet>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::TransactionWitnessSet>> for TransactionWitnessSets {
+    fn into(self) -> Vec<core::TransactionWitnessSet> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Vkeywitnesss(pub(crate) Vec<core::Vkeywitness>);
+
+#[wasm_bindgen]
+
+impl Vkeywitnesss {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Vkeywitness {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &Vkeywitness) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::Vkeywitness>> for Vkeywitnesss {
+    fn from(native: Vec<core::Vkeywitness>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::Vkeywitness>> for Vkeywitnesss {
+    fn into(self) -> Vec<core::Vkeywitness> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct BootstrapWitnesss(pub(crate) Vec<core::BootstrapWitness>);
+
+#[wasm_bindgen]
+
+impl BootstrapWitnesss {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> BootstrapWitness {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &BootstrapWitness) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::BootstrapWitness>> for BootstrapWitnesss {
+    fn from(native: Vec<core::BootstrapWitness>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::BootstrapWitness>> for BootstrapWitnesss {
+    fn into(self) -> Vec<core::BootstrapWitness> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PlutusDatas(pub(crate) Vec<core::PlutusData>);
+
+#[wasm_bindgen]
+
+impl PlutusDatas {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> PlutusData {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &PlutusData) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::PlutusData>> for PlutusDatas {
+    fn from(native: Vec<core::PlutusData>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::PlutusData>> for PlutusDatas {
+    fn into(self) -> Vec<core::PlutusData> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::PlutusData, core::PlutusData>> for MapPlutusDataToPlutusData {
+    fn from(native: OrderedHashMap<core::PlutusData, core::PlutusData>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::PlutusData, core::PlutusData>> for MapPlutusDataToPlutusData {
+    fn into(self) -> OrderedHashMap<core::PlutusData, core::PlutusData> {
+        self.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Redeemers(pub(crate) Vec<core::Redeemer>);
+
+#[wasm_bindgen]
+
+impl Redeemers {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Redeemer {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &Redeemer) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::Redeemer>> for Redeemers {
+    fn from(native: Vec<core::Redeemer>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<Vec<core::Redeemer>> for Redeemers {
+    fn into(self) -> Vec<core::Redeemer> {
+        self.0
+    }
+}
+
+impl From<OrderedHashMap<core::TransactionIndex, core::AuxiliaryData>> for MapTransactionIndexToAuxiliaryData {
+    fn from(native: OrderedHashMap<core::TransactionIndex, core::AuxiliaryData>) -> Self {
+        Self(native)
+    }
+}
+
+impl std::convert::Into<OrderedHashMap<core::TransactionIndex, core::AuxiliaryData>> for MapTransactionIndexToAuxiliaryData {
+    fn into(self) -> OrderedHashMap<core::TransactionIndex, core::AuxiliaryData> {
+        self.0
+    }
+}
+
+pub mod address;
+
+pub use address::*;
+
+
+pub mod block;
+
+pub use block::*;
+
+
+pub mod certs;
+
+pub use certs::*;
+
+
+pub mod crypto;
+
+pub use crypto::*;
+
+
+pub mod metadata;
+
+pub use metadata::*;
+
+
+pub mod plutus;
+
+pub use plutus::*;
+
+
+pub mod transaction;
+
+pub use transaction::*;
+pub type BoundedBytes = Vec<u8>;
+
+pub type Coin = u64;
+
+pub type DeltaCoin = Int;
+
+pub type Epoch = u64;
+
+pub type Int64 = i64;
+
+pub type PolicyId = Hash28;
+
+pub type Port = u16;
+
+pub type SubCoin = PositiveInterval;
+
+pub type TransactionIndex = u16;
+
+pub type TransactionMetadatumLabel = u64;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapTransactionMetadatumLabelToTransactionMetadatum(pub(crate) OrderedHashMap<core::TransactionMetadatumLabel, core::TransactionMetadatum>);
+
+#[wasm_bindgen]
+
+impl MapTransactionMetadatumLabelToTransactionMetadatum {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: TransactionMetadatumLabel, value: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.insert(key, value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: TransactionMetadatumLabel) -> Option<TransactionMetadatum> {
+        self.0.get(&key).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> Vec<TransactionMetadatumLabel> {
+        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>()
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapTransactionMetadatumToTransactionMetadatum(pub(crate) OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum>);
+
+#[wasm_bindgen]
+
+impl MapTransactionMetadatumToTransactionMetadatum {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &TransactionMetadatum, value: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.get(&key.0).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> TransactionMetadatums {
+        TransactionMetadatums(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapPolicyIdToMapAssetNameToU64(pub(crate) OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, u64>>);
+
+#[wasm_bindgen]
+
+impl MapPolicyIdToMapAssetNameToU64 {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &PolicyId, value: &MapAssetNameToU64) -> Option<MapAssetNameToU64> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: &PolicyId) -> Option<MapAssetNameToU64> {
+        self.0.get(&key.0).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> PolicyIds {
+        PolicyIds(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapAssetNameToU64(pub(crate) OrderedHashMap<core::AssetName, u64>);
+
+#[wasm_bindgen]
+
+impl MapAssetNameToU64 {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &AssetName, value: u64) -> Option<u64> {
+        self.0.insert(key.clone().into(), value)
+    }
+
+    pub fn get(&self, key: &AssetName) -> Option<u64> {
+        self.0.get(&key.0).copied()
+    }
+
+    pub fn keys(&self) -> AssetNames {
+        AssetNames(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct AssetName(pub(crate) core::AssetName);
+
+#[wasm_bindgen]
+
+impl AssetName {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<AssetName, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AssetName, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn get(&self) -> Vec<u8> {
+        self.0.get().clone().clone()
+    }
+}
+
+impl From<core::AssetName> for AssetName {
+    fn from(native: core::AssetName) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AssetName> for core::AssetName {
+    fn from(wasm: AssetName) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapStakeCredentialToDeltaCoin(pub(crate) OrderedHashMap<core::StakeCredential, core::DeltaCoin>);
+
+#[wasm_bindgen]
+
+impl MapStakeCredentialToDeltaCoin {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &StakeCredential, value: &DeltaCoin) -> Option<DeltaCoin> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: &StakeCredential) -> Option<DeltaCoin> {
+        self.0.get(&key.0).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> StakeCredentials {
+        StakeCredentials(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapRewardAccountToCoin(pub(crate) OrderedHashMap<core::RewardAccount, core::Coin>);
+
+#[wasm_bindgen]
+
+impl MapRewardAccountToCoin {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &RewardAccount, value: Coin) -> Option<Coin> {
+        self.0.insert(key.clone().into(), value)
+    }
+
+    pub fn get(&self, key: &RewardAccount) -> Option<Coin> {
+        self.0.get(&key.0).copied()
+    }
+
+    pub fn keys(&self) -> RewardAccounts {
+        RewardAccounts(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapGenesishashToProtocolParamUpdate(pub(crate) OrderedHashMap<core::Genesishash, core::ProtocolParamUpdate>);
+
+#[wasm_bindgen]
+
+impl MapGenesishashToProtocolParamUpdate {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &Genesishash, value: &ProtocolParamUpdate) -> Option<ProtocolParamUpdate> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: &Genesishash) -> Option<ProtocolParamUpdate> {
+        self.0.get(&key.0).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> Genesishashs {
+        Genesishashs(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapPolicyIdToMapAssetNameToInt64(pub(crate) OrderedHashMap<core::PolicyId, OrderedHashMap<core::AssetName, core::Int64>>);
+
+#[wasm_bindgen]
+
+impl MapPolicyIdToMapAssetNameToInt64 {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &PolicyId, value: &MapAssetNameToInt64) -> Option<MapAssetNameToInt64> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: &PolicyId) -> Option<MapAssetNameToInt64> {
+        self.0.get(&key.0).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> PolicyIds {
+        PolicyIds(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapAssetNameToInt64(pub(crate) OrderedHashMap<core::AssetName, core::Int64>);
+
+#[wasm_bindgen]
+
+impl MapAssetNameToInt64 {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &AssetName, value: Int64) -> Option<Int64> {
+        self.0.insert(key.clone().into(), value)
+    }
+
+    pub fn get(&self, key: &AssetName) -> Option<Int64> {
+        self.0.get(&key.0).copied()
+    }
+
+    pub fn keys(&self) -> AssetNames {
+        AssetNames(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapPlutusDataToPlutusData(pub(crate) OrderedHashMap<core::PlutusData, core::PlutusData>);
+
+#[wasm_bindgen]
+
+impl MapPlutusDataToPlutusData {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &PlutusData, value: &PlutusData) -> Option<PlutusData> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: &PlutusData) -> Option<PlutusData> {
+        self.0.get(&key.0).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> PlutusDatas {
+        PlutusDatas(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct MapTransactionIndexToAuxiliaryData(pub(crate) OrderedHashMap<core::TransactionIndex, core::AuxiliaryData>);
+
+#[wasm_bindgen]
+
+impl MapTransactionIndexToAuxiliaryData {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: TransactionIndex, value: &AuxiliaryData) -> Option<AuxiliaryData> {
+        self.0.insert(key, value.clone().into()).map(|v| v.clone().into())
+    }
+
+    pub fn get(&self, key: TransactionIndex) -> Option<AuxiliaryData> {
+        self.0.get(&key).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> Vec<TransactionIndex> {
+        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>()
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct BootstrapWitness(pub(crate) core::BootstrapWitness);
+
+#[wasm_bindgen]
+
+impl BootstrapWitness {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<BootstrapWitness, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<BootstrapWitness, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn public_key(&self) -> Vkey {
+        self.0.public_key.clone().into()
+    }
+
+    pub fn signature(&self) -> Signature {
+        self.0.signature.clone().into()
+    }
+
+    pub fn chain_code(&self) -> Vec<u8> {
+        self.0.chain_code.clone()
+    }
+
+    pub fn attributes(&self) -> Vec<u8> {
+        self.0.attributes.clone()
+    }
+
+    pub fn new(public_key: &Vkey, signature: &Signature, chain_code: Vec<u8>, attributes: Vec<u8>) -> Self {
+        Self(core::BootstrapWitness::new(public_key.clone().into(), signature.clone().into(), chain_code, attributes))
+    }
+}
+
+impl From<core::BootstrapWitness> for BootstrapWitness {
+    fn from(native: core::BootstrapWitness) -> Self {
+        Self(native)
+    }
+}
+
+impl From<BootstrapWitness> for core::BootstrapWitness {
+    fn from(wasm: BootstrapWitness) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct DatumOption0(pub(crate) core::DatumOption0);
+
+#[wasm_bindgen]
+
+impl DatumOption0 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<DatumOption0, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<DatumOption0, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn hash32(&self) -> Hash32 {
+        self.0.hash32.clone().into()
+    }
+
+    pub fn new(hash32: &Hash32) -> Self {
+        Self(core::DatumOption0::new(hash32.clone().into()))
+    }
+}
+
+impl From<core::DatumOption0> for DatumOption0 {
+    fn from(native: core::DatumOption0) -> Self {
+        Self(native)
+    }
+}
+
+impl From<DatumOption0> for core::DatumOption0 {
+    fn from(wasm: DatumOption0) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct DatumOption1(pub(crate) core::DatumOption1);
+
+#[wasm_bindgen]
+
+impl DatumOption1 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<DatumOption1, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<DatumOption1, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn data(&self) -> Data {
+        self.0.data.clone()
+    }
+
+    pub fn new(data: Data) -> Self {
+        Self(core::DatumOption1::new(data.into()))
+    }
+}
+
+impl From<core::DatumOption1> for DatumOption1 {
+    fn from(native: core::DatumOption1) -> Self {
+        Self(native)
+    }
+}
+
+impl From<DatumOption1> for core::DatumOption1 {
+    fn from(wasm: DatumOption1) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum I0OrI1Kind {
+    I0,
+    I1,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct I0OrI1(pub(crate) core::I0OrI1);
+
+#[wasm_bindgen]
+
+impl I0OrI1 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<I0OrI1, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<I0OrI1, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_i0() -> Self {
+        Self(core::I0OrI1::new_i0())
+    }
+
+    pub fn new_i1() -> Self {
+        Self(core::I0OrI1::new_i1())
+    }
+
+    pub fn kind(&self) -> I0OrI1Kind {
+        match &self.0 {
+            core::I0OrI1::I0{ .. } => I0OrI1Kind::I0,
+            core::I0OrI1::I1{ .. } => I0OrI1Kind::I1,
+        }
+    }
+}
+
+impl From<core::I0OrI1> for I0OrI1 {
+    fn from(native: core::I0OrI1) -> Self {
+        Self(native)
+    }
+}
+
+impl From<I0OrI1> for core::I0OrI1 {
+    fn from(wasm: I0OrI1) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Int(pub(crate) core::Int);
+
+#[wasm_bindgen]
+
+impl Int {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Int, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Int, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new(x: i64) -> Self {
+        if x >= 0 {
+            Self(core::Int::new_uint(x as u64))
+        }
+        else {
+            Self(core::Int::new_nint((x + 1).abs() as u64))
+        }
+    }
+
+    pub fn to_str(&self) -> String {
+        self.0.to_string()
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(string: &str) -> Result<Int, JsValue> {
+        // have to redefine so it's visible in WASM
+        std::str::FromStr::from_str(string).map(Self).map_err(|e| JsValue::from_str(&format!("Int.from_str({}): {:?}", string, e)))
+    }
+}
+
+impl From<core::Int> for Int {
+    fn from(native: core::Int) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Int> for core::Int {
+    fn from(wasm: Int) -> Self {
+        wasm.0
+    }
+}
+
+type Mint = MapPolicyIdToMapAssetNameToInt64;
+
+type Multiasset = MapPolicyIdToMapAssetNameToU64;
+
+#[wasm_bindgen]
+
+pub enum NetworkIdKind {
+    I0,
+    I1,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct NetworkId(pub(crate) core::NetworkId);
+
+#[wasm_bindgen]
+
+impl NetworkId {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<NetworkId, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<NetworkId, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_i0() -> Self {
+        Self(core::NetworkId::new_i0())
+    }
+
+    pub fn new_i1() -> Self {
+        Self(core::NetworkId::new_i1())
+    }
+
+    pub fn kind(&self) -> NetworkIdKind {
+        match &self.0 {
+            core::NetworkId::I0{ .. } => NetworkIdKind::I0,
+            core::NetworkId::I1{ .. } => NetworkIdKind::I1,
+        }
+    }
+}
+
+impl From<core::NetworkId> for NetworkId {
+    fn from(native: core::NetworkId) -> Self {
+        Self(native)
+    }
+}
+
+impl From<NetworkId> for core::NetworkId {
+    fn from(wasm: NetworkId) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Nonce1(pub(crate) core::Nonce1);
+
+#[wasm_bindgen]
+
+impl Nonce1 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Nonce1, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Nonce1, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn bytes(&self) -> Vec<u8> {
+        self.0.bytes.clone()
+    }
+
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(core::Nonce1::new(bytes))
+    }
+}
+
+impl From<core::Nonce1> for Nonce1 {
+    fn from(native: core::Nonce1) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Nonce1> for core::Nonce1 {
+    fn from(wasm: Nonce1) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PositiveInterval(pub(crate) core::PositiveInterval);
+
+#[wasm_bindgen]
+
+impl PositiveInterval {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PositiveInterval, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<PositiveInterval, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new() -> Self {
+        Self(core::PositiveInterval::new())
+    }
+}
+
+impl From<core::PositiveInterval> for PositiveInterval {
+    fn from(native: core::PositiveInterval) -> Self {
+        Self(native)
+    }
+}
+
+impl From<PositiveInterval> for core::PositiveInterval {
+    fn from(wasm: PositiveInterval) -> Self {
+        wasm.0
+    }
+}
+
+type ProposedProtocolParameterUpdates = MapGenesishashToProtocolParamUpdate;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ProtocolParamUpdate(pub(crate) core::ProtocolParamUpdate);
+
+#[wasm_bindgen]
+
+impl ProtocolParamUpdate {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ProtocolParamUpdate, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ProtocolParamUpdate, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_key_0(&mut self, key_0: u64) {
+        self.0.key_0 = Some(key_0)
+    }
+
+    pub fn key_0(&self) -> Option<u64> {
+        self.0.key_0
+    }
+
+    pub fn set_key_1(&mut self, key_1: u64) {
+        self.0.key_1 = Some(key_1)
+    }
+
+    pub fn key_1(&self) -> Option<u64> {
+        self.0.key_1
+    }
+
+    pub fn set_key_2(&mut self, key_2: u64) {
+        self.0.key_2 = Some(key_2)
+    }
+
+    pub fn key_2(&self) -> Option<u64> {
+        self.0.key_2
+    }
+
+    pub fn set_key_3(&mut self, key_3: u64) {
+        self.0.key_3 = Some(key_3)
+    }
+
+    pub fn key_3(&self) -> Option<u64> {
+        self.0.key_3
+    }
+
+    pub fn set_key_4(&mut self, key_4: u64) {
+        self.0.key_4 = Some(key_4)
+    }
+
+    pub fn key_4(&self) -> Option<u64> {
+        self.0.key_4
+    }
+
+    pub fn set_key_5(&mut self, key_5: Coin) {
+        self.0.key_5 = Some(key_5)
+    }
+
+    pub fn key_5(&self) -> Option<Coin> {
+        self.0.key_5
+    }
+
+    pub fn set_key_6(&mut self, key_6: Coin) {
+        self.0.key_6 = Some(key_6)
+    }
+
+    pub fn key_6(&self) -> Option<Coin> {
+        self.0.key_6
+    }
+
+    pub fn set_key_7(&mut self, key_7: Epoch) {
+        self.0.key_7 = Some(key_7)
+    }
+
+    pub fn key_7(&self) -> Option<Epoch> {
+        self.0.key_7
+    }
+
+    pub fn set_key_8(&mut self, key_8: u64) {
+        self.0.key_8 = Some(key_8)
+    }
+
+    pub fn key_8(&self) -> Option<u64> {
+        self.0.key_8
+    }
+
+    pub fn set_key_9(&mut self, key_9: &Rational) {
+        self.0.key_9 = Some(key_9.clone().into())
+    }
+
+    pub fn key_9(&self) -> Option<Rational> {
+        self.0.key_9.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_10(&mut self, key_10: &UnitInterval) {
+        self.0.key_10 = Some(key_10.clone().into())
+    }
+
+    pub fn key_10(&self) -> Option<UnitInterval> {
+        self.0.key_10.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_11(&mut self, key_11: &UnitInterval) {
+        self.0.key_11 = Some(key_11.clone().into())
+    }
+
+    pub fn key_11(&self) -> Option<UnitInterval> {
+        self.0.key_11.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_14(&mut self, key_14: &ProtocolVersionStruct) {
+        self.0.key_14 = Some(key_14.clone().into())
+    }
+
+    pub fn key_14(&self) -> Option<ProtocolVersionStruct> {
+        self.0.key_14.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_16(&mut self, key_16: Coin) {
+        self.0.key_16 = Some(key_16)
+    }
+
+    pub fn key_16(&self) -> Option<Coin> {
+        self.0.key_16
+    }
+
+    pub fn set_key_17(&mut self, key_17: Coin) {
+        self.0.key_17 = Some(key_17)
+    }
+
+    pub fn key_17(&self) -> Option<Coin> {
+        self.0.key_17
+    }
+
+    pub fn set_key_18(&mut self, key_18: &Costmdls) {
+        self.0.key_18 = Some(key_18.clone().into())
+    }
+
+    pub fn key_18(&self) -> Option<Costmdls> {
+        self.0.key_18.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_19(&mut self, key_19: &ExUnitPrices) {
+        self.0.key_19 = Some(key_19.clone().into())
+    }
+
+    pub fn key_19(&self) -> Option<ExUnitPrices> {
+        self.0.key_19.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_20(&mut self, key_20: &ExUnits) {
+        self.0.key_20 = Some(key_20.clone().into())
+    }
+
+    pub fn key_20(&self) -> Option<ExUnits> {
+        self.0.key_20.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_21(&mut self, key_21: &ExUnits) {
+        self.0.key_21 = Some(key_21.clone().into())
+    }
+
+    pub fn key_21(&self) -> Option<ExUnits> {
+        self.0.key_21.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_22(&mut self, key_22: u64) {
+        self.0.key_22 = Some(key_22)
+    }
+
+    pub fn key_22(&self) -> Option<u64> {
+        self.0.key_22
+    }
+
+    pub fn set_key_23(&mut self, key_23: u64) {
+        self.0.key_23 = Some(key_23)
+    }
+
+    pub fn key_23(&self) -> Option<u64> {
+        self.0.key_23
+    }
+
+    pub fn set_key_24(&mut self, key_24: u64) {
+        self.0.key_24 = Some(key_24)
+    }
+
+    pub fn key_24(&self) -> Option<u64> {
+        self.0.key_24
+    }
+
+    pub fn new() -> Self {
+        Self(core::ProtocolParamUpdate::new())
+    }
+}
+
+impl From<core::ProtocolParamUpdate> for ProtocolParamUpdate {
+    fn from(native: core::ProtocolParamUpdate) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ProtocolParamUpdate> for core::ProtocolParamUpdate {
+    fn from(wasm: ProtocolParamUpdate) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ProtocolVersionStruct(pub(crate) core::ProtocolVersionStruct);
+
+#[wasm_bindgen]
+
+impl ProtocolVersionStruct {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ProtocolVersionStruct, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ProtocolVersionStruct, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.0.protocol_version.clone().into()
+    }
+
+    pub fn new(protocol_version: &ProtocolVersion) -> Self {
+        Self(core::ProtocolVersionStruct::new(protocol_version.clone().into()))
+    }
+}
+
+impl From<core::ProtocolVersionStruct> for ProtocolVersionStruct {
+    fn from(native: core::ProtocolVersionStruct) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ProtocolVersionStruct> for core::ProtocolVersionStruct {
+    fn from(wasm: ProtocolVersionStruct) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Rational(pub(crate) core::Rational);
+
+#[wasm_bindgen]
+
+impl Rational {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Rational, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Rational, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn numerator(&self) -> u64 {
+        self.0.numerator
+    }
+
+    pub fn denominator(&self) -> u64 {
+        self.0.denominator
+    }
+
+    pub fn new(numerator: u64, denominator: u64) -> Self {
+        Self(core::Rational::new(numerator, denominator))
+    }
+}
+
+impl From<core::Rational> for Rational {
+    fn from(native: core::Rational) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Rational> for core::Rational {
+    fn from(wasm: Rational) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Script0(pub(crate) core::Script0);
+
+#[wasm_bindgen]
+
+impl Script0 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Script0, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Script0, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn native_script(&self) -> NativeScript {
+        self.0.native_script.clone().into()
+    }
+
+    pub fn new(native_script: &NativeScript) -> Self {
+        Self(core::Script0::new(native_script.clone().into()))
+    }
+}
+
+impl From<core::Script0> for Script0 {
+    fn from(native: core::Script0) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Script0> for core::Script0 {
+    fn from(wasm: Script0) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Script1(pub(crate) core::Script1);
+
+#[wasm_bindgen]
+
+impl Script1 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Script1, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Script1, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn plutus_v1_script(&self) -> PlutusV1Script {
+        self.0.plutus_v1_script.clone()
+    }
+
+    pub fn new(plutus_v1_script: PlutusV1Script) -> Self {
+        Self(core::Script1::new(plutus_v1_script))
+    }
+}
+
+impl From<core::Script1> for Script1 {
+    fn from(native: core::Script1) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Script1> for core::Script1 {
+    fn from(wasm: Script1) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Script2(pub(crate) core::Script2);
+
+#[wasm_bindgen]
+
+impl Script2 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Script2, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Script2, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn plutus_v2_script(&self) -> PlutusV2Script {
+        self.0.plutus_v2_script.clone()
+    }
+
+    pub fn new(plutus_v2_script: PlutusV2Script) -> Self {
+        Self(core::Script2::new(plutus_v2_script))
+    }
+}
+
+impl From<core::Script2> for Script2 {
+    fn from(native: core::Script2) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Script2> for core::Script2 {
+    fn from(wasm: Script2) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct StakeCredential0(pub(crate) core::StakeCredential0);
+
+#[wasm_bindgen]
+
+impl StakeCredential0 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeCredential0, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<StakeCredential0, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn addr_keyhash(&self) -> AddrKeyhash {
+        self.0.addr_keyhash.clone().into()
+    }
+
+    pub fn new(addr_keyhash: &AddrKeyhash) -> Self {
+        Self(core::StakeCredential0::new(addr_keyhash.clone().into()))
+    }
+}
+
+impl From<core::StakeCredential0> for StakeCredential0 {
+    fn from(native: core::StakeCredential0) -> Self {
+        Self(native)
+    }
+}
+
+impl From<StakeCredential0> for core::StakeCredential0 {
+    fn from(wasm: StakeCredential0) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct StakeCredential1(pub(crate) core::StakeCredential1);
+
+#[wasm_bindgen]
+
+impl StakeCredential1 {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeCredential1, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<StakeCredential1, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn scripthash(&self) -> Scripthash {
+        self.0.scripthash.clone().into()
+    }
+
+    pub fn new(scripthash: &Scripthash) -> Self {
+        Self(core::StakeCredential1::new(scripthash.clone().into()))
+    }
+}
+
+impl From<core::StakeCredential1> for StakeCredential1 {
+    fn from(native: core::StakeCredential1) -> Self {
+        Self(native)
+    }
+}
+
+impl From<StakeCredential1> for core::StakeCredential1 {
+    fn from(wasm: StakeCredential1) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct UnitInterval(pub(crate) core::UnitInterval);
+
+#[wasm_bindgen]
+
+impl UnitInterval {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<UnitInterval, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<UnitInterval, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn index_0(&self) -> u64 {
+        self.0.index_0
+    }
+
+    pub fn index_1(&self) -> u64 {
+        self.0.index_1
+    }
+
+    pub fn new(index_0: u64, index_1: u64) -> Self {
+        Self(core::UnitInterval::new(index_0, index_1))
+    }
+}
+
+impl From<core::UnitInterval> for UnitInterval {
+    fn from(native: core::UnitInterval) -> Self {
+        Self(native)
+    }
+}
+
+impl From<UnitInterval> for core::UnitInterval {
+    fn from(wasm: UnitInterval) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Update(pub(crate) core::Update);
+
+#[wasm_bindgen]
+
+impl Update {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Update, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Update, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn proposed_protocol_parameter_updates(&self) -> ProposedProtocolParameterUpdates {
+        self.0.proposed_protocol_parameter_updates.clone().into()
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.0.epoch
+    }
+
+    pub fn new(proposed_protocol_parameter_updates: ProposedProtocolParameterUpdates, epoch: Epoch) -> Self {
+        Self(core::Update::new(proposed_protocol_parameter_updates.clone().into(), epoch))
+    }
+}
+
+impl From<core::Update> for Update {
+    fn from(native: core::Update) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Update> for core::Update {
+    fn from(wasm: Update) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Value(pub(crate) core::Value);
+
+#[wasm_bindgen]
+
+impl Value {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Value, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Value, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn coin(&self) -> Coin {
+        self.0.coin
+    }
+
+    pub fn multiasset(&self) -> Multiasset {
+        self.0.multiasset.clone().into()
+    }
+
+    pub fn new(coin: Coin, multiasset: Multiasset) -> Self {
+        Self(core::Value::new(coin, multiasset.clone().into()))
+    }
+}
+
+impl From<core::Value> for Value {
+    fn from(native: core::Value) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Value> for core::Value {
+    fn from(wasm: Value) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Vkeywitness(pub(crate) core::Vkeywitness);
+
+#[wasm_bindgen]
+
+impl Vkeywitness {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Vkeywitness, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Vkeywitness, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn vkey(&self) -> Vkey {
+        self.0.vkey.clone().into()
+    }
+
+    pub fn signature(&self) -> Signature {
+        self.0.signature.clone().into()
+    }
+
+    pub fn new(vkey: &Vkey, signature: &Signature) -> Self {
+        Self(core::Vkeywitness::new(vkey.clone().into(), signature.clone().into()))
+    }
+}
+
+impl From<core::Vkeywitness> for Vkeywitness {
+    fn from(native: core::Vkeywitness) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Vkeywitness> for core::Vkeywitness {
+    fn from(wasm: Vkeywitness) -> Self {
+        wasm.0
+    }
+}
+
+type Withdrawals = MapRewardAccountToCoin;

--- a/rust/wasm/src/metadata.rs
+++ b/rust/wasm/src/metadata.rs
@@ -1,0 +1,349 @@
+pub type ShelleyAuxData = MapTransactionMetadatumLabelToTransactionMetadatum;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct AlonzoAuxData(pub(crate) core::AlonzoAuxData);
+
+#[wasm_bindgen]
+
+impl AlonzoAuxData {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<AlonzoAuxData, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoAuxData, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_key_0(&mut self, key_0: Metadata) {
+        self.0.key_0 = Some(key_0.clone().into())
+    }
+
+    pub fn key_0(&self) -> Option<Metadata> {
+        self.0.key_0.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_1(&mut self, key_1: &NativeScripts) {
+        self.0.key_1 = Some(key_1.clone().into())
+    }
+
+    pub fn key_1(&self) -> Option<NativeScripts> {
+        self.0.key_1.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_2(&mut self, key_2: &PlutusV1Scripts) {
+        self.0.key_2 = Some(key_2.clone().into())
+    }
+
+    pub fn key_2(&self) -> Option<PlutusV1Scripts> {
+        self.0.key_2.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_3(&mut self, key_3: &PlutusV2Scripts) {
+        self.0.key_3 = Some(key_3.clone().into())
+    }
+
+    pub fn key_3(&self) -> Option<PlutusV2Scripts> {
+        self.0.key_3.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new() -> Self {
+        Self(core::AlonzoAuxData::new())
+    }
+}
+
+impl From<core::AlonzoAuxData> for AlonzoAuxData {
+    fn from(native: core::AlonzoAuxData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoAuxData> for core::AlonzoAuxData {
+    fn from(wasm: AlonzoAuxData) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum AuxiliaryDataKind {
+    ShelleyAuxData,
+    ShelleyMaAuxData,
+    AlonzoAuxData,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct AuxiliaryData(pub(crate) core::AuxiliaryData);
+
+#[wasm_bindgen]
+
+impl AuxiliaryData {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<AuxiliaryData, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AuxiliaryData, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_shelley_aux_data(shelley_aux_data: ShelleyAuxData) -> Self {
+        Self(core::AuxiliaryData::new_shelley_aux_data(shelley_aux_data.clone().into()))
+    }
+
+    pub fn new_shelley_ma_aux_data(shelley_ma_aux_data: &ShelleyMaAuxData) -> Self {
+        Self(core::AuxiliaryData::new_shelley_ma_aux_data(shelley_ma_aux_data.clone().into()))
+    }
+
+    pub fn new_alonzo_aux_data(alonzo_aux_data: &AlonzoAuxData) -> Self {
+        Self(core::AuxiliaryData::new_alonzo_aux_data(alonzo_aux_data.clone().into()))
+    }
+
+    pub fn kind(&self) -> AuxiliaryDataKind {
+        match &self.0 {
+            core::AuxiliaryData::ShelleyAuxData{ .. } => AuxiliaryDataKind::ShelleyAuxData,
+            core::AuxiliaryData::ShelleyMaAuxData(_) => AuxiliaryDataKind::ShelleyMaAuxData,
+            core::AuxiliaryData::AlonzoAuxData(_) => AuxiliaryDataKind::AlonzoAuxData,
+        }
+    }
+
+    pub fn as_shelley_aux_data(&self) -> Option<ShelleyAuxData> {
+        match &self.0 {
+            core::AuxiliaryData::ShelleyAuxData{ shelley_aux_data, .. } => Some(shelley_aux_data.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_shelley_ma_aux_data(&self) -> Option<ShelleyMaAuxData> {
+        match &self.0 {
+            core::AuxiliaryData::ShelleyMaAuxData(shelley_ma_aux_data) => Some(shelley_ma_aux_data.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_alonzo_aux_data(&self) -> Option<AlonzoAuxData> {
+        match &self.0 {
+            core::AuxiliaryData::AlonzoAuxData(alonzo_aux_data) => Some(alonzo_aux_data.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::AuxiliaryData> for AuxiliaryData {
+    fn from(native: core::AuxiliaryData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AuxiliaryData> for core::AuxiliaryData {
+    fn from(wasm: AuxiliaryData) -> Self {
+        wasm.0
+    }
+}
+
+type Metadata = MapTransactionMetadatumLabelToTransactionMetadatum;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ShelleyMaAuxData(pub(crate) core::ShelleyMaAuxData);
+
+#[wasm_bindgen]
+
+impl ShelleyMaAuxData {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ShelleyMaAuxData, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyMaAuxData, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn transaction_metadata(&self) -> Metadata {
+        self.0.transaction_metadata.clone().into()
+    }
+
+    pub fn auxiliary_scripts(&self) -> NativeScripts {
+        self.0.auxiliary_scripts.clone().into()
+    }
+
+    pub fn new(transaction_metadata: Metadata, auxiliary_scripts: &NativeScripts) -> Self {
+        Self(core::ShelleyMaAuxData::new(transaction_metadata.clone().into(), auxiliary_scripts.clone().into()))
+    }
+}
+
+impl From<core::ShelleyMaAuxData> for ShelleyMaAuxData {
+    fn from(native: core::ShelleyMaAuxData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyMaAuxData> for core::ShelleyMaAuxData {
+    fn from(wasm: ShelleyMaAuxData) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum TransactionMetadatumKind {
+    MapTransactionMetadatumToTransactionMetadatum,
+    ArrTransactionMetadatum,
+    Int,
+    Bytes,
+    Text,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionMetadatum(pub(crate) core::TransactionMetadatum);
+
+#[wasm_bindgen]
+
+impl TransactionMetadatum {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionMetadatum, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<TransactionMetadatum, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_map_transaction_metadatum_to_transaction_metadatum(map_transaction_metadatum_to_transaction_metadatum: &MapTransactionMetadatumToTransactionMetadatum) -> Self {
+        Self(core::TransactionMetadatum::new_map_transaction_metadatum_to_transaction_metadatum(map_transaction_metadatum_to_transaction_metadatum.clone().into()))
+    }
+
+    pub fn new_arr_transaction_metadatum(arr_transaction_metadatum: &TransactionMetadatums) -> Self {
+        Self(core::TransactionMetadatum::new_arr_transaction_metadatum(arr_transaction_metadatum.clone().into()))
+    }
+
+    pub fn new_int(int: &Int) -> Self {
+        Self(core::TransactionMetadatum::new_int(int.clone().into()))
+    }
+
+    pub fn new_bytes(bytes: Vec<u8>) -> Self {
+        Self(core::TransactionMetadatum::new_bytes(bytes))
+    }
+
+    pub fn new_text(text: String) -> Self {
+        Self(core::TransactionMetadatum::new_text(text))
+    }
+
+    pub fn kind(&self) -> TransactionMetadatumKind {
+        match &self.0 {
+            core::TransactionMetadatum::MapTransactionMetadatumToTransactionMetadatum{ .. } => TransactionMetadatumKind::MapTransactionMetadatumToTransactionMetadatum,
+            core::TransactionMetadatum::ArrTransactionMetadatum{ .. } => TransactionMetadatumKind::ArrTransactionMetadatum,
+            core::TransactionMetadatum::Int(_) => TransactionMetadatumKind::Int,
+            core::TransactionMetadatum::Bytes{ .. } => TransactionMetadatumKind::Bytes,
+            core::TransactionMetadatum::Text{ .. } => TransactionMetadatumKind::Text,
+        }
+    }
+
+    pub fn as_map_transaction_metadatum_to_transaction_metadatum(&self) -> Option<MapTransactionMetadatumToTransactionMetadatum> {
+        match &self.0 {
+            core::TransactionMetadatum::MapTransactionMetadatumToTransactionMetadatum{ map_transaction_metadatum_to_transaction_metadatum, .. } => Some(map_transaction_metadatum_to_transaction_metadatum.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_arr_transaction_metadatum(&self) -> Option<TransactionMetadatums> {
+        match &self.0 {
+            core::TransactionMetadatum::ArrTransactionMetadatum{ arr_transaction_metadatum, .. } => Some(arr_transaction_metadatum.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_int(&self) -> Option<Int> {
+        match &self.0 {
+            core::TransactionMetadatum::Int(int) => Some(int.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_bytes(&self) -> Option<Vec<u8>> {
+        match &self.0 {
+            core::TransactionMetadatum::Bytes{ bytes, .. } => Some(bytes.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_text(&self) -> Option<String> {
+        match &self.0 {
+            core::TransactionMetadatum::Text{ text, .. } => Some(text.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::TransactionMetadatum> for TransactionMetadatum {
+    fn from(native: core::TransactionMetadatum) -> Self {
+        Self(native)
+    }
+}
+
+impl From<TransactionMetadatum> for core::TransactionMetadatum {
+    fn from(wasm: TransactionMetadatum) -> Self {
+        wasm.0
+    }
+}
+
+use super::*;

--- a/rust/wasm/src/plutus.rs
+++ b/rust/wasm/src/plutus.rs
@@ -1,0 +1,603 @@
+pub type PlutusV1Script = Vec<u8>;
+
+pub type PlutusV2Script = Vec<u8>;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct BigInt(pub(crate) core::BigInt);
+
+#[wasm_bindgen]
+
+impl BigInt {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<BigInt, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<BigInt, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new() -> Self {
+        Self(core::BigInt::new())
+    }
+}
+
+impl From<core::BigInt> for BigInt {
+    fn from(native: core::BigInt) -> Self {
+        Self(native)
+    }
+}
+
+impl From<BigInt> for core::BigInt {
+    fn from(wasm: BigInt) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ConstrPlutusData(pub(crate) core::ConstrPlutusData);
+
+#[wasm_bindgen]
+
+impl ConstrPlutusData {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ConstrPlutusData, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ConstrPlutusData, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn index_0(&self) -> u64 {
+        self.0.index_0
+    }
+
+    pub fn plutus_datas(&self) -> PlutusDatas {
+        self.0.plutus_datas.clone().into()
+    }
+
+    pub fn new(index_0: u64, plutus_datas: &PlutusDatas) -> Self {
+        Self(core::ConstrPlutusData::new(index_0, plutus_datas.clone().into()))
+    }
+}
+
+impl From<core::ConstrPlutusData> for ConstrPlutusData {
+    fn from(native: core::ConstrPlutusData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ConstrPlutusData> for core::ConstrPlutusData {
+    fn from(wasm: ConstrPlutusData) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Costmdls(pub(crate) core::Costmdls);
+
+#[wasm_bindgen]
+
+impl Costmdls {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Costmdls, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Costmdls, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_key_0(&mut self, key_0: &Ints) {
+        self.0.key_0 = Some(key_0.clone().into())
+    }
+
+    pub fn key_0(&self) -> Option<Ints> {
+        self.0.key_0.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_1(&mut self, key_1: &Ints) {
+        self.0.key_1 = Some(key_1.clone().into())
+    }
+
+    pub fn key_1(&self) -> Option<Ints> {
+        self.0.key_1.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new() -> Self {
+        Self(core::Costmdls::new())
+    }
+}
+
+impl From<core::Costmdls> for Costmdls {
+    fn from(native: core::Costmdls) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Costmdls> for core::Costmdls {
+    fn from(wasm: Costmdls) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ExUnitPrices(pub(crate) core::ExUnitPrices);
+
+#[wasm_bindgen]
+
+impl ExUnitPrices {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ExUnitPrices, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ExUnitPrices, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn mem_price(&self) -> SubCoin {
+        self.0.mem_price.clone().into()
+    }
+
+    pub fn step_price(&self) -> SubCoin {
+        self.0.step_price.clone().into()
+    }
+
+    pub fn new(mem_price: &SubCoin, step_price: &SubCoin) -> Self {
+        Self(core::ExUnitPrices::new(mem_price.clone().into(), step_price.clone().into()))
+    }
+}
+
+impl From<core::ExUnitPrices> for ExUnitPrices {
+    fn from(native: core::ExUnitPrices) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ExUnitPrices> for core::ExUnitPrices {
+    fn from(wasm: ExUnitPrices) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ExUnits(pub(crate) core::ExUnits);
+
+#[wasm_bindgen]
+
+impl ExUnits {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ExUnits, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ExUnits, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn mem(&self) -> u64 {
+        self.0.mem
+    }
+
+    pub fn steps(&self) -> u64 {
+        self.0.steps
+    }
+
+    pub fn new(mem: u64, steps: u64) -> Self {
+        Self(core::ExUnits::new(mem, steps))
+    }
+}
+
+impl From<core::ExUnits> for ExUnits {
+    fn from(native: core::ExUnits) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ExUnits> for core::ExUnits {
+    fn from(wasm: ExUnits) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum LanguageKind {
+    I0,
+    I1,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Language(pub(crate) core::Language);
+
+#[wasm_bindgen]
+
+impl Language {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Language, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Language, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_i0() -> Self {
+        Self(core::Language::new_i0())
+    }
+
+    pub fn new_i1() -> Self {
+        Self(core::Language::new_i1())
+    }
+
+    pub fn kind(&self) -> LanguageKind {
+        match &self.0 {
+            core::Language::I0{ .. } => LanguageKind::I0,
+            core::Language::I1{ .. } => LanguageKind::I1,
+        }
+    }
+}
+
+impl From<core::Language> for Language {
+    fn from(native: core::Language) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Language> for core::Language {
+    fn from(wasm: Language) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum PlutusDataKind {
+    ConstrPlutusData,
+    MapPlutusDataToPlutusData,
+    ArrPlutusData,
+    BigInt,
+    BoundedBytes,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct PlutusData(pub(crate) core::PlutusData);
+
+#[wasm_bindgen]
+
+impl PlutusData {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PlutusData, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<PlutusData, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_constr_plutus_data(constr_plutus_data: &ConstrPlutusData) -> Self {
+        Self(core::PlutusData::new_constr_plutus_data(constr_plutus_data.clone().into()))
+    }
+
+    pub fn new_map_plutus_data_to_plutus_data(map_plutus_data_to_plutus_data: &MapPlutusDataToPlutusData) -> Self {
+        Self(core::PlutusData::new_map_plutus_data_to_plutus_data(map_plutus_data_to_plutus_data.clone().into()))
+    }
+
+    pub fn new_arr_plutus_data(arr_plutus_data: &PlutusDatas) -> Self {
+        Self(core::PlutusData::new_arr_plutus_data(arr_plutus_data.clone().into()))
+    }
+
+    pub fn new_big_int(big_int: &BigInt) -> Self {
+        Self(core::PlutusData::new_big_int(big_int.clone().into()))
+    }
+
+    pub fn new_bounded_bytes(bounded_bytes: BoundedBytes) -> Self {
+        Self(core::PlutusData::new_bounded_bytes(bounded_bytes))
+    }
+
+    pub fn kind(&self) -> PlutusDataKind {
+        match &self.0 {
+            core::PlutusData::ConstrPlutusData(_) => PlutusDataKind::ConstrPlutusData,
+            core::PlutusData::MapPlutusDataToPlutusData{ .. } => PlutusDataKind::MapPlutusDataToPlutusData,
+            core::PlutusData::ArrPlutusData{ .. } => PlutusDataKind::ArrPlutusData,
+            core::PlutusData::BigInt(_) => PlutusDataKind::BigInt,
+            core::PlutusData::BoundedBytes{ .. } => PlutusDataKind::BoundedBytes,
+        }
+    }
+
+    pub fn as_constr_plutus_data(&self) -> Option<ConstrPlutusData> {
+        match &self.0 {
+            core::PlutusData::ConstrPlutusData(constr_plutus_data) => Some(constr_plutus_data.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_map_plutus_data_to_plutus_data(&self) -> Option<MapPlutusDataToPlutusData> {
+        match &self.0 {
+            core::PlutusData::MapPlutusDataToPlutusData{ map_plutus_data_to_plutus_data, .. } => Some(map_plutus_data_to_plutus_data.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_arr_plutus_data(&self) -> Option<PlutusDatas> {
+        match &self.0 {
+            core::PlutusData::ArrPlutusData{ arr_plutus_data, .. } => Some(arr_plutus_data.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_big_int(&self) -> Option<BigInt> {
+        match &self.0 {
+            core::PlutusData::BigInt(big_int) => Some(big_int.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_bounded_bytes(&self) -> Option<BoundedBytes> {
+        match &self.0 {
+            core::PlutusData::BoundedBytes{ bounded_bytes, .. } => Some(bounded_bytes.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::PlutusData> for PlutusData {
+    fn from(native: core::PlutusData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<PlutusData> for core::PlutusData {
+    fn from(wasm: PlutusData) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Redeemer(pub(crate) core::Redeemer);
+
+#[wasm_bindgen]
+
+impl Redeemer {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Redeemer, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Redeemer, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn tag(&self) -> RedeemerTag {
+        self.0.tag.clone().into()
+    }
+
+    pub fn index(&self) -> u64 {
+        self.0.index
+    }
+
+    pub fn data(&self) -> PlutusData {
+        self.0.data.clone().into()
+    }
+
+    pub fn ex_units(&self) -> ExUnits {
+        self.0.ex_units.clone().into()
+    }
+
+    pub fn new(tag: &RedeemerTag, index: u64, data: &PlutusData, ex_units: &ExUnits) -> Self {
+        Self(core::Redeemer::new(tag.clone().into(), index, data.clone().into(), ex_units.clone().into()))
+    }
+}
+
+impl From<core::Redeemer> for Redeemer {
+    fn from(native: core::Redeemer) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Redeemer> for core::Redeemer {
+    fn from(wasm: Redeemer) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum RedeemerTagKind {
+    I0,
+    I1,
+    I2,
+    I3,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct RedeemerTag(pub(crate) core::RedeemerTag);
+
+#[wasm_bindgen]
+
+impl RedeemerTag {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<RedeemerTag, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<RedeemerTag, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_i0() -> Self {
+        Self(core::RedeemerTag::new_i0())
+    }
+
+    pub fn new_i1() -> Self {
+        Self(core::RedeemerTag::new_i1())
+    }
+
+    pub fn new_i2() -> Self {
+        Self(core::RedeemerTag::new_i2())
+    }
+
+    pub fn new_i3() -> Self {
+        Self(core::RedeemerTag::new_i3())
+    }
+
+    pub fn kind(&self) -> RedeemerTagKind {
+        match &self.0 {
+            core::RedeemerTag::I0{ .. } => RedeemerTagKind::I0,
+            core::RedeemerTag::I1{ .. } => RedeemerTagKind::I1,
+            core::RedeemerTag::I2{ .. } => RedeemerTagKind::I2,
+            core::RedeemerTag::I3{ .. } => RedeemerTagKind::I3,
+        }
+    }
+}
+
+impl From<core::RedeemerTag> for RedeemerTag {
+    fn from(native: core::RedeemerTag) -> Self {
+        Self(native)
+    }
+}
+
+impl From<RedeemerTag> for core::RedeemerTag {
+    fn from(wasm: RedeemerTag) -> Self {
+        wasm.0
+    }
+}
+
+use super::*;

--- a/rust/wasm/src/transaction.rs
+++ b/rust/wasm/src/transaction.rs
@@ -1,0 +1,1339 @@
+pub type Data = Vec<u8>;
+
+pub type ScriptDataHash = Hash32;
+
+pub type ScriptRef = Vec<u8>;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct AlonzoTxOut(pub(crate) core::AlonzoTxOut);
+
+#[wasm_bindgen]
+
+impl AlonzoTxOut {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<AlonzoTxOut, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoTxOut, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn address(&self) -> Address {
+        self.0.address.clone().into()
+    }
+
+    pub fn amount(&self) -> Value {
+        self.0.amount.clone().into()
+    }
+
+    pub fn datum_hash(&self) -> Hash32 {
+        self.0.datum_hash.clone().into()
+    }
+
+    pub fn new(address: &Address, amount: &Value, datum_hash: &Hash32) -> Self {
+        Self(core::AlonzoTxOut::new(address.clone().into(), amount.clone().into(), datum_hash.clone().into()))
+    }
+}
+
+impl From<core::AlonzoTxOut> for AlonzoTxOut {
+    fn from(native: core::AlonzoTxOut) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTxOut> for core::AlonzoTxOut {
+    fn from(wasm: AlonzoTxOut) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct BabbageTxOut(pub(crate) core::BabbageTxOut);
+
+#[wasm_bindgen]
+
+impl BabbageTxOut {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<BabbageTxOut, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<BabbageTxOut, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn key_0(&self) -> Address {
+        self.0.key_0.clone().into()
+    }
+
+    pub fn key_1(&self) -> Value {
+        self.0.key_1.clone().into()
+    }
+
+    pub fn set_key_2(&mut self, key_2: &DatumOption) {
+        self.0.key_2 = Some(key_2.clone().into())
+    }
+
+    pub fn key_2(&self) -> Option<DatumOption> {
+        self.0.key_2.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_3(&mut self, key_3: ScriptRef) {
+        self.0.key_3 = Some(key_3.into())
+    }
+
+    pub fn key_3(&self) -> Option<ScriptRef> {
+        self.0.key_3.clone()
+    }
+
+    pub fn new(key_0: &Address, key_1: &Value) -> Self {
+        Self(core::BabbageTxOut::new(key_0.clone().into(), key_1.clone().into()))
+    }
+}
+
+impl From<core::BabbageTxOut> for BabbageTxOut {
+    fn from(native: core::BabbageTxOut) -> Self {
+        Self(native)
+    }
+}
+
+impl From<BabbageTxOut> for core::BabbageTxOut {
+    fn from(wasm: BabbageTxOut) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum DatumOptionKind {
+    DatumOption0,
+    DatumOption1,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct DatumOption(pub(crate) core::DatumOption);
+
+#[wasm_bindgen]
+
+impl DatumOption {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<DatumOption, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<DatumOption, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_datum_option0(hash32: &Hash32) -> Self {
+        Self(core::DatumOption::new_datum_option0(hash32.clone().into()))
+    }
+
+    pub fn new_datum_option1(data: Data) -> Self {
+        Self(core::DatumOption::new_datum_option1(data.into()))
+    }
+
+    pub fn kind(&self) -> DatumOptionKind {
+        match &self.0 {
+            core::DatumOption::DatumOption0(_) => DatumOptionKind::DatumOption0,
+            core::DatumOption::DatumOption1(_) => DatumOptionKind::DatumOption1,
+        }
+    }
+
+    pub fn as_datum_option0(&self) -> Option<DatumOption0> {
+        match &self.0 {
+            core::DatumOption::DatumOption0(datum_option0) => Some(datum_option0.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_datum_option1(&self) -> Option<DatumOption1> {
+        match &self.0 {
+            core::DatumOption::DatumOption1(datum_option1) => Some(datum_option1.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::DatumOption> for DatumOption {
+    fn from(native: core::DatumOption) -> Self {
+        Self(native)
+    }
+}
+
+impl From<DatumOption> for core::DatumOption {
+    fn from(wasm: DatumOption) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct InvalidBefore(pub(crate) core::InvalidBefore);
+
+#[wasm_bindgen]
+
+impl InvalidBefore {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<InvalidBefore, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<InvalidBefore, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn index_1(&self) -> u64 {
+        self.0.index_1
+    }
+
+    pub fn new(index_1: u64) -> Self {
+        Self(core::InvalidBefore::new(index_1))
+    }
+}
+
+impl From<core::InvalidBefore> for InvalidBefore {
+    fn from(native: core::InvalidBefore) -> Self {
+        Self(native)
+    }
+}
+
+impl From<InvalidBefore> for core::InvalidBefore {
+    fn from(wasm: InvalidBefore) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct InvalidHereafter(pub(crate) core::InvalidHereafter);
+
+#[wasm_bindgen]
+
+impl InvalidHereafter {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<InvalidHereafter, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<InvalidHereafter, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn index_1(&self) -> u64 {
+        self.0.index_1
+    }
+
+    pub fn new(index_1: u64) -> Self {
+        Self(core::InvalidHereafter::new(index_1))
+    }
+}
+
+impl From<core::InvalidHereafter> for InvalidHereafter {
+    fn from(native: core::InvalidHereafter) -> Self {
+        Self(native)
+    }
+}
+
+impl From<InvalidHereafter> for core::InvalidHereafter {
+    fn from(wasm: InvalidHereafter) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum NativeScriptKind {
+    ScriptPubkey,
+    ScriptAll,
+    ScriptAny,
+    ScriptNOfK,
+    InvalidBefore,
+    InvalidHereafter,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct NativeScript(pub(crate) core::NativeScript);
+
+#[wasm_bindgen]
+
+impl NativeScript {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<NativeScript, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<NativeScript, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_script_pubkey(addr_keyhash: &AddrKeyhash) -> Self {
+        Self(core::NativeScript::new_script_pubkey(addr_keyhash.clone().into()))
+    }
+
+    pub fn new_script_all(native_scripts: &NativeScripts) -> Self {
+        Self(core::NativeScript::new_script_all(native_scripts.clone().into()))
+    }
+
+    pub fn new_script_any(native_scripts: &NativeScripts) -> Self {
+        Self(core::NativeScript::new_script_any(native_scripts.clone().into()))
+    }
+
+    pub fn new_script_n_of_k(n: u64, native_scripts: &NativeScripts) -> Self {
+        Self(core::NativeScript::new_script_n_of_k(n, native_scripts.clone().into()))
+    }
+
+    pub fn new_invalid_before(index_1: u64) -> Self {
+        Self(core::NativeScript::new_invalid_before(index_1))
+    }
+
+    pub fn new_invalid_hereafter(index_1: u64) -> Self {
+        Self(core::NativeScript::new_invalid_hereafter(index_1))
+    }
+
+    pub fn kind(&self) -> NativeScriptKind {
+        match &self.0 {
+            core::NativeScript::ScriptPubkey(_) => NativeScriptKind::ScriptPubkey,
+            core::NativeScript::ScriptAll(_) => NativeScriptKind::ScriptAll,
+            core::NativeScript::ScriptAny(_) => NativeScriptKind::ScriptAny,
+            core::NativeScript::ScriptNOfK(_) => NativeScriptKind::ScriptNOfK,
+            core::NativeScript::InvalidBefore(_) => NativeScriptKind::InvalidBefore,
+            core::NativeScript::InvalidHereafter(_) => NativeScriptKind::InvalidHereafter,
+        }
+    }
+
+    pub fn as_script_pubkey(&self) -> Option<ScriptPubkey> {
+        match &self.0 {
+            core::NativeScript::ScriptPubkey(script_pubkey) => Some(script_pubkey.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_script_all(&self) -> Option<ScriptAll> {
+        match &self.0 {
+            core::NativeScript::ScriptAll(script_all) => Some(script_all.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_script_any(&self) -> Option<ScriptAny> {
+        match &self.0 {
+            core::NativeScript::ScriptAny(script_any) => Some(script_any.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_script_n_of_k(&self) -> Option<ScriptNOfK> {
+        match &self.0 {
+            core::NativeScript::ScriptNOfK(script_n_of_k) => Some(script_n_of_k.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_invalid_before(&self) -> Option<InvalidBefore> {
+        match &self.0 {
+            core::NativeScript::InvalidBefore(invalid_before) => Some(invalid_before.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_invalid_hereafter(&self) -> Option<InvalidHereafter> {
+        match &self.0 {
+            core::NativeScript::InvalidHereafter(invalid_hereafter) => Some(invalid_hereafter.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::NativeScript> for NativeScript {
+    fn from(native: core::NativeScript) -> Self {
+        Self(native)
+    }
+}
+
+impl From<NativeScript> for core::NativeScript {
+    fn from(wasm: NativeScript) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct RequiredSigners(pub(crate) core::RequiredSigners);
+
+#[wasm_bindgen]
+
+impl RequiredSigners {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<RequiredSigners, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<RequiredSigners, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn addr_keyhash(&self) -> AddrKeyhash {
+        self.0.addr_keyhash.clone().into()
+    }
+
+    pub fn new(addr_keyhash: &AddrKeyhash) -> Self {
+        Self(core::RequiredSigners::new(addr_keyhash.clone().into()))
+    }
+}
+
+impl From<core::RequiredSigners> for RequiredSigners {
+    fn from(native: core::RequiredSigners) -> Self {
+        Self(native)
+    }
+}
+
+impl From<RequiredSigners> for core::RequiredSigners {
+    fn from(wasm: RequiredSigners) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum ScriptKind {
+    Script0,
+    Script1,
+    Script2,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Script(pub(crate) core::Script);
+
+#[wasm_bindgen]
+
+impl Script {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Script, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Script, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_script0(native_script: &NativeScript) -> Self {
+        Self(core::Script::new_script0(native_script.clone().into()))
+    }
+
+    pub fn new_script1(plutus_v1_script: PlutusV1Script) -> Self {
+        Self(core::Script::new_script1(plutus_v1_script))
+    }
+
+    pub fn new_script2(plutus_v2_script: PlutusV2Script) -> Self {
+        Self(core::Script::new_script2(plutus_v2_script))
+    }
+
+    pub fn kind(&self) -> ScriptKind {
+        match &self.0 {
+            core::Script::Script0(_) => ScriptKind::Script0,
+            core::Script::Script1(_) => ScriptKind::Script1,
+            core::Script::Script2(_) => ScriptKind::Script2,
+        }
+    }
+
+    pub fn as_script0(&self) -> Option<Script0> {
+        match &self.0 {
+            core::Script::Script0(script0) => Some(script0.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_script1(&self) -> Option<Script1> {
+        match &self.0 {
+            core::Script::Script1(script1) => Some(script1.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_script2(&self) -> Option<Script2> {
+        match &self.0 {
+            core::Script::Script2(script2) => Some(script2.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::Script> for Script {
+    fn from(native: core::Script) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Script> for core::Script {
+    fn from(wasm: Script) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ScriptAll(pub(crate) core::ScriptAll);
+
+#[wasm_bindgen]
+
+impl ScriptAll {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ScriptAll, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ScriptAll, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn native_scripts(&self) -> NativeScripts {
+        self.0.native_scripts.clone().into()
+    }
+
+    pub fn new(native_scripts: &NativeScripts) -> Self {
+        Self(core::ScriptAll::new(native_scripts.clone().into()))
+    }
+}
+
+impl From<core::ScriptAll> for ScriptAll {
+    fn from(native: core::ScriptAll) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ScriptAll> for core::ScriptAll {
+    fn from(wasm: ScriptAll) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ScriptAny(pub(crate) core::ScriptAny);
+
+#[wasm_bindgen]
+
+impl ScriptAny {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ScriptAny, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ScriptAny, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn native_scripts(&self) -> NativeScripts {
+        self.0.native_scripts.clone().into()
+    }
+
+    pub fn new(native_scripts: &NativeScripts) -> Self {
+        Self(core::ScriptAny::new(native_scripts.clone().into()))
+    }
+}
+
+impl From<core::ScriptAny> for ScriptAny {
+    fn from(native: core::ScriptAny) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ScriptAny> for core::ScriptAny {
+    fn from(wasm: ScriptAny) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ScriptNOfK(pub(crate) core::ScriptNOfK);
+
+#[wasm_bindgen]
+
+impl ScriptNOfK {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ScriptNOfK, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ScriptNOfK, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn n(&self) -> u64 {
+        self.0.n
+    }
+
+    pub fn native_scripts(&self) -> NativeScripts {
+        self.0.native_scripts.clone().into()
+    }
+
+    pub fn new(n: u64, native_scripts: &NativeScripts) -> Self {
+        Self(core::ScriptNOfK::new(n, native_scripts.clone().into()))
+    }
+}
+
+impl From<core::ScriptNOfK> for ScriptNOfK {
+    fn from(native: core::ScriptNOfK) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ScriptNOfK> for core::ScriptNOfK {
+    fn from(wasm: ScriptNOfK) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ScriptPubkey(pub(crate) core::ScriptPubkey);
+
+#[wasm_bindgen]
+
+impl ScriptPubkey {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ScriptPubkey, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ScriptPubkey, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn addr_keyhash(&self) -> AddrKeyhash {
+        self.0.addr_keyhash.clone().into()
+    }
+
+    pub fn new(addr_keyhash: &AddrKeyhash) -> Self {
+        Self(core::ScriptPubkey::new(addr_keyhash.clone().into()))
+    }
+}
+
+impl From<core::ScriptPubkey> for ScriptPubkey {
+    fn from(native: core::ScriptPubkey) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ScriptPubkey> for core::ScriptPubkey {
+    fn from(wasm: ScriptPubkey) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct ShelleyTxOut(pub(crate) core::ShelleyTxOut);
+
+#[wasm_bindgen]
+
+impl ShelleyTxOut {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<ShelleyTxOut, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyTxOut, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn address(&self) -> Address {
+        self.0.address.clone().into()
+    }
+
+    pub fn amount(&self) -> Value {
+        self.0.amount.clone().into()
+    }
+
+    pub fn new(address: &Address, amount: &Value) -> Self {
+        Self(core::ShelleyTxOut::new(address.clone().into(), amount.clone().into()))
+    }
+}
+
+impl From<core::ShelleyTxOut> for ShelleyTxOut {
+    fn from(native: core::ShelleyTxOut) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTxOut> for core::ShelleyTxOut {
+    fn from(wasm: ShelleyTxOut) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Transaction(pub(crate) core::Transaction);
+
+#[wasm_bindgen]
+
+impl Transaction {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Transaction, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Transaction, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn transaction_body(&self) -> TransactionBody {
+        self.0.transaction_body.clone().into()
+    }
+
+    pub fn transaction_witness_set(&self) -> TransactionWitnessSet {
+        self.0.transaction_witness_set.clone().into()
+    }
+
+    pub fn index_2(&self) -> bool {
+        self.0.index_2
+    }
+
+    pub fn auxiliary_data(&self) -> Option<AuxiliaryData> {
+        self.0.auxiliary_data.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(transaction_body: &TransactionBody, transaction_witness_set: &TransactionWitnessSet, index_2: bool, auxiliary_data: Option<AuxiliaryData>) -> Self {
+        Self(core::Transaction::new(transaction_body.clone().into(), transaction_witness_set.clone().into(), index_2, auxiliary_data.map(Into::into)))
+    }
+}
+
+impl From<core::Transaction> for Transaction {
+    fn from(native: core::Transaction) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Transaction> for core::Transaction {
+    fn from(wasm: Transaction) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionBody(pub(crate) core::TransactionBody);
+
+#[wasm_bindgen]
+
+impl TransactionBody {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionBody, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<TransactionBody, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn key_0(&self) -> TransactionInputs {
+        self.0.key_0.clone().into()
+    }
+
+    pub fn key_1(&self) -> TransactionOutputs {
+        self.0.key_1.clone().into()
+    }
+
+    pub fn key_2(&self) -> Coin {
+        self.0.key_2
+    }
+
+    pub fn set_key_3(&mut self, key_3: u64) {
+        self.0.key_3 = Some(key_3)
+    }
+
+    pub fn key_3(&self) -> Option<u64> {
+        self.0.key_3
+    }
+
+    pub fn set_key_4(&mut self, key_4: &Certificates) {
+        self.0.key_4 = Some(key_4.clone().into())
+    }
+
+    pub fn key_4(&self) -> Option<Certificates> {
+        self.0.key_4.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_5(&mut self, key_5: Withdrawals) {
+        self.0.key_5 = Some(key_5.clone().into())
+    }
+
+    pub fn key_5(&self) -> Option<Withdrawals> {
+        self.0.key_5.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_6(&mut self, key_6: &Update) {
+        self.0.key_6 = Some(key_6.clone().into())
+    }
+
+    pub fn key_6(&self) -> Option<Update> {
+        self.0.key_6.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_7(&mut self, key_7: &AuxiliaryDataHash) {
+        self.0.key_7 = Some(key_7.clone().into())
+    }
+
+    pub fn key_7(&self) -> Option<AuxiliaryDataHash> {
+        self.0.key_7.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_8(&mut self, key_8: u64) {
+        self.0.key_8 = Some(key_8)
+    }
+
+    pub fn key_8(&self) -> Option<u64> {
+        self.0.key_8
+    }
+
+    pub fn set_key_9(&mut self, key_9: Mint) {
+        self.0.key_9 = Some(key_9.clone().into())
+    }
+
+    pub fn key_9(&self) -> Option<Mint> {
+        self.0.key_9.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_11(&mut self, key_11: &ScriptDataHash) {
+        self.0.key_11 = Some(key_11.clone().into())
+    }
+
+    pub fn key_11(&self) -> Option<ScriptDataHash> {
+        self.0.key_11.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_13(&mut self, key_13: &TransactionInputs) {
+        self.0.key_13 = Some(key_13.clone().into())
+    }
+
+    pub fn key_13(&self) -> Option<TransactionInputs> {
+        self.0.key_13.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_14(&mut self, key_14: &RequiredSigners) {
+        self.0.key_14 = Some(key_14.clone().into())
+    }
+
+    pub fn key_14(&self) -> Option<RequiredSigners> {
+        self.0.key_14.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_15(&mut self, key_15: &NetworkId) {
+        self.0.key_15 = Some(key_15.clone().into())
+    }
+
+    pub fn key_15(&self) -> Option<NetworkId> {
+        self.0.key_15.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_16(&mut self, key_16: &TransactionOutput) {
+        self.0.key_16 = Some(key_16.clone().into())
+    }
+
+    pub fn key_16(&self) -> Option<TransactionOutput> {
+        self.0.key_16.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_17(&mut self, key_17: Coin) {
+        self.0.key_17 = Some(key_17)
+    }
+
+    pub fn key_17(&self) -> Option<Coin> {
+        self.0.key_17
+    }
+
+    pub fn set_key_18(&mut self, key_18: &TransactionInputs) {
+        self.0.key_18 = Some(key_18.clone().into())
+    }
+
+    pub fn key_18(&self) -> Option<TransactionInputs> {
+        self.0.key_18.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(key_0: &TransactionInputs, key_1: &TransactionOutputs, key_2: Coin) -> Self {
+        Self(core::TransactionBody::new(key_0.clone().into(), key_1.clone().into(), key_2))
+    }
+}
+
+impl From<core::TransactionBody> for TransactionBody {
+    fn from(native: core::TransactionBody) -> Self {
+        Self(native)
+    }
+}
+
+impl From<TransactionBody> for core::TransactionBody {
+    fn from(wasm: TransactionBody) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionInput(pub(crate) core::TransactionInput);
+
+#[wasm_bindgen]
+
+impl TransactionInput {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionInput, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<TransactionInput, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn transaction_id(&self) -> Hash32 {
+        self.0.transaction_id.clone().into()
+    }
+
+    pub fn index(&self) -> u64 {
+        self.0.index
+    }
+
+    pub fn new(transaction_id: &Hash32, index: u64) -> Self {
+        Self(core::TransactionInput::new(transaction_id.clone().into(), index))
+    }
+}
+
+impl From<core::TransactionInput> for TransactionInput {
+    fn from(native: core::TransactionInput) -> Self {
+        Self(native)
+    }
+}
+
+impl From<TransactionInput> for core::TransactionInput {
+    fn from(wasm: TransactionInput) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+pub enum TransactionOutputKind {
+    ShelleyTxOut,
+    AlonzoTxOut,
+    BabbageTxOut,
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionOutput(pub(crate) core::TransactionOutput);
+
+#[wasm_bindgen]
+
+impl TransactionOutput {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionOutput, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<TransactionOutput, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_shelley_tx_out(shelley_tx_out: &ShelleyTxOut) -> Self {
+        Self(core::TransactionOutput::new_shelley_tx_out(shelley_tx_out.clone().into()))
+    }
+
+    pub fn new_alonzo_tx_out(alonzo_tx_out: &AlonzoTxOut) -> Self {
+        Self(core::TransactionOutput::new_alonzo_tx_out(alonzo_tx_out.clone().into()))
+    }
+
+    pub fn new_babbage_tx_out(babbage_tx_out: &BabbageTxOut) -> Self {
+        Self(core::TransactionOutput::new_babbage_tx_out(babbage_tx_out.clone().into()))
+    }
+
+    pub fn kind(&self) -> TransactionOutputKind {
+        match &self.0 {
+            core::TransactionOutput::ShelleyTxOut(_) => TransactionOutputKind::ShelleyTxOut,
+            core::TransactionOutput::AlonzoTxOut(_) => TransactionOutputKind::AlonzoTxOut,
+            core::TransactionOutput::BabbageTxOut(_) => TransactionOutputKind::BabbageTxOut,
+        }
+    }
+
+    pub fn as_shelley_tx_out(&self) -> Option<ShelleyTxOut> {
+        match &self.0 {
+            core::TransactionOutput::ShelleyTxOut(shelley_tx_out) => Some(shelley_tx_out.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_alonzo_tx_out(&self) -> Option<AlonzoTxOut> {
+        match &self.0 {
+            core::TransactionOutput::AlonzoTxOut(alonzo_tx_out) => Some(alonzo_tx_out.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_babbage_tx_out(&self) -> Option<BabbageTxOut> {
+        match &self.0 {
+            core::TransactionOutput::BabbageTxOut(babbage_tx_out) => Some(babbage_tx_out.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::TransactionOutput> for TransactionOutput {
+    fn from(native: core::TransactionOutput) -> Self {
+        Self(native)
+    }
+}
+
+impl From<TransactionOutput> for core::TransactionOutput {
+    fn from(wasm: TransactionOutput) -> Self {
+        wasm.0
+    }
+}
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct TransactionWitnessSet(pub(crate) core::TransactionWitnessSet);
+
+#[wasm_bindgen]
+
+impl TransactionWitnessSet {
+    pub fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
+        use core::serialization::ToBytes;
+        ToBytes::to_bytes(&self.0, force_canonical)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionWitnessSet, JsValue> {
+        use core::prelude::FromBytes;
+        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<TransactionWitnessSet, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_key_0(&mut self, key_0: &Vkeywitnesss) {
+        self.0.key_0 = Some(key_0.clone().into())
+    }
+
+    pub fn key_0(&self) -> Option<Vkeywitnesss> {
+        self.0.key_0.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_1(&mut self, key_1: &NativeScripts) {
+        self.0.key_1 = Some(key_1.clone().into())
+    }
+
+    pub fn key_1(&self) -> Option<NativeScripts> {
+        self.0.key_1.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_2(&mut self, key_2: &BootstrapWitnesss) {
+        self.0.key_2 = Some(key_2.clone().into())
+    }
+
+    pub fn key_2(&self) -> Option<BootstrapWitnesss> {
+        self.0.key_2.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_3(&mut self, key_3: &PlutusV1Scripts) {
+        self.0.key_3 = Some(key_3.clone().into())
+    }
+
+    pub fn key_3(&self) -> Option<PlutusV1Scripts> {
+        self.0.key_3.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_4(&mut self, key_4: &PlutusDatas) {
+        self.0.key_4 = Some(key_4.clone().into())
+    }
+
+    pub fn key_4(&self) -> Option<PlutusDatas> {
+        self.0.key_4.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_5(&mut self, key_5: &Redeemers) {
+        self.0.key_5 = Some(key_5.clone().into())
+    }
+
+    pub fn key_5(&self) -> Option<Redeemers> {
+        self.0.key_5.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_key_6(&mut self, key_6: &PlutusV2Scripts) {
+        self.0.key_6 = Some(key_6.clone().into())
+    }
+
+    pub fn key_6(&self) -> Option<PlutusV2Scripts> {
+        self.0.key_6.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new() -> Self {
+        Self(core::TransactionWitnessSet::new())
+    }
+}
+
+impl From<core::TransactionWitnessSet> for TransactionWitnessSet {
+    fn from(native: core::TransactionWitnessSet) -> Self {
+        Self(native)
+    }
+}
+
+impl From<TransactionWitnessSet> for core::TransactionWitnessSet {
+    fn from(wasm: TransactionWitnessSet) -> Self {
+        wasm.0
+    }
+}
+
+use super::*;

--- a/specs/babbage/address.cddl
+++ b/specs/babbage/address.cddl
@@ -1,0 +1,38 @@
+
+; to force the generation of its own struct instead of bytes
+; since we have our own handwritten address struct
+; address = bytes
+address = [0]
+; reward_account = bytes
+reward_account = [1]
+
+; address format:
+; [ 8 bit header | payload ];
+;
+; shelley payment addresses:
+; bit 7: 0
+; bit 6: base/other
+; bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
+; bit 4: payment cred is keyhash/scripthash
+; bits 3-0: network id
+;
+; reward addresses:
+; bits 7-5: 111
+; bit 4: credential is keyhash/scripthash
+; bits 3-0: network id
+;
+; byron addresses:
+; bits 7-4: 1000
+
+; 0000: base address: keyhash28,keyhash28
+; 0001: base address: scripthash28,keyhash28
+; 0010: base address: keyhash28,scripthash28
+; 0011: base address: scripthash28,scripthash28
+; 0100: pointer address: keyhash28, 3 variable length uint
+; 0101: pointer address: scripthash28, 3 variable length uint
+; 0110: enterprise address: keyhash28
+; 0111: enterprise address: scripthash28
+; 1000: byron address
+; 1110: reward account: keyhash28
+; 1111: reward account: scripthash28
+; 1001 - 1101: future formats

--- a/specs/babbage/block.cddl
+++ b/specs/babbage/block.cddl
@@ -1,0 +1,38 @@
+block =
+  [ header
+  , transaction_bodies         : [* transaction_body]
+  , transaction_witness_sets   : [* transaction_witness_set]
+  , auxiliary_data_set         : {* transaction_index => auxiliary_data }
+  , invalid_transactions       : [* transaction_index ]
+  ]; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
+
+header =
+  [ header_body
+  , body_signature : $kes_signature
+  ]
+
+header_body =
+  [ block_number     : uint
+  , slot             : uint
+  , prev_hash        : $hash32 / null
+  , issuer_vkey      : $vkey
+  , vrf_vkey         : $vrf_vkey
+  , vrf_result       : $vrf_cert ; New, replaces nonce_vrf and leader_vrf
+  , block_body_size  : uint
+  , block_body_hash  : $hash32 ; merkle triple root
+  , operational_cert
+  , protocol_version
+  ]
+
+operational_cert =
+  ( hot_vkey        : $kes_vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : $signature
+  )
+
+protocol_version = (uint, uint)

--- a/specs/babbage/certs.cddl
+++ b/specs/babbage/certs.cddl
@@ -1,0 +1,65 @@
+certificate =
+  [ stake_registration
+  // stake_deregistration
+  // stake_delegation
+  // pool_registration
+  // pool_retirement
+  // genesis_key_delegation
+  // move_instantaneous_rewards_cert
+  ]
+
+stake_registration = (0, stake_credential)
+stake_deregistration = (1, stake_credential)
+stake_delegation = (2, stake_credential, pool_keyhash)
+pool_registration = (3, pool_params)
+pool_retirement = (4, pool_keyhash, epoch)
+genesis_key_delegation = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
+move_instantaneous_rewards_cert = (6, move_instantaneous_reward)
+
+move_instantaneous_reward = [ 0 / 1, { * stake_credential => delta_coin } / coin ]
+; The first field determines where the funds are drawn from.
+; 0 denotes the reserves, 1 denotes the treasury.
+; If the second field is a map, funds are moved to stake credentials,
+; otherwise the funds are given to the other accounting pot.
+
+pool_params = ( operator:       pool_keyhash
+              , vrf_keyhash:    vrf_keyhash
+              , pledge:         coin
+              , cost:           coin
+              , margin:         unit_interval
+              , reward_account: reward_account
+              , pool_owners:    [* addr_keyhash]
+              , relays:         [* relay]
+              , pool_metadata:  pool_metadata / null
+              )
+
+ipv4 = bytes .size 4
+ipv6 = bytes .size 16
+dns_name = tstr .size (0..64)
+
+single_host_addr = ( 0
+                   , port / null
+                   , ipv4 / null
+                   , ipv6 / null
+                   )
+single_host_name = ( 1
+                   , port / null
+                   , dns_name ; An A or AAAA DNS record
+                   )
+multi_host_name = ( 2
+                   , dns_name ; A SRV DNS record
+                   )
+relay =
+  [  single_host_addr
+  // single_host_name
+  // multi_host_name
+  ]
+
+pool_metadata = [url, pool_metadata_hash]
+url = tstr .size (0..64)
+
+
+stake_credential =
+  [  0, addr_keyhash
+  // 1, scripthash
+  ]

--- a/specs/babbage/crypto.cddl
+++ b/specs/babbage/crypto.cddl
@@ -1,0 +1,36 @@
+$hash28 /= bytes .size 28
+$hash32 /= bytes .size 32
+
+$vkey /= bytes .size 8
+
+$vrf_vkey /= bytes .size 8
+$vrf_cert /= [bytes, bytes .size 10]
+natural = #6.2(bytes)
+
+$kes_vkey /= bytes .size 8
+$kes_signature /= bytes .size 32
+signkeyKES = bytes .size 16
+
+$signature /= bytes .size 16
+
+$nonce /= [ 0 // 1, bytes .size 32 ]
+
+addr_keyhash          = $hash28
+genesis_delegate_hash = $hash28
+pool_keyhash          = $hash28
+genesishash           = $hash28
+
+vrf_keyhash           = $hash32
+auxiliary_data_hash   = $hash32
+pool_metadata_hash    = $hash32
+
+; To compute a script hash, note that you must prepend
+; a tag to the bytes of the script before hashing.
+; The tag is determined by the language.
+; The tags in the Babbage era are:
+;   "\x00" for multisig scripts
+;   "\x01" for Plutus V1 scripts
+;   "\x02" for Plutus V2 scripts
+scripthash            = $hash28
+
+datum_hash = $hash32

--- a/specs/babbage/lib.cddl
+++ b/specs/babbage/lib.cddl
@@ -1,0 +1,88 @@
+coin = uint
+delta_coin = int
+transaction_index = uint .size 2
+port = uint .le 65535
+epoch = uint
+transaction_metadatum_label = uint
+
+unit_interval = #6.30([uint, uint])
+  ; real unit_interval is: #6.30([uint, uint])
+  ; but this produces numbers outside the unit interval
+  ; and can also produce a zero in the denominator
+
+rational =  #6.30(
+   [ numerator   : uint
+   , denominator : uint
+   ])
+  ; real rational is: #6.30([uint, uint])
+  ; but this produces numbers outside the unit interval
+  ; and can also produce a zero in the denominator
+
+positive_interval = #6.30([1, 2])
+  ; fractional positive_interval is: #6.30([uint, uint])
+  ; but this can produce a zero in the denominator
+
+withdrawals = { * reward_account => coin }
+
+update = [ proposed_protocol_parameter_updates
+         , epoch
+         ]
+
+proposed_protocol_parameter_updates =
+  { * genesishash => protocol_param_update }
+
+protocol_version_struct = [protocol_version]
+
+protocol_param_update =
+  { ? 0:  uint               ; @name minfee_a
+  , ? 1:  uint               ; @name minfee_b
+  , ? 2:  uint               ; @name max_block_body_size
+  , ? 3:  uint               ; @name max_transaction_size
+  , ? 4:  uint               ; @name max_block_header_size
+  , ? 5:  coin               ; @name key_deposit
+  , ? 6:  coin               ; @name pool_deposit
+  , ? 7: epoch               ; @name maximum_epoch
+  , ? 8: uint                ; @name n_opt desired number of stake pools
+  , ? 9: rational            ; @name pool_pledge_influence
+  , ? 10: unit_interval      ; @name expansion_rate
+  , ? 11: unit_interval      ; @name treasury_growth_rate
+  , ? 14: protocol_version_struct ; @name protocol_version
+  , ? 16: coin               ; @name min_pool_cost
+  , ? 17: coin               ; @name ada_per_utxo_byte
+  , ? 18: costmdls           ; @name cost_models_for_script_languages
+  , ? 19: ex_unit_prices     ; @name execution_costs
+  , ? 20: ex_units           ; @name max_tx_ex_units
+  , ? 21: ex_units           ; @name max_block_ex_units
+  , ? 22: uint               ; @name max_value_size
+  , ? 23: uint               ; @name collateral_percentage
+  , ? 24: uint               ; @name max_collateral_inputs
+  }
+
+bounded_bytes = bytes
+
+
+
+vkeywitness = [ $vkey, $signature ]
+
+bootstrap_witness =
+  [ public_key : $vkey
+  , signature  : $signature
+  , chain_code : bytes .size 32
+  , attributes : bytes
+  ]
+
+
+sub_coin = positive_interval
+
+multiasset = { * policy_id => { * asset_name => uint } }
+
+policy_id = scripthash
+asset_name = bytes .size (0..32)
+
+value = [coin,multiasset]
+mint = { * policy_id => { * asset_name => int64 } }
+
+int64 = -9223372036854775808 .. 9223372036854775807
+
+network_id = 0 / 1
+

--- a/specs/babbage/metadata.cddl
+++ b/specs/babbage/metadata.cddl
@@ -1,0 +1,25 @@
+transaction_metadatum =
+    { * transaction_metadatum => transaction_metadatum }
+  / [ * transaction_metadatum ]
+  / int
+  / bytes .size (0..64)
+  / text .size (0..64)
+
+metadata = { * transaction_metadatum_label => transaction_metadatum }
+
+shelley_aux_data = metadata
+shelley_ma_aux_data = [ transaction_metadata: metadata ; Shelley-ma
+    , auxiliary_scripts: [ * native_script ]
+    ]
+
+; Alonzo and beyond
+alonzo_aux_data = #6.259({
+	? 0 => metadata ; @name metadata        
+      , ? 1 => [ * native_script ] ; @name native_scripts
+      , ? 2 => [ * plutus_v1_script ] ; @name plutus_v1_scripts
+      , ? 3 => [ * plutus_v2_script ] ; @name plutus_v2_scripts
+      })
+auxiliary_data =
+  shelley_aux_data
+  / shelley_ma_aux_data
+  / alonzo_aux_data

--- a/specs/babbage/plutus.cddl
+++ b/specs/babbage/plutus.cddl
@@ -1,0 +1,32 @@
+plutus_v1_script = bytes
+plutus_v2_script = bytes
+
+plutus_data =
+    constr_plutus_data
+  / { * plutus_data => plutus_data }
+  / [ * plutus_data ]
+  / big_int
+  / bounded_bytes
+
+big_int = [0, 1]
+
+constr_plutus_data = #6.102([uint, [* plutus_data]])
+
+redeemer = [ tag: redeemer_tag, index: uint, data: plutus_data, ex_units: ex_units ]
+redeemer_tag =
+    0 ; @name inputTag "Spend"
+  / 1 ; @name mintTag  "Mint"
+  / 2 ; @name certTag  "Cert"
+  / 3 ; @name wdrlTag  "Reward"
+ex_units = [mem: uint, steps: uint]
+
+ex_unit_prices =
+  [ mem_price: sub_coin, step_price: sub_coin ]
+
+language = 0 ; @name plutus_v1
+         / 1 ; @name plutus_v2
+
+costmdls =
+  { ? 0 : [ 166*166 int ] ; @name plutus_v1
+  , ? 1 : [ 175*175 int ] ; @name plutus_v2
+  }

--- a/specs/babbage/transaction.cddl
+++ b/specs/babbage/transaction.cddl
@@ -1,0 +1,139 @@
+
+
+transaction =
+  [ transaction_body
+  , transaction_witness_set
+  , bool
+  , auxiliary_data / null
+  ]
+
+transaction_body =
+  { 0 : [* transaction_input]    ; @name inputs
+  , 1 : [* transaction_output] ; @name outputs
+  , 2 : coin                      ; @name fee
+  , ? 3 : uint                    ; @name ttl
+  , ? 4 : [* certificate] ; @name certs
+  , ? 5 : withdrawals ; @name withdrawals
+  , ? 6 : update ; @name update
+  , ? 7 : auxiliary_data_hash ; @name auxiliary_data_hash
+  , ? 8 : uint                    ; @name validity_interval_start
+  , ? 9 : mint ; @name mint
+  , ? 11 : script_data_hash ; @name script_data_hash
+  , ? 13 : [* transaction_input] ; @name collateral_inputs
+  , ? 14 : required_signers ; @name required_signers
+  , ? 15 : network_id ; @name network_id
+  , ? 16 : transaction_output     ; @name collateral_return
+  , ? 17 : coin                   ; @name total_collateral
+  , ? 18 : [* transaction_input] ; @name reference_inputs
+  }
+
+required_signers = [* $addr_keyhash]
+
+transaction_input = [ transaction_id : $hash32
+                    , index : uint
+                    ]
+
+shelley_tx_out = [address, amount: value]
+alonzo_tx_out = [
+  address,
+  amount : value,
+  datum_hash : $hash32
+]
+babbage_tx_out = {
+    0 : address ; @name address
+  , 1 : value ; @name value
+  , ? 2 : datum_option ; @name datum_option
+  , ? 3 : script_ref   ; @name script_reference
+}
+
+transaction_output = shelley_tx_out / alonzo_tx_out / babbage_tx_out
+
+
+script_data_hash = $hash32
+
+; This is a hash of data which may affect evaluation of a script.
+; This data consists of:
+;   - The redeemers from the transaction_witness_set (the value of field 5).
+;   - The datums from the transaction_witness_set (the value of field 4).
+;   - The value in the costmdls map corresponding to the script's language
+;     (in field 18 of protocol_param_update.)
+; (In the future it may contain additional protocol parameters.)
+;
+; Since this data does not exist in contiguous form inside a transaction, it needs
+; to be independently constructed by each recipient.
+;
+; script data format:
+; [ redeemers | datums | language views ]
+; The redeemers are exactly the data present in the transaction witness set.
+; Similarly for the datums, if present. If no datums are provided, the middle
+; field is an empty string.
+;
+; language views CDDL:
+; { * language => script_integrity_data }
+;
+; This must be encoded canonically, using the same scheme as in
+; RFC7049 section 3.9:
+;  - Maps, strings, and bytestrings must use a definite-length encoding
+;  - Integers must be as small as possible.
+;  - The expressions for map length, string length, and bytestring length
+;    must be as short as possible.
+;  - The keys in the map must be sorted as follows:
+;     -  If two keys have different lengths, the shorter one sorts earlier.
+;     -  If two keys have the same length, the one with the lower value
+;        in (byte-wise) lexical order sorts earlier.
+;
+; For PlutusV1 (language id 0), the language view is the following:
+;   - the value of costmdls map at key 0 is encoded as an indefinite length
+;     list and the result is encoded as a bytestring. (our apologies)
+;   - the language ID tag is also encoded twice. first as a uint then as
+;     a bytestring. (our apologies)
+; For PlutusV2 (language id 1), the language view is the following:
+;   - the value of costmdls map at key 1 is encoded as an definite length list.
+;
+; Note that each Plutus language represented inside a transaction must have
+; a cost model in the costmdls protocol parameter in order to execute,
+; regardless of what the script integrity data is.
+;
+; Finally, note that in the case that a transaction includes datums but does not
+; include any redeemers, the script data format becomes (in hex):
+; [ 80 | datums | A0 ]
+; corresponding to a CBOR empty list and an empty map.
+
+data = #6.24(bytes .cbor plutus_data)
+
+datum_option = [ 0, $hash32 // 1, data ]
+
+script_ref = #6.24(bytes .cbor script)
+
+script = [ 0, native_script // 1, plutus_v1_script // 2, plutus_v2_script ]
+
+
+transaction_witness_set =
+  { ? 0: [* vkeywitness ] ; @name vkeywitnesses
+  , ? 1: [* native_script ] ; @name native_scripts
+  , ? 2: [* bootstrap_witness ] ; @name bootstrap_witnesses
+  , ? 3: [* plutus_v1_script ] ; @name plutus_v1_scripts
+  , ? 4: [* plutus_data ] ; @name plutus_datums
+  , ? 5: [* redeemer ] ; @name redeemers
+  , ? 6: [* plutus_v2_script ] ; @name plutus_v2_scripts
+  }
+
+native_script =
+  [ script_pubkey
+  // script_all
+  // script_any
+  // script_n_of_k
+  // invalid_before
+     ; Timelock validity intervals are half-open intervals [a, b).
+     ; This field specifies the left (included) endpoint a.
+  // invalid_hereafter
+     ; Timelock validity intervals are half-open intervals [a, b).
+     ; This field specifies the right (excluded) endpoint b.
+  ]
+
+script_pubkey = (0, addr_keyhash)
+script_all = (1, [ * native_script ])
+script_any = (2, [ * native_script ])
+script_n_of_k = (3, n: uint, [ * native_script ])
+invalid_before = (4, uint)
+invalid_hereafter = (5, uint)


### PR DESCRIPTION
This contains the direct code after generating off of the binary spec in `specs/babbage/`.

We will now be working out of these two crates in the `develop` branch, but they will just be sitting there unused until we do the final switch over where we delete the root `rust` crate and have everything moved over to `rust/core` and `rust/wasm`