### PR TITLE
Support for wasm32-wasi

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -38,12 +38,12 @@ thiserror = "1.0.37"
 # This could possibly be resolved with macros but maybe not.
 
 # non-wasm
-#[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
+#[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))'.dependencies]
 #rand_os = "0.1"
 #noop_proc_macro = "0.3.0"
 
 # wasm
-#[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+#[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
 #rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 #js-sys = "=0.3.59"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,12 +38,12 @@ cfg-if = "1"
 # This could possibly be resolved with macros but maybe not.
 
 # non-wasm
-#[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
+#[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))'.dependencies]
 #rand_os = "0.1"
 #noop_proc_macro = "0.3.0"
 
 # wasm
-#[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+#[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
 #rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 #js-sys = "=0.3.59"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,12 +41,12 @@ base64 = "0.13"
 unicode-segmentation = "1.10.0"
 
 # non-wasm
-[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))'.dependencies]
 rand_os = "0.1"
 noop_proc_macro = "0.3.0"
 
 # wasm
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))'.dependencies]
 getrandom = { version = "0.2.8", features = ["js"], optional = true}
 wasm-bindgen = { version = "=0.2.82", features = ["serde-serialize"] }
 rand_os = { version = "0.1", features = ["wasm-bindgen"] }

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -42,12 +42,12 @@ cfg-if = "1"
 # This could possibly be resolved with macros but maybe not.
 
 # non-wasm
-#[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
+#[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))'.dependencies]
 #rand_os = "0.1"
 #noop_proc_macro = "0.3.0"
 
 # wasm
-#[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+#[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = { version = "=0.2.82", features = ["serde-serialize"] }
 #rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 #js-sys = "=0.3.59"

--- a/rust/src/byron/mod.rs
+++ b/rust/src/byron/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use std::io::{BufRead, Write};

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -178,16 +178,16 @@ impl From<chain_crypto::PublicKeyError> for DeserializeError {
 // Generic string error that is replaced with JsError on wasm builds but still usable from non-wasm builds
 // since JsError panics when used for non-constants in non-wasm builds even just creating one
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 pub type JsError = wasm_bindgen::prelude::JsValue;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 #[derive(Debug, Clone)]
 pub struct JsError {
     msg: String,
 }
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 impl JsError {
     pub fn from_str(s: &str) -> Self {
         Self {
@@ -201,7 +201,7 @@ impl JsError {
     }
 }
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 impl std::fmt::Display for JsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.msg)

--- a/rust/src/ledger/babbage/min_ada.rs
+++ b/rust/src/ledger/babbage/min_ada.rs
@@ -1,7 +1,7 @@
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use crate::Datum;

--- a/rust/src/ledger/byron/witness.rs
+++ b/rust/src/ledger/byron/witness.rs
@@ -1,7 +1,7 @@
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use crate::{crypto::{TransactionHash, LegacyDaedalusPrivateKey, BootstrapWitness, Bip32PublicKey, Vkey, Bip32PrivateKey, Ed25519Signature}, byron::ByronAddress};

--- a/rust/src/ledger/common/binary.rs
+++ b/rust/src/ledger/common/binary.rs
@@ -16,7 +16,7 @@ macro_rules! from_bytes {
     // Custom from_bytes() code
     ($name:ident, $data: ident, $body:block) => {
         // wasm-exposed JsError return - JsError panics when used outside wasm
-        #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
         #[wasm_bindgen]
         impl $name {
             pub fn from_bytes($data: Vec<u8>) -> Result<$name, JsError> {
@@ -24,7 +24,7 @@ macro_rules! from_bytes {
             }
         }
         // non-wasm exposed DeserializeError return
-        #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+        #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
         impl $name {
             pub fn from_bytes($data: Vec<u8>) -> Result<$name, DeserializeError> $body
         }
@@ -74,7 +74,7 @@ macro_rules! to_from_json {
                     .map_err(|e| JsError::from_str(&format!("to_json: {}", e)))
             }
 
-            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+            #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
             pub fn to_js_value(&self) -> Result<JsValue, JsError> {
                 JsValue::from_serde(&self)
                     .map_err(|e| JsError::from_str(&format!("to_js_value: {}", e)))

--- a/rust/src/ledger/common/deposit.rs
+++ b/rust/src/ledger/common/deposit.rs
@@ -1,7 +1,7 @@
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use crate::{Withdrawals, Certificates, CertificateEnum, TransactionBody, error::JsError};

--- a/rust/src/ledger/common/hash.rs
+++ b/rust/src/ledger/common/hash.rs
@@ -1,7 +1,7 @@
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use crate::{TransactionBody, metadata::AuxiliaryData, crypto::{AuxiliaryDataHash, blake2b256, DataHash, TransactionHash, ScriptDataHash, blake2b224, ScriptHash, self}, plutus::{PlutusData, Redeemers, Costmdls, PlutusList, Languages}, error::JsError};

--- a/rust/src/ledger/common/native_script_json.rs
+++ b/rust/src/ledger/common/native_script_json.rs
@@ -1,7 +1,7 @@
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use std::collections::HashMap;

--- a/rust/src/ledger/common/utxo.rs
+++ b/rust/src/ledger/common/utxo.rs
@@ -4,10 +4,10 @@ use cbor_event::Special as CBORSpecial;
 use crate::error::JsError;
 
 use cbor_event::{self, de::Deserializer, se::{Serialize, Serializer}};
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use crate::{to_from_bytes, TransactionInput, TransactionOutput, error::{DeserializeFailure, DeserializeError}};

--- a/rust/src/ledger/common/value.rs
+++ b/rust/src/ledger/common/value.rs
@@ -1,10 +1,10 @@
 use std::io::{BufRead, Seek, Write};
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
 use schemars::JsonSchema;
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use cbor_event::Special as CBORSpecial;

--- a/rust/src/ledger/shelley/witness.rs
+++ b/rust/src/ledger/shelley/witness.rs
@@ -1,7 +1,7 @@
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 use crate::crypto::{TransactionHash, PrivateKey, Vkeywitness, Vkey};

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,10 +20,10 @@ use std::io::{BufRead, Seek, Write};
 use crate::ledger::common::binary::*;
 use ledger::common::hash::{ScriptHashNamespace, hash_script};
 use ledger::common::value::{BigNum, Int, Coin, Value};
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten"))))]
 use noop_proc_macro::wasm_bindgen;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::{JsValue, wasm_bindgen};
 
 // This file was code-generated using an experimental CDDL to rust tool:


### PR DESCRIPTION
It is not currently possible to build CML for wasm32-wasi because it depends on os_rand when compiling for wasm32.
Compiles fine when removing the rand_os dependency, but then you still get all of the js bindings in the output wasm causing it to be incompatible with standard wasi hosts :(

This PR changes all arch cfg checks to prevent js-bindings from being generated for wasi builds



