### PR TITLE
Flaky random-improve tests now try 3 times

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "cryptoxide",
  "digest 0.9.0",
  "ed25519-bip32",
+ "flaky_test",
  "fraction",
  "getrandom 0.2.8",
  "hex",
@@ -193,6 +194,17 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "flaky_test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479cde5eb168cf5a056dd98f311cbfab7494c216394e4fb9eba0336827a8db93"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,6 +60,7 @@ opt-level = "s"
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"
 rand_chacha = "0.3.1"
+flaky_test = "0.1.0"
 
 [features]
 wasm = ["getrandom"]

--- a/rust/src/builders/tx_builder.rs
+++ b/rust/src/builders/tx_builder.rs
@@ -3002,6 +3002,7 @@ mod tests {
     }
 
     #[test]
+    #[flaky_test::flaky_test]
     fn tx_builder_cip2_random_improve_multiasset() {
         let mut tx_builder = create_tx_builder_with_fee(&create_linear_fee(0, 0));
         let pid1 = PolicyID::from([1u8; 28]);
@@ -3089,6 +3090,7 @@ mod tests {
     }
 
     #[test]
+    #[flaky_test::flaky_test]
     fn tx_builder_cip2_random_improve() {
         // we have a = 1 to test increasing fees when more inputs are added
         let mut tx_builder = create_tx_builder_with_fee(&create_linear_fee(1, 0));
@@ -3134,6 +3136,7 @@ mod tests {
     }
 
     #[test]
+    #[flaky_test::flaky_test]
     fn tx_builder_cip2_random_improve_exclude_used_indices() {
         let mut tx_builder = create_tx_builder_with_fee(&create_linear_fee(44, 155381));
         const COST: u64 = 1000000;
@@ -3169,6 +3172,7 @@ mod tests {
     }
 
     #[test]
+    #[flaky_test::flaky_test]
     fn tx_builder_cip2_random_improve_when_using_all_available_inputs() {
         // we have a = 1 to test increasing fees when more inputs are added
         let linear_fee = LinearFee::new(&to_bignum(1), &to_bignum(0));
@@ -3205,6 +3209,7 @@ mod tests {
     }
 
     #[test]
+    #[flaky_test::flaky_test]
     fn tx_builder_cip2_random_improve_adds_enough_for_fees() {
         // we have a = 1 to test increasing fees when more inputs are added
         let linear_fee = LinearFee::new(&to_bignum(1), &to_bignum(0));


### PR DESCRIPTION
Before this change I ran the tests 100 times and had 3 failures (i.e. 1 or more of those 5 tests failed).

This can occasionally be annoying if it causes the CI to report a failure.

After this change each one runs 3 times which should make it extremely unlikely to have a test fail as the same test would have to fail 3 times in a row to fail. Using those stats from above that's a <0.0027% (assuming each test 3% chance - likely much lower as that's the chance for only 1 or more of the 5 tests failing) chance of failure.