### PR TITLE
Change PR checks trigger strategy

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,12 +1,13 @@
 name: PR Checks
 
 on:
-  pull_request_review:
-    types: [submitted]
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
 
 jobs:
   test-and-build:
-    if: github.event.review && (github.event.review.state == 'approved' || contains(github.event.review.body, '/check'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +43,6 @@ jobs:
         run: |
           npm run rust:build-browser
   check-warns:
-    if: github.event.review && (github.event.review.state == 'approved' || contains(github.event.review.body, '/check'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ rust/core/Cargo.lock
 rust/wasm/target/**
 rust/wasm/Cargo.lock
 rust/json-gen-split/target/**
+tools/metadata-cddl-checker/Cargo.lock


### PR DESCRIPTION
It makes sense to run CI when PR is open. Otherwise we can't verify it works and compiles unless we submit review / run locally. Before reviewing it makes sense quite often to see that checks have passed.

This relates to dependabot updates as well: good to see whether CI passes before reviewing.