### PR TITLE
CIP25 updates + add core/wasm crate + regen core/metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ target/
 core/target/**
 core/Cargo.lock
 
+core-wasm/target/**
+core-wasm/Cargo.lock
+core-wasm/pkg/**
+
 crypto/target/**
 crypto/Cargo.lock
 

--- a/chain/src/serialization.rs
+++ b/chain/src/serialization.rs
@@ -4536,7 +4536,7 @@ impl Deserialize for Transaction {
                 Ok(TransactionWitnessSet::deserialize(raw)?)
             })().map_err(|e| e.annotate("transaction_witness_set"))?;
             let index_2 = (|| -> Result<_, DeserializeError> {
-                Ok(bool::deserialize(raw)?)
+                Ok(raw.bool()?)
             })().map_err(|e| e.annotate("index_2"))?;
             let auxiliary_data = (|| -> Result<_, DeserializeError> {
                 Ok(match raw.cbor_type()? != CBORType::Special {

--- a/cip25-wasm/README.md
+++ b/cip25-wasm/README.md
@@ -1,3 +1,47 @@
 # cardano-multiplatform-lib-cip25
 
 Multiplatform SDK for CIP25 (Cardano NFT Metadata)
+
+This can be used for both parsing and creating CIP25-compatible metadata.
+
+Parsing can either be done directly from metadata bytes:
+
+```javascript
+let schema = wasm.CIP25.CIP25Metadata.from_bytes(Buffer.from("a11902d1a26464617461a144baadf00da144cafed00da5646e616d656d4d65746164617461204e616d656566696c657382a3637372636473726331646e616d656966696c656e616d6531696d65646961547970656966696c657479706531a3637372636473726332646e616d656966696c656e616d6532696d65646961547970656966696c65747970653265696d6167657821687474733a2f2f736f6d652e776562736974652e636f6d2f696d6167652e706e67696d656469615479706567696d6167652f2a6b6465736372697074696f6e776465736372697074696f6e206f662074686973204e46546776657273696f6e02", "hex"));
+
+// the above CBOR hex is for a V2 CIP25 schema. You should check which type it is first
+// as as_label_metadata_v2() will return None (undefined) if it's a v1 schema
+let v2Schema = schema.key_721().as_label_metadata_v2().data();
+let policies = v2Schema.keys();
+for (var i = 0; i < policies.len(); ++i) {
+  let policy = policies.get(i);
+  let assets = v2Schema.get(policy);
+  let assetNames = assets.keys();
+  for (var j = 0; j < assetNames.len(); ++j) {
+    let assetName = assetNames.get(j);
+    let details = assets.get(assetName);
+    console.log(`CIP25 NFT ${policy.toString("hex")}.${asset_name.toString("hex")} found:`);
+    console.log(`  name: ${details.name().to_str()}`);
+    console.log(`  image: ${details.image().to_string()}`);
+    let mediaType = details.media_type();
+    if (mediaType != null) {
+      console.log(`  media_type: ${mediaType.to_str()}`);
+    }
+    let description = details.media_type();
+    if (description != null) {
+      console.log(`  description: ${description.to_str()}`);
+    }
+    let files = details.files();
+    if (files != null) {
+      console.log(`  files:`);
+      for (var k = 0; k < files.len(); ++k) {
+        let file = files.get(k);
+        console.log(`    file #${k + 1}:`);
+        console.log(`      name: ${file.name().to_str()}`);
+        console.log(`      media_type: ${file.media_type().to_str()}`);
+        console.log(`      src: ${file.src().to_string()}`);
+      }
+    }
+  }
+}
+```

--- a/cip25-wasm/json-gen/src/main.rs
+++ b/cip25-wasm/json-gen/src/main.rs
@@ -17,5 +17,5 @@ fn main() {
     gen_json_schema!(Metadata);
     gen_json_schema!(MetadataDetails);
     gen_json_schema!(String64);
-    gen_json_schema!(String64OrArrString64);
+    gen_json_schema!(ChunkableString);
 }

--- a/cip25-wasm/src/lib.rs
+++ b/cip25-wasm/src/lib.rs
@@ -1,4 +1,6 @@
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
+
+use cardano_multiplatform_lib_core_wasm::metadata::Metadata;
 
 // TODO: remove after regen
 use core::{ToBytes, FromBytes};
@@ -14,12 +16,10 @@ pub type PolicyIdV1 = String64;
 pub type PolicyIdV2 = Vec<u8>;
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct MapAssetNameV2ToMetadataDetails(BTreeMap<core::AssetNameV2, core::MetadataDetails>);
 
 #[wasm_bindgen]
-
 impl MapAssetNameV2ToMetadataDetails {
     pub fn new() -> Self {
         Self(BTreeMap::new())
@@ -55,12 +55,10 @@ impl std::convert::Into<BTreeMap<core::AssetNameV2, core::MetadataDetails>> for 
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct AssetNameV2s(Vec<core::AssetNameV2>);
 
 #[wasm_bindgen]
-
 impl AssetNameV2s {
     pub fn new() -> Self {
         Self(Vec::new())
@@ -92,12 +90,10 @@ impl std::convert::Into<Vec<core::AssetNameV2>> for AssetNameV2s {
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct String64s(Vec<core::String64>);
 
 #[wasm_bindgen]
-
 impl String64s {
     pub fn new() -> Self {
         Self(Vec::new())
@@ -129,12 +125,10 @@ impl std::convert::Into<Vec<core::String64>> for String64s {
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct FilesDetailss(Vec<core::FilesDetails>);
 
 #[wasm_bindgen]
-
 impl FilesDetailss {
     pub fn new() -> Self {
         Self(Vec::new())
@@ -166,12 +160,10 @@ impl std::convert::Into<Vec<core::FilesDetails>> for FilesDetailss {
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct Data(BTreeMap<core::PolicyIdV2, BTreeMap<core::AssetNameV2, core::MetadataDetails>>);
 
 #[wasm_bindgen]
-
 impl Data {
     pub fn new() -> Self {
         Self(BTreeMap::new())
@@ -207,31 +199,29 @@ impl std::convert::Into<BTreeMap<core::PolicyIdV2, BTreeMap<core::AssetNameV2, c
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct FilesDetails(core::FilesDetails);
 
 #[wasm_bindgen]
-
 impl FilesDetails {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(&self.0)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<FilesDetails, JsValue> {
-        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    pub fn from_bytes(data: Vec<u8>) -> Result<FilesDetails, JsError> {
+        FromBytes::from_bytes(data).map(Self).map_err(Into::into)
     }
 
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    pub fn to_json(&self) -> Result<String, JsError> {
+        serde_json::to_string_pretty(&self.0).map_err(Into::into)
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    pub fn to_json_value(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(Into::into)
     }
 
-    pub fn from_json(json: &str) -> Result<FilesDetails, JsValue> {
-        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    pub fn from_json(json: &str) -> Result<FilesDetails, JsError> {
+        serde_json::from_str(json).map(Self).map_err(Into::into)
     }
 
     pub fn name(&self) -> String64 {
@@ -242,11 +232,11 @@ impl FilesDetails {
         self.0.media_type.clone().into()
     }
 
-    pub fn src(&self) -> String64OrArrString64 {
+    pub fn src(&self) -> ChunkableString {
         self.0.src.clone().into()
     }
 
-    pub fn new(name: &String64, media_type: &String64, src: &String64OrArrString64) -> Self {
+    pub fn new(name: &String64, media_type: &String64, src: &ChunkableString) -> Self {
         Self(core::FilesDetails::new(name.clone().into(), media_type.clone().into(), src.clone().into()))
     }
 }
@@ -264,13 +254,11 @@ impl From<FilesDetails> for core::FilesDetails {
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
-pub struct MapPolicyIdV1ToMapAssetNameV1ToMetadataDetails(BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>>);
+pub struct LabelMetadataV1(BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>>);
 
 #[wasm_bindgen]
-
-impl MapPolicyIdV1ToMapAssetNameV1ToMetadataDetails {
+impl LabelMetadataV1 {
     pub fn new() -> Self {
         Self(BTreeMap::new())
     }
@@ -292,25 +280,23 @@ impl MapPolicyIdV1ToMapAssetNameV1ToMetadataDetails {
     }
 }
 
-impl From<BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>>> for MapPolicyIdV1ToMapAssetNameV1ToMetadataDetails {
+impl From<BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>>> for LabelMetadataV1 {
     fn from(native: BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>>) -> Self {
         Self(native)
     }
 }
 
-impl std::convert::Into<BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>>> for MapPolicyIdV1ToMapAssetNameV1ToMetadataDetails {
+impl std::convert::Into<BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>>> for LabelMetadataV1 {
     fn into(self) -> BTreeMap<core::PolicyIdV1, BTreeMap<core::AssetNameV1, core::MetadataDetails>> {
         self.0
     }
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct PolicyIdV1s(Vec<core::PolicyIdV1>);
 
 #[wasm_bindgen]
-
 impl PolicyIdV1s {
     pub fn new() -> Self {
         Self(Vec::new())
@@ -342,12 +328,10 @@ impl std::convert::Into<Vec<core::PolicyIdV1>> for PolicyIdV1s {
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct MapAssetNameV1ToMetadataDetails(BTreeMap<core::AssetNameV1, core::MetadataDetails>);
 
 #[wasm_bindgen]
-
 impl MapAssetNameV1ToMetadataDetails {
     pub fn new() -> Self {
         Self(BTreeMap::new())
@@ -383,12 +367,10 @@ impl std::convert::Into<BTreeMap<core::AssetNameV1, core::MetadataDetails>> for 
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct AssetNameV1s(Vec<core::AssetNameV1>);
 
 #[wasm_bindgen]
-
 impl AssetNameV1s {
     pub fn new() -> Self {
         Self(Vec::new())
@@ -420,12 +402,10 @@ impl std::convert::Into<Vec<core::AssetNameV1>> for AssetNameV1s {
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct PolicyIdV2s(Vec<core::PolicyIdV2>);
 
 #[wasm_bindgen]
-
 impl PolicyIdV2s {
     pub fn new() -> Self {
         Self(Vec::new())
@@ -457,38 +437,35 @@ impl std::convert::Into<Vec<core::PolicyIdV2>> for PolicyIdV2s {
 }
 
 #[wasm_bindgen]
-
 pub enum LabelMetadataKind {
     LabelMetadataV1,
     LabelMetadataV2,
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct LabelMetadata(core::LabelMetadata);
 
 #[wasm_bindgen]
-
 impl LabelMetadata {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(&self.0)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<LabelMetadata, JsValue> {
-        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    pub fn from_bytes(data: Vec<u8>) -> Result<LabelMetadata, JsError> {
+        FromBytes::from_bytes(data).map(Self).map_err(Into::into)
     }
 
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    pub fn to_json(&self) -> Result<String, JsError> {
+        serde_json::to_string_pretty(&self.0).map_err(Into::into)
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    pub fn to_json_value(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(Into::into)
     }
 
-    pub fn from_json(json: &str) -> Result<LabelMetadata, JsValue> {
-        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    pub fn from_json(json: &str) -> Result<LabelMetadata, JsError> {
+        serde_json::from_str(json).map(Self).map_err(Into::into)
     }
 
     pub fn new_label_metadata_v1(label_metadata_v1: LabelMetadataV1) -> Self {
@@ -533,34 +510,30 @@ impl From<LabelMetadata> for core::LabelMetadata {
     }
 }
 
-type LabelMetadataV1 = MapPolicyIdV1ToMapAssetNameV1ToMetadataDetails;
-
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct LabelMetadataV2(core::LabelMetadataV2);
 
 #[wasm_bindgen]
-
 impl LabelMetadataV2 {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(&self.0)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<LabelMetadataV2, JsValue> {
-        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    pub fn from_bytes(data: Vec<u8>) -> Result<LabelMetadataV2, JsError> {
+        FromBytes::from_bytes(data).map(Self).map_err(Into::into)
     }
 
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    pub fn to_json(&self) -> Result<String, JsError> {
+        serde_json::to_string_pretty(&self.0).map_err(Into::into)
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    pub fn to_json_value(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(Into::into)
     }
 
-    pub fn from_json(json: &str) -> Result<LabelMetadataV2, JsValue> {
-        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    pub fn from_json(json: &str) -> Result<LabelMetadataV2, JsError> {
+        serde_json::from_str(json).map(Self).map_err(Into::into)
     }
 
     pub fn data(&self) -> Data {
@@ -584,88 +557,113 @@ impl From<LabelMetadataV2> for core::LabelMetadataV2 {
     }
 }
 
+/// This is the entire metadata schema for CIP-25
+/// It can be parsed by passing in the CBOR bytes of the entire transaction metadata
+/// or by passing in an existing Metadata struct.
+/// Parsing from CBOR bytes should be marginally faster.
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
-pub struct Metadata(core::Metadata);
+pub struct CIP25Metadata(core::CIP25Metadata);
 
 #[wasm_bindgen]
+impl CIP25Metadata {
+    /// Create a Metadata containing only the CIP25 schema
+    pub fn to_metadata(&self) -> Result<Metadata, JsError> {
+        self.0.to_metadata().map(Metadata::from).map_err(Into::into)
+    }
 
-impl Metadata {
+    /// Read the CIP25 schema from a Metadata. Ignores all other data besides CIP25
+    /// Can fail if the Metadata does not conform to CIP25
+    pub fn from_metadata(metadata: &Metadata) -> Result<CIP25Metadata, JsError> {
+        core::CIP25Metadata::from_metadata(metadata.as_ref()).map(Self).map_err(Into::into)
+    }
+
+    /// Add to an existing metadata (could be empty) the full CIP25 metadata
+    pub fn add_to_metadata(&self, metadata: &mut Metadata) -> Result<(), JsError> {
+        self.0.add_to_metadata(metadata.as_mut()).map_err(Into::into)
+    }
+
+    /// Serialize to CBOR bytes compatible with tx metadata
+    /// Does not guarantee any specific type of CBOR format and should NOT
+    /// be used with round-tripping. It will ignore all non-CIP25 keys.
+    /// Use core::metadate crate for round-tripping metadata.
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(&self.0)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<Metadata, JsValue> {
-        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    /// Deserialize from CBOR bytes compatible with tx metadata
+    /// Does not guarantee any specific type of CBOR format and should NOT
+    /// be used with round-tripping. It will ignore all non-CIP25 keys.
+    /// Use core::metadate crate for round-tripping metadata.
+    pub fn from_bytes(data: Vec<u8>) -> Result<CIP25Metadata, JsError> {
+        FromBytes::from_bytes(data).map(Self).map_err(Into::into)
     }
 
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    pub fn to_json(&self) -> Result<String, JsError> {
+        serde_json::to_string_pretty(&self.0).map_err(Into::into)
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    pub fn to_json_value(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(Into::into)
     }
 
-    pub fn from_json(json: &str) -> Result<Metadata, JsValue> {
-        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    pub fn from_json(json: &str) -> Result<CIP25Metadata, JsError> {
+        serde_json::from_str(json).map(Self).map_err(Into::into)
     }
 
+    /// The core details of the CIP25 spec
     pub fn key_721(&self) -> LabelMetadata {
         self.0.key_721.clone().into()
     }
 
     pub fn new(key_721: &LabelMetadata) -> Self {
-        Self(core::Metadata::new(key_721.clone().into()))
+        Self(core::CIP25Metadata::new(key_721.clone().into()))
     }
 }
 
-impl From<core::Metadata> for Metadata {
-    fn from(native: core::Metadata) -> Self {
+impl From<core::CIP25Metadata> for CIP25Metadata {
+    fn from(native: core::CIP25Metadata) -> Self {
         Self(native)
     }
 }
 
-impl From<Metadata> for core::Metadata {
-    fn from(wasm: Metadata) -> Self {
+impl From<CIP25Metadata> for core::CIP25Metadata {
+    fn from(wasm: CIP25Metadata) -> Self {
         wasm.0
     }
 }
 
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct MetadataDetails(core::MetadataDetails);
 
 #[wasm_bindgen]
-
 impl MetadataDetails {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(&self.0)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<MetadataDetails, JsValue> {
-        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    pub fn from_bytes(data: Vec<u8>) -> Result<MetadataDetails, JsError> {
+        FromBytes::from_bytes(data).map(Self).map_err(Into::into)
     }
 
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    pub fn to_json(&self) -> Result<String, JsError> {
+        serde_json::to_string_pretty(&self.0).map_err(Into::into)
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    pub fn to_json_value(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(Into::into)
     }
 
-    pub fn from_json(json: &str) -> Result<MetadataDetails, JsValue> {
-        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    pub fn from_json(json: &str) -> Result<MetadataDetails, JsError> {
+        serde_json::from_str(json).map(Self).map_err(Into::into)
     }
 
     pub fn name(&self) -> String64 {
         self.0.name.clone().into()
     }
 
-    pub fn image(&self) -> String64OrArrString64 {
+    pub fn image(&self) -> ChunkableString {
         self.0.image.clone().into()
     }
 
@@ -677,11 +675,11 @@ impl MetadataDetails {
         self.0.media_type.clone().map(std::convert::Into::into)
     }
 
-    pub fn set_description(&mut self, description: &String64OrArrString64) {
+    pub fn set_description(&mut self, description: &ChunkableString) {
         self.0.description = Some(description.clone().into())
     }
 
-    pub fn description(&self) -> Option<String64OrArrString64> {
+    pub fn description(&self) -> Option<ChunkableString> {
         self.0.description.clone().map(std::convert::Into::into)
     }
 
@@ -693,7 +691,7 @@ impl MetadataDetails {
         self.0.files.clone().map(std::convert::Into::into)
     }
 
-    pub fn new(name: &String64, image: &String64OrArrString64) -> Self {
+    pub fn new(name: &String64, image: &ChunkableString) -> Self {
         Self(core::MetadataDetails::new(name.clone().into(), image.clone().into()))
     }
 }
@@ -710,36 +708,40 @@ impl From<MetadataDetails> for core::MetadataDetails {
     }
 }
 
+/// A String of at most 64 bytes.
+/// This is to conform with Cardano metadata restrictions.
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
 pub struct String64(core::String64);
 
 #[wasm_bindgen]
-
 impl String64 {
+    pub fn new(s: &str) -> Result<String64, JsError> {
+        core::String64::new(s).map(Self).map_err(Into::into)
+    }
+
+    pub fn to_str(&self) -> String {
+        self.0.to_str().to_owned()
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(&self.0)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<String64, JsValue> {
-        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    pub fn from_bytes(data: Vec<u8>) -> Result<String64, JsError> {
+        FromBytes::from_bytes(data).map(Self).map_err(Into::into)
     }
 
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    pub fn to_json(&self) -> Result<String, JsError> {
+        serde_json::to_string_pretty(&self.0).map_err(Into::into)
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    pub fn to_json_value(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(Into::into)
     }
 
-    pub fn from_json(json: &str) -> Result<String64, JsValue> {
-        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
-    pub fn get(&self) -> String {
-        self.0.get().clone().clone()
+    pub fn from_json(json: &str) -> Result<String64, JsError> {
+        serde_json::from_str(json).map(Self).map_err(Into::into)
     }
 }
 
@@ -756,78 +758,90 @@ impl From<String64> for core::String64 {
 }
 
 #[wasm_bindgen]
-
-pub enum String64OrArrString64Kind {
-    String64,
-    ArrString64,
+pub enum ChunkableStringKind {
+    Single,
+    Chunked,
 }
 
+/// A String that may or may not be chunked into 64-byte chunks to be able
+/// to conform to Cardano TX Metadata limitations.
+/// Most users should simply use ChunkableString::from_string() and ChunkableString::to_string()
+/// and avoid the explicit single/chunk interface:
+/// ```javascript
+/// let chunkableString = CIP25.ChunkableString.from_string("this can be any length and will automatically be chunked if needed");
+/// ```
 #[wasm_bindgen]
-
 #[derive(Clone, Debug)]
-pub struct String64OrArrString64(core::String64OrArrString64);
+pub struct ChunkableString(core::ChunkableString);
 
 #[wasm_bindgen]
+impl ChunkableString {
+    pub fn from_string(str: &str) -> Self {
+        Self(core::ChunkableString::from(str))
+    }
 
-impl String64OrArrString64 {
+    pub fn to_string(&self) -> String {
+        String::from(&self.0)
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(&self.0)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<String64OrArrString64, JsValue> {
-        FromBytes::from_bytes(data).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    pub fn from_bytes(data: Vec<u8>) -> Result<ChunkableString, JsError> {
+        FromBytes::from_bytes(data).map(Self).map_err(Into::into)
     }
 
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    pub fn to_json(&self) -> Result<String, JsError> {
+        serde_json::to_string_pretty(&self.0).map_err(Into::into)
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        JsValue::from_serde(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    pub fn to_json_value(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(Into::into)
     }
 
-    pub fn from_json(json: &str) -> Result<String64OrArrString64, JsValue> {
-        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    pub fn from_json(json: &str) -> Result<ChunkableString, JsError> {
+        serde_json::from_str(json).map(Self).map_err(Into::into)
     }
 
-    pub fn new_string64(string64: &String64) -> Self {
-        Self(core::String64OrArrString64::new_string64(string64.clone().into()))
+    pub fn new_single(string64: &String64) -> Self {
+        Self(core::ChunkableString::new_single(string64.clone().into()))
     }
 
-    pub fn new_arr_string64(arr_string64: &String64s) -> Self {
-        Self(core::String64OrArrString64::new_arr_string64(arr_string64.clone().into()))
+    pub fn new_chunked(arr_string64: &String64s) -> Self {
+        Self(core::ChunkableString::new_chunked(arr_string64.clone().into()))
     }
 
-    pub fn kind(&self) -> String64OrArrString64Kind {
+    pub fn kind(&self) -> ChunkableStringKind {
         match &self.0 {
-            core::String64OrArrString64::String64(_) => String64OrArrString64Kind::String64,
-            core::String64OrArrString64::ArrString64(_) => String64OrArrString64Kind::ArrString64,
+            core::ChunkableString::Single(_) => ChunkableStringKind::Single,
+            core::ChunkableString::Chunked(_) => ChunkableStringKind::Chunked,
         }
     }
 
     pub fn as_string64(&self) -> Option<String64> {
         match &self.0 {
-            core::String64OrArrString64::String64(string64) => Some(string64.clone().into()),
+            core::ChunkableString::Single(string64) => Some(string64.clone().into()),
             _ => None,
         }
     }
 
-    pub fn as_arr_string64(&self) -> Option<String64s> {
+    pub fn as_chunks(&self) -> Option<String64s> {
         match &self.0 {
-            core::String64OrArrString64::ArrString64(arr_string64) => Some(arr_string64.clone().into()),
+            core::ChunkableString::Chunked(arr_string64) => Some(arr_string64.clone().into()),
             _ => None,
         }
     }
 }
 
-impl From<core::String64OrArrString64> for String64OrArrString64 {
-    fn from(native: core::String64OrArrString64) -> Self {
+impl From<core::ChunkableString> for ChunkableString {
+    fn from(native: core::ChunkableString) -> Self {
         Self(native)
     }
 }
 
-impl From<String64OrArrString64> for core::String64OrArrString64 {
-    fn from(wasm: String64OrArrString64) -> Self {
+impl From<ChunkableString> for core::ChunkableString {
+    fn from(wasm: ChunkableString) -> Self {
         wasm.0
     }
 }

--- a/cip25/src/lib.rs
+++ b/cip25/src/lib.rs
@@ -1,14 +1,15 @@
-use std::io::{BufRead, Seek, Write};
+use std::io::{BufRead, Write};
 
 pub use cardano_multiplatform_lib_core::{
     serialization::*,
     error::*,
+    metadata::{Metadata, TransactionMetadatum},
 };
 
 // This library was code-generated using an experimental CDDL to rust tool:
 // https://github.com/Emurgo/cddl-codegen
 
-use cbor_event::{self, de::Deserializer, se::{Serialize, Serializer}};
+use cbor_event::{self, de::Deserializer, se::Serializer};
 
 use cbor_event::Type as CBORType;
 
@@ -37,15 +38,17 @@ pub type PolicyIdV2 = Vec<u8>;
 
 pub type PolicyIdV2s = Vec<PolicyIdV2>;
 
+pub static CIP25_METADATA_LABEL: u64 = 721;
+
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct FilesDetails {
     pub name: String64,
     pub media_type: String64,
-    pub src: String64OrArrString64,
+    pub src: ChunkableString,
 }
 
 impl FilesDetails {
-    pub fn new(name: String64, media_type: String64, src: String64OrArrString64) -> Self {
+    pub fn new(name: String64, media_type: String64, src: ChunkableString) -> Self {
         Self {
             name,
             media_type,
@@ -83,30 +86,77 @@ impl LabelMetadataV2 {
     }
 }
 
+/// This is the entire metadata schema for CIP-25
+/// It can be parsed by passing in the CBOR bytes of the entire transaction metadata
+/// or by passing in an existing Metadata struct.
+/// Parsing from CBOR bytes should be marginally faster.
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
-pub struct Metadata {
+pub struct CIP25Metadata {
+    /// The core details of the CIP25 spec
     pub key_721: LabelMetadata,
 }
 
-impl Metadata {
+impl CIP25Metadata {
     pub fn new(key_721: LabelMetadata) -> Self {
         Self {
             key_721,
         }
+    }
+
+    /// Create a Metadata containing only the CIP25 schema
+    pub fn to_metadata(&self) -> Result<Metadata, DeserializeError> {
+        use std::convert::TryInto;
+        self.try_into()
+    }
+
+    /// Read the CIP25 schema from a Metadata. Ignores all other data besides CIP25
+    /// Can fail if the Metadata does not conform to CIP25
+    pub fn from_metadata(metadata: &Metadata) -> Result<CIP25Metadata, DeserializeError> {
+        Self::try_from(metadata)
+    }
+
+    /// Add to an existing metadata (could be empty) the full CIP25 metadata
+    pub fn add_to_metadata(&self, metadata: &mut Metadata) -> Result<(), DeserializeError> {
+        let cip25_metadatum = TransactionMetadatum::from_cbor_bytes(&self.key_721.to_bytes())?;
+        metadata.insert(CIP25_METADATA_LABEL, cip25_metadatum);
+        Ok(())
+    }
+}
+
+impl std::convert::TryFrom<&Metadata> for CIP25Metadata {
+    type Error = DeserializeError;
+
+    fn try_from(metadata: &Metadata) -> Result<Self, Self::Error> {
+        let cip25_metadatum = metadata
+            .get(&CIP25_METADATA_LABEL)
+            .ok_or_else(|| DeserializeFailure::MandatoryFieldMissing(Key::Uint(CIP25_METADATA_LABEL)))?;
+        Ok(Self {
+            key_721: LabelMetadata::from_cbor_bytes(&cip25_metadatum.to_original_cbor_bytes())?,
+        })
+    }
+}
+
+impl std::convert::TryInto<Metadata> for &CIP25Metadata {
+    type Error = DeserializeError;
+
+    fn try_into(self) -> Result<Metadata, Self::Error> {
+        let mut metadata = Metadata::new();
+        self.add_to_metadata(&mut metadata)?;
+        Ok(metadata)
     }
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct MetadataDetails {
     pub name: String64,
-    pub image: String64OrArrString64,
+    pub image: ChunkableString,
     pub media_type: Option<String64>,
-    pub description: Option<String64OrArrString64>,
+    pub description: Option<ChunkableString>,
     pub files: Option<Vec<FilesDetails>>,
 }
 
 impl MetadataDetails {
-    pub fn new(name: String64, image: String64OrArrString64) -> Self {
+    pub fn new(name: String64, image: ChunkableString) -> Self {
         Self {
             name,
             image,
@@ -117,26 +167,28 @@ impl MetadataDetails {
     }
 }
 
+/// A String of at most 64 bytes.
+/// This is to conform with Cardano metadata restrictions.
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Eq, PartialEq, Ord, PartialOrd)]
 pub struct String64(String);
 
 impl String64 {
-    pub fn get(&self) -> &String {
-        &self.0
-    }
-
-    pub fn new(inner: String) -> Result<Self, DeserializeError> {
+    pub fn new(inner: &str) -> Result<Self, DeserializeError> {
         if inner.len() > 64 {
             return Err(DeserializeError::new("String64", DeserializeFailure::RangeCheck{ found: inner.len(), min: Some(0), max: Some(64) }));
         }
-        Ok(Self(inner))
+        Ok(Self(inner.to_owned()))
+    }
+
+    pub fn to_str(&self) -> &str {
+        &self.0
     }
 }
 
-impl TryFrom<String> for String64 {
+impl TryFrom<&str> for String64 {
     type Error = DeserializeError;
 
-    fn try_from(inner: String) -> Result<Self, Self::Error> {
+    fn try_from(inner: &str) -> Result<Self, Self::Error> {
         String64::new(inner)
     }
 }
@@ -147,18 +199,96 @@ impl From<String64> for String {
     }
 }
 
+/// A String that may or may not be chunked into 64-byte chunks to be able
+/// to conform to Cardano TX Metadata limitations.
+/// Unless you have good reasons, you should be using the From<&str> trait to construct this:
+/// ```
+/// use cardano_multiplatform_lib_cip25::ChunkableString;
+/// // automatically chunks this too long string into two chunks:
+/// let chunkable_string = ChunkableString::from("this can be any length and will automatically be chunked into 64-byte pieces when/if needed");
+/// match chunkable_string {
+///     ChunkableString::Single(_) => panic!(),
+///     ChunkableString::Chunked(chunks) => {
+///         assert_eq!(chunks[0].to_str(), "this can be any length and will automatically be chunked into 64");
+///         assert_eq!(chunks[1].to_str(), "-byte pieces when/if needed");
+///     },
+/// }
+/// ```
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
-pub enum String64OrArrString64 {
-    String64(String64),
-    ArrString64(Vec<String64>),
+pub enum ChunkableString {
+    Single(String64),
+    Chunked(Vec<String64>),
 }
 
-impl String64OrArrString64 {
-    pub fn new_string64(string64: String64) -> Self {
-        Self::String64(string64)
+impl ChunkableString {
+    /// Construct from a single <=64 byte string chunk.
+    /// If size is not known or for simplicity use From<&str> instead
+    pub fn new_single(string64: String64) -> Self {
+        Self::Single(string64)
     }
 
-    pub fn new_arr_string64(arr_string64: Vec<String64>) -> Self {
-        Self::ArrString64(arr_string64)
+    /// Construct from an explicit list of chunks
+    /// If size is not known or for simplicity use From<&str> instead
+    pub fn new_chunked(arr_string64: Vec<String64>) -> Self {
+        Self::Chunked(arr_string64)
+    }
+}
+
+impl From<&str> for ChunkableString {
+    fn from(s: &str) -> Self {
+        String64::new(s)
+            .map(Self::Single)
+            .unwrap_or_else(|_err| {
+                let mut chunks = Vec::with_capacity(s.len() / 64);
+                for i in (0..s.len()).step_by(64) {
+                    let j = std::cmp::min(s.len(), i + 64);
+                    chunks.push(String64::new(&s[i..j]).unwrap());
+                }
+                Self::Chunked(chunks)
+            })
+    }
+}
+
+impl From<&ChunkableString> for String {
+    fn from(chunkable: &ChunkableString) -> Self {
+        match chunkable {
+            ChunkableString::Single(chunk) => chunk.to_str().to_owned(),
+            ChunkableString::Chunked(chunks) => chunks.iter().map(|chunk| chunk.to_str().to_owned()).collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create() {
+        let mut details = MetadataDetails::new(
+            String64::try_from("Metadata Name").unwrap(),
+            ChunkableString::from("htts://some.website.com/image.png"));
+        details.description = Some(ChunkableString::from("description of this NFT"));
+        details.media_type = Some(String64::try_from("image/*").unwrap());
+        details.files = Some(vec![
+            FilesDetails::new(
+                String64::new("filename1").unwrap(),
+                String64::new("filetype1").unwrap(),
+                ChunkableString::from("src1")),
+            FilesDetails::new(
+                String64::new("filename2").unwrap(),
+                String64::new("filetype2").unwrap(),
+                ChunkableString::from("src2")),
+        ]);
+        let mut v2 = Data::new();
+        let mut v2_inner = BTreeMap::new();
+        v2_inner.insert(vec![0xCA, 0xFE, 0xD0, 0x0D], details);
+        v2.insert(vec![0xBA, 0xAD, 0xF0, 0x0D], v2_inner);
+        let metadata = CIP25Metadata::new(LabelMetadata::new_label_metadata_v2(LabelMetadataV2::new(v2)));
+        let metadata_bytes = metadata.to_bytes();
+        let roundtrip = CIP25Metadata::from_cbor_bytes(&metadata_bytes).unwrap();
+        assert_eq!(metadata_bytes, roundtrip.to_bytes());
+        let as_metadata = metadata.to_metadata().unwrap();
+        let from_metadata = CIP25Metadata::from_metadata(&as_metadata).unwrap();
+        assert_eq!(metadata_bytes, from_metadata.to_bytes());
     }
 }

--- a/core-wasm/Cargo.toml
+++ b/core-wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cardano-multiplatform-lib-cip25-wasm"
+name = "cardano-multiplatform-lib-core-wasm"
 version = "0.1.0"
 edition = "2018"
 
@@ -7,8 +7,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-core = { path = "../cip25", package = "cardano-multiplatform-lib-cip25" }
-cardano-multiplatform-lib-core-wasm = { path = "../core-wasm" }
+cardano-multiplatform-lib-core = { path = "../core" }
 cbor_event = "2.2.0"
 wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
 linked-hash-map = "0.5.3"

--- a/core-wasm/src/lib.rs
+++ b/core-wasm/src/lib.rs
@@ -1,0 +1,74 @@
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+use cardano_multiplatform_lib_core::{
+    ordered_hash_map::OrderedHashMap,
+    serialization::{Deserialize, Serialize},
+};
+
+pub mod metadata;
+
+#[wasm_bindgen]
+
+#[derive(Clone, Debug)]
+pub struct Int(cardano_multiplatform_lib_core::Int);
+
+#[wasm_bindgen]
+
+impl Int {
+    pub fn to_original_cbor_bytes(&self) -> Vec<u8> {
+        Serialize::to_original_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Int, JsValue> {
+        Deserialize::from_cbor_bytes(cbor_bytes).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<Int, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new(x: i64) -> Self {
+        if x >= 0 {
+            Self(cardano_multiplatform_lib_core::Int::new_uint(x as u64))
+        }
+        else {
+            Self(cardano_multiplatform_lib_core::Int::new_nint((x + 1).abs() as u64))
+        }
+    }
+
+    pub fn to_str(&self) -> String {
+        self.0.to_string()
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(string: &str) -> Result<Int, JsValue> {
+        // have to redefine so it's visible in WASM
+        std::str::FromStr::from_str(string).map(Self).map_err(|e| JsValue::from_str(&format!("Int.from_str({}): {:?}", string, e)))
+    }
+}
+
+impl From<cardano_multiplatform_lib_core::Int> for Int {
+    fn from(native: cardano_multiplatform_lib_core::Int) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Int> for cardano_multiplatform_lib_core::Int {
+    fn from(wasm: Int) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cardano_multiplatform_lib_core::Int> for Int {
+    fn as_ref(&self) -> &cardano_multiplatform_lib_core::Int {
+        &self.0
+    }
+}

--- a/core-wasm/src/metadata.rs
+++ b/core-wasm/src/metadata.rs
@@ -1,0 +1,282 @@
+#![allow(clippy::len_without_is_empty, clippy::too_many_arguments, clippy::new_without_default)]
+
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+use cardano_multiplatform_lib_core::metadata as core;
+
+use super::*;
+
+pub use cardano_multiplatform_lib_core::metadata::TransactionMetadatumLabel;
+
+impl From<OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum>> for MetadatumMap {
+    fn from(native: OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MetadatumMap> for OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum> {
+    fn from(wrapper: MetadatumMap) -> Self {
+        wrapper.0
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct MetadatumList(Vec<core::TransactionMetadatum>);
+
+#[wasm_bindgen]
+impl MetadatumList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionMetadatum {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &TransactionMetadatum) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<core::TransactionMetadatum>> for MetadatumList {
+    fn from(native: Vec<core::TransactionMetadatum>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MetadatumList> for Vec<core::TransactionMetadatum> {
+    fn from(wrapper: MetadatumList) -> Self {
+        wrapper.0
+    }
+}
+
+impl From<OrderedHashMap<TransactionMetadatumLabel, core::TransactionMetadatum>> for Metadata {
+    fn from(native: OrderedHashMap<TransactionMetadatumLabel, core::TransactionMetadatum>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<Metadata> for OrderedHashMap<TransactionMetadatumLabel, core::TransactionMetadatum> {
+    fn from(wrapper: Metadata) -> Self {
+        wrapper.0
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct TransactionMetadatumLabels(Vec<TransactionMetadatumLabel>);
+
+#[wasm_bindgen]
+impl TransactionMetadatumLabels {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionMetadatumLabel {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: TransactionMetadatumLabel) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<TransactionMetadatumLabel>> for TransactionMetadatumLabels {
+    fn from(native: Vec<TransactionMetadatumLabel>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<TransactionMetadatumLabels> for Vec<TransactionMetadatumLabel> {
+    fn from(wrapper: TransactionMetadatumLabels) -> Self {
+        wrapper.0
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct MetadatumMap(OrderedHashMap<core::TransactionMetadatum, core::TransactionMetadatum>);
+
+#[wasm_bindgen]
+impl MetadatumMap {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &TransactionMetadatum, value: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(Into::into)
+    }
+
+    pub fn get(&self, key: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.get(&key.0).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> MetadatumList {
+        MetadatumList(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct Metadata(core::Metadata);
+
+#[wasm_bindgen]
+impl Metadata {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: TransactionMetadatumLabel, value: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.insert(key.clone().into(), value.clone().into()).map(Into::into)
+    }
+
+    pub fn get(&self, key: TransactionMetadatumLabel) -> Option<TransactionMetadatum> {
+        self.0.get(&key).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> TransactionMetadatumLabels {
+        TransactionMetadatumLabels(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
+    }
+}
+
+impl AsMut<core::Metadata> for Metadata {
+    fn as_mut(&mut self) -> &mut core::Metadata {
+        &mut self.0
+    }
+}
+
+impl AsRef<core::Metadata> for Metadata {
+    fn as_ref(&self) -> &core::Metadata {
+        &self.0
+    }
+}
+
+#[wasm_bindgen]
+pub enum TransactionMetadatumKind {
+    Map,
+    List,
+    Int,
+    Bytes,
+    Text,
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct TransactionMetadatum(core::TransactionMetadatum);
+
+#[wasm_bindgen]
+impl TransactionMetadatum {
+    pub fn to_original_cbor_bytes(&self) -> Vec<u8> {
+        Serialize::to_original_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<TransactionMetadatum, JsValue> {
+        Deserialize::from_cbor_bytes(cbor_bytes).map(Self).map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0).map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0).map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<TransactionMetadatum, JsValue> {
+        serde_json::from_str(json).map(Self).map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_map(entries: &MetadatumMap) -> Self {
+        Self(core::TransactionMetadatum::new_map(entries.clone().into()))
+    }
+
+    pub fn new_list(elements: &MetadatumList) -> Self {
+        Self(core::TransactionMetadatum::new_list(elements.clone().into()))
+    }
+
+    pub fn new_int(int: &Int) -> Self {
+        Self(core::TransactionMetadatum::new_int(int.clone().into()))
+    }
+
+    pub fn new_bytes(bytes: Vec<u8>) -> Self {
+        Self(core::TransactionMetadatum::new_bytes(bytes))
+    }
+
+    pub fn new_text(text: String) -> Self {
+        Self(core::TransactionMetadatum::new_text(text))
+    }
+
+    pub fn kind(&self) -> TransactionMetadatumKind {
+        match &self.0 {
+            core::TransactionMetadatum::Map{ .. } => TransactionMetadatumKind::Map,
+            core::TransactionMetadatum::List{ .. } => TransactionMetadatumKind::List,
+            core::TransactionMetadatum::Int(_) => TransactionMetadatumKind::Int,
+            core::TransactionMetadatum::Bytes{ .. } => TransactionMetadatumKind::Bytes,
+            core::TransactionMetadatum::Text{ .. } => TransactionMetadatumKind::Text,
+        }
+    }
+
+    pub fn as_map(&self) -> Option<MetadatumMap> {
+        match &self.0 {
+            core::TransactionMetadatum::Map{ entries, .. } => Some(entries.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_list(&self) -> Option<MetadatumList> {
+        match &self.0 {
+            core::TransactionMetadatum::List{ elements, .. } => Some(elements.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_int(&self) -> Option<Int> {
+        match &self.0 {
+            core::TransactionMetadatum::Int(int) => Some(int.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_bytes(&self) -> Option<Vec<u8>> {
+        match &self.0 {
+            core::TransactionMetadatum::Bytes{ bytes, .. } => Some(bytes.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn as_text(&self) -> Option<String> {
+        match &self.0 {
+            core::TransactionMetadatum::Text{ text, .. } => Some(text.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl From<core::TransactionMetadatum> for TransactionMetadatum {
+    fn from(native: core::TransactionMetadatum) -> Self {
+        Self(native)
+    }
+}
+
+impl From<TransactionMetadatum> for core::TransactionMetadatum {
+    fn from(wasm: TransactionMetadatum) -> Self {
+        wasm.0
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,10 +8,9 @@ pub mod metadata;
 pub mod ordered_hash_map;
 
 use crate::serialization::{
-  Serialize,
-  Deserialize,
-  StringEncoding,
-  fit_sz,
+    Serialize,
+    Deserialize,
+    fit_sz,
 };
 
 extern crate derivative;

--- a/core/src/metadata.rs
+++ b/core/src/metadata.rs
@@ -82,125 +82,119 @@ impl TransactionMetadatum {
 
 
 impl Serialize for TransactionMetadatum {
-  fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
-      match self {
-          TransactionMetadatum::Map{ entries, entries_encoding } => {
-              serializer.write_map_sz(entries_encoding.to_len_sz(entries.len() as u64, force_canonical))?;
-              let mut key_order = entries.iter().map(|(k, v)| {
-                  let mut buf = cbor_event::se::Serializer::new_vec();
-                  k.serialize(&mut buf, force_canonical)?;
-                  Ok((buf.finalize(), k, v))
-              }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
-              if force_canonical {
-                  key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
-                      match lhs_bytes.len().cmp(&rhs_bytes.len()) {
-                          std::cmp::Ordering::Equal => lhs_bytes.cmp(&rhs_bytes),
-                          diff_ord => diff_ord,
-                      }
-                  });
-              }
-              for (key_bytes, key, value) in key_order {
-                  serializer.write_raw_bytes(&key_bytes)?;
-                  value.serialize(serializer, force_canonical)?;
-              }
-              entries_encoding.end(serializer, force_canonical)
-          },
-          TransactionMetadatum::List{ elements, elements_encoding } => {
-              serializer.write_array_sz(elements_encoding.to_len_sz(elements.len() as u64, force_canonical))?;
-              for element in elements.iter() {
-                  element.serialize(serializer, force_canonical)?;
-              }
-              elements_encoding.end(serializer, force_canonical)
-          },
-          TransactionMetadatum::Int(int) => {
-              int.serialize(serializer, force_canonical)
-          },
-          TransactionMetadatum::Bytes{ bytes, bytes_encoding } => {
-              serializer.write_bytes_sz(&bytes, bytes_encoding.to_str_len_sz(bytes.len() as u64, force_canonical))
-          },
-          TransactionMetadatum::Text{ text, text_encoding } => {
-              serializer.write_text_sz(&text, text_encoding.to_str_len_sz(text.len() as u64, force_canonical))
-          },
-      }
-  }
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            TransactionMetadatum::Map{ entries, entries_encoding } => {
+                serializer.write_map_sz(entries_encoding.to_len_sz(entries.len() as u64, force_canonical))?;
+                let mut key_order = entries.iter().map(|(k, v)| {
+                    let mut buf = cbor_event::se::Serializer::new_vec();
+                    k.serialize(&mut buf, force_canonical)?;
+                    Ok((buf.finalize(), k, v))
+                }).collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                if force_canonical {
+                    key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                        match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                            std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                            diff_ord => diff_ord,
+                        }
+                    });
+                }
+                for (key_bytes, _key, value) in key_order {
+                    serializer.write_raw_bytes(&key_bytes)?;
+                    value.serialize(serializer, force_canonical)?;
+                }
+                entries_encoding.end(serializer, force_canonical)
+            },
+            TransactionMetadatum::List{ elements, elements_encoding } => {
+                serializer.write_array_sz(elements_encoding.to_len_sz(elements.len() as u64, force_canonical))?;
+                for element in elements.iter() {
+                    element.serialize(serializer, force_canonical)?;
+                }
+                elements_encoding.end(serializer, force_canonical)
+            },
+            TransactionMetadatum::Int(int) => {
+                int.serialize(serializer, force_canonical)
+            },
+            TransactionMetadatum::Bytes{ bytes, bytes_encoding } => {
+                serializer.write_bytes_sz(&bytes, bytes_encoding.to_str_len_sz(bytes.len() as u64, force_canonical))
+            },
+            TransactionMetadatum::Text{ text, text_encoding } => {
+                serializer.write_text_sz(&text, text_encoding.to_str_len_sz(text.len() as u64, force_canonical))
+            },
+        }
+    }
 }
 
 impl Deserialize for TransactionMetadatum {
-  fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-      (|| -> Result<_, DeserializeError> {
-          let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
-          match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-              let mut map_transaction_metadatum_to_transaction_metadatum_table = OrderedHashMap::new();
-              let map_transaction_metadatum_to_transaction_metadatum_len = raw.map_sz()?;
-              let entries_encoding = map_transaction_metadatum_to_transaction_metadatum_len.into();
-              while match map_transaction_metadatum_to_transaction_metadatum_len { cbor_event::LenSz::Len(n, _) => map_transaction_metadatum_to_transaction_metadatum_table.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
-                  if raw.cbor_type()? == cbor_event::Type::Special {
-                      assert_eq!(raw.special()?, cbor_event::Special::Break);
-                      break;
-                  }
-                  let map_transaction_metadatum_to_transaction_metadatum_key = TransactionMetadatum::deserialize(raw)?;
-                  let map_transaction_metadatum_to_transaction_metadatum_value = TransactionMetadatum::deserialize(raw)?;
-                  if map_transaction_metadatum_to_transaction_metadatum_table.insert(map_transaction_metadatum_to_transaction_metadatum_key.clone(), map_transaction_metadatum_to_transaction_metadatum_value).is_some() {
-                      return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
-                  }
-              }
-              Ok((map_transaction_metadatum_to_transaction_metadatum_table, entries_encoding))
-          })(raw)
-          {
-              Ok((entries, entries_encoding)) => return Ok(Self::Map {
-                  entries,
-                  entries_encoding,
-              }),
-              Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-          };
-          match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-              let mut arr_transaction_metadatum_arr = Vec::new();
-              let len = raw.array_sz()?;
-              let elements_encoding = len.into();
-              while match len { cbor_event::LenSz::Len(n, _) => arr_transaction_metadatum_arr.len() < n as usize, cbor_event::LenSz::Indefinite => true, } {
-                  if raw.cbor_type()? == cbor_event::Type::Special {
-                      assert_eq!(raw.special()?, cbor_event::Special::Break);
-                      break;
-                  }
-                  arr_transaction_metadatum_arr.push(TransactionMetadatum::deserialize(raw)?);
-              }
-              Ok((arr_transaction_metadatum_arr, elements_encoding))
-          })(raw)
-          {
-              Ok((elements, elements_encoding)) => return Ok(Self::List {
-                  elements,
-                  elements_encoding,
-              }),
-              Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-          };
-          match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-              Ok(Int::deserialize(raw)?)
-          })(raw)
-          {
-              Ok(int) => return Ok(Self::Int(int)),
-              Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-          };
-          match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-              Ok(raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc)))?)
-          })(raw)
-          {
-              Ok((bytes, bytes_encoding)) => return Ok(Self::Bytes {
-                  bytes,
-                  bytes_encoding,
-              }),
-              Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-          };
-          match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-              Ok(raw.text_sz().map(|(s, enc)| (s, StringEncoding::from(enc)))?)
-          })(raw)
-          {
-              Ok((text, text_encoding)) => return Ok(Self::Text {
-                  text,
-                  text_encoding,
-              }),
-              Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-          };
-          Err(DeserializeError::new("TransactionMetadatum", DeserializeFailure::NoVariantMatched.into()))
-      })().map_err(|e| e.annotate("TransactionMetadatum"))
-  }
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut entries_table = OrderedHashMap::new();
+                let entries_len = raw.map_sz()?;
+                let entries_encoding = entries_len.into();
+                while match entries_len { cbor_event::LenSz::Len(n, _) => (entries_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let entries_key = TransactionMetadatum::deserialize(raw)?;
+                    let entries_value = TransactionMetadatum::deserialize(raw)?;
+                    if entries_table.insert(entries_key.clone(), entries_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                }
+                Ok((entries_table, entries_encoding))
+            })(raw)
+            {
+                Ok((entries, entries_encoding)) => return Ok(Self::Map {
+                    entries,
+                    entries_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut elements_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let elements_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => (elements_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    elements_arr.push(TransactionMetadatum::deserialize(raw)?);
+                }
+                Ok((elements_arr, elements_encoding))
+            })(raw)
+            {
+                Ok((elements, elements_encoding)) => return Ok(Self::List {
+                    elements,
+                    elements_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> = Int::deserialize(raw);
+            match deser_variant {
+                Ok(int) => return Ok(Self::Int(int)),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> = raw.bytes_sz().map(|(bytes, enc)| (bytes, StringEncoding::from(enc))).map_err(Into::<DeserializeError>::into);
+            match deser_variant {
+                Ok((bytes, bytes_encoding)) => return Ok(Self::Bytes {
+                    bytes,
+                    bytes_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> = raw.text_sz().map(|(s, enc)| (s, StringEncoding::from(enc))).map_err(Into::<DeserializeError>::into);
+            match deser_variant {
+                Ok((text, text_encoding)) => return Ok(Self::Text {
+                    text,
+                    text_encoding,
+                }),
+                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+            };
+            Err(DeserializeError::new("TransactionMetadatum", DeserializeFailure::NoVariantMatched))
+        })().map_err(|e| e.annotate("TransactionMetadatum"))
+    }
 }


### PR DESCRIPTION
More work on CIP25 to add tests/improve API

Add a core-wasm crate for bindings over core. This is meant to be consumed from our other WASM crates i.e. cip25-wasm/cip36-wasm

Regenerate core/metadata + core-wasm/metadata

Add some documentation to CIP25