### PR TITLE
Add testcase for MetadataDetails

### DIFF
--- a/cip25/rust/Cargo.toml
+++ b/cip25/rust/Cargo.toml
@@ -13,3 +13,6 @@ cbor_event = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 schemars = "0.8.8"
+
+[dev-dependencies]
+hex = "0.4.0"

--- a/cip25/rust/src/utils.rs
+++ b/cip25/rust/src/utils.rs
@@ -137,4 +137,17 @@ mod tests {
         let from_metadata = CIP25Metadata::from_metadata(&as_metadata).unwrap();
         assert_eq!(metadata_bytes, from_metadata.to_bytes());
     }
+
+    #[test]
+    fn parse_metadata_details() {
+        // {
+        //  "arweaveId": "6srpXZOTfK_62KUrJKh4VdCFG0YS271pq20OMRpE5Ts",
+        //  "image": "ipfs://QmUWP6xGHucgBUv514gwgbt4yijg36aUQunEP61z5D8RKS",
+        //  "name": "SpaceBud #1507",
+        //  "traits": ["Star Suit", "Chestplate", "Belt", "Flag", "Pistol"],
+        //  "type": "Alien",
+        // }
+        let bytes = "a569617277656176654964782b36737270585a4f54664b5f36324b55724a4b68345664434647305953323731707132304f4d52704535547365696d6167657835697066733a2f2f516d5557503678474875636742557635313467776762743479696a673336615551756e455036317a354438524b53646e616d656e53706163654275642023313530376674726169747385695374617220537569746a4368657374706c6174656442656c7464466c616766506973746f6c647479706565416c69656e";
+        let details = MetadataDetails::from_bytes(hex::decode(bytes).unwrap()).unwrap(); 
+    }
 }


### PR DESCRIPTION
There is currently a bug in the way we handle optional keys in CML (notably, CIP25)

As you know, we ignored optional keys as you can see [here](https://github.com/dcSpark/cardano-multiplatform-lib/blob/76a8b0eda94624f9901742eaa9e917a0f6635014/cip25/rust/src/serialization.rs#L451)

However, we didn't change the way length checking is handled

# Bug details

CIP25 has only 2 mandatory fields: `name` and `image`

The following CIP25 entry has both mandatory fields, and 3 extra fields not tracked by CIP25

```json
{
    "image": "ipfs://QmUWP6xGHucgBUv514gwgbt4yijg36aUQunEP61z5D8RKS",
    "name": "SpaceBud #1507",

    "arweaveId": "6srpXZOTfK_62KUrJKh4VdCFG0YS271pq20OMRpE5Ts",
    "traits": ["Star Suit", "Chestplate", "Belt", "Flag", "Pistol"],
    "type": "Alien",
}
```

This means that [read_len](https://github.com/dcSpark/cardano-multiplatform-lib/blob/76a8b0eda94624f9901742eaa9e917a0f6635014/cip25/rust/src/serialization.rs#L385) here is equal to 5

However, these 3 unexpected keys are not tracked by `read_len`, so when we get to the end of the function, [read_len.finish()](https://github.com/dcSpark/cardano-multiplatform-lib/blob/76a8b0eda94624f9901742eaa9e917a0f6635014/cip25/rust/src/serialization.rs#L472) crashes with `DeserializeError { location: Some("MetadataDetails"), failure: DefiniteLenMismatch(5, Some(2))`
