### PR TITLE
Add loose nft parsing

### DIFF
--- a/cip25/rust/Cargo.toml
+++ b/cip25/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cml-cip25"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2018"
 keywords = ["cardano"]
 

--- a/cip25/rust/src/utils.rs
+++ b/cip25/rust/src/utils.rs
@@ -127,20 +127,17 @@ impl MiniMetadataDetails {
     }
 
     /// loose parsing of CIP25 metadata to allow for common exceptions to the format
+    /// `metadatum` should represent the data where the `MetadataDetails` is in the cip25 structure
     /// TODO: this is not an ideal solution
     ///       ideally: we would have a function that takes in a policy ID
     ///       and would have a lookup map to know which lambda to call to get the name & image depending on the policy ID
     ///       with a fallback to the standard CIP25 definition
     ///       however, since this is a lot of work, we use this temporary solution instead
-    pub fn loose_parse(data: Vec<u8>) -> Result<Self, DeserializeError> {
-        let metadatum = TransactionMetadatum::from_bytes(
-            data,
-        )?;
+    pub fn loose_parse(metadatum: TransactionMetadatum) -> Result<Self, DeserializeError> {
         match metadatum {
             TransactionMetadatum::Map { entries, .. } => {
                 let name: Option<String64> = entries
                 .get(&TransactionMetadatum::new_text("name".to_owned()))
-                .or_else(|| entries.get(&TransactionMetadatum::new_text("name".to_owned())))
                 // for some reason, 1% of NFTs seem to use the wrong case
                 .or_else(|| entries.get(&TransactionMetadatum::new_text("Name".to_owned())))
                 // for some reason, 0.5% of NFTs use "title" instead of name
@@ -260,28 +257,28 @@ mod tests {
     #[test]
     fn just_name() {
         // {"name":"Metaverse"}
-        let details = MiniMetadataDetails::loose_parse(hex::decode("a1646e616d65694d6574617665727365").unwrap()).unwrap();
+        let details = MiniMetadataDetails::loose_parse(TransactionMetadatum::from_bytes(hex::decode("a1646e616d65694d6574617665727365").unwrap()).unwrap()).unwrap();
         assert_eq!(details.name.unwrap().0, "Metaverse");
     }
 
     #[test]
     fn uppercase_name() {
         // {"Date":"9 May 2021","Description":"Happy Mother's Day to all the Cardano Moms!","Image":"ipfs.io/ipfs/Qmah6QPKUKvp6K9XQB2SA42Q3yrffCbYBbk8EoRrB7FN2g","Name":"Mother's Day 2021","Ticker":"MOM21","URL":"ipfs.io/ipfs/Qmah6QPKUKvp6K9XQB2SA42Q3yrffCbYBbk8EoRrB7FN2g"}
-        let details = MiniMetadataDetails::loose_parse(hex::decode("a664446174656a39204d617920323032316b4465736372697074696f6e782b4861707079204d6f7468657227732044617920746f20616c6c207468652043617264616e6f204d6f6d732165496d616765783b697066732e696f2f697066732f516d61683651504b554b7670364b39585142325341343251337972666643625942626b38456f52724237464e3267644e616d65714d6f746865722773204461792032303231665469636b6572654d4f4d32316355524c783b697066732e696f2f697066732f516d61683651504b554b7670364b39585142325341343251337972666643625942626b38456f52724237464e3267").unwrap()).unwrap();
+        let details = MiniMetadataDetails::loose_parse(TransactionMetadatum::from_bytes(hex::decode("a664446174656a39204d617920323032316b4465736372697074696f6e782b4861707079204d6f7468657227732044617920746f20616c6c207468652043617264616e6f204d6f6d732165496d616765783b697066732e696f2f697066732f516d61683651504b554b7670364b39585142325341343251337972666643625942626b38456f52724237464e3267644e616d65714d6f746865722773204461792032303231665469636b6572654d4f4d32316355524c783b697066732e696f2f697066732f516d61683651504b554b7670364b39585142325341343251337972666643625942626b38456f52724237464e3267").unwrap()).unwrap()).unwrap();
         assert_eq!(details.name.unwrap().0, "Mother's Day 2021");
     }
 
     #[test]
     fn id_no_name() {
         // {"id":"00","image":"ipfs://QmSfYTF8B4ua6hFdr6URdRDZBZ9FjCQNUdDcLr2f7P8xn3"}
-        let details = MiniMetadataDetails::loose_parse(hex::decode("a262696462303065696d6167657835697066733a2f2f516d5366595446384234756136684664723655526452445a425a39466a43514e556444634c723266375038786e33").unwrap()).unwrap();
+        let details = MiniMetadataDetails::loose_parse(TransactionMetadatum::from_bytes(hex::decode("a262696462303065696d6167657835697066733a2f2f516d5366595446384234756136684664723655526452445a425a39466a43514e556444634c723266375038786e33").unwrap()).unwrap()).unwrap();
         assert_eq!(details.name.unwrap().0, "00");
     }
 
     #[test]
     fn just_image() {
         // {"image":"ipfs://QmSfYTF8B4ua6hFdr6URdRDZBZ9FjCQNUdDcLr2f7P8xn3"}
-        let details = MiniMetadataDetails::loose_parse(hex::decode("a165696d6167657835697066733a2f2f516d5366595446384234756136684664723655526452445a425a39466a43514e556444634c723266375038786e33").unwrap()).unwrap();
+        let details = MiniMetadataDetails::loose_parse(TransactionMetadatum::from_bytes(hex::decode("a165696d6167657835697066733a2f2f516d5366595446384234756136684664723655526452445a425a39466a43514e556444634c723266375038786e33").unwrap()).unwrap()).unwrap();
         assert_eq!(String::from(&details.image.unwrap()), "ipfs://QmSfYTF8B4ua6hFdr6URdRDZBZ9FjCQNUdDcLr2f7P8xn3");
     }
 

--- a/cip25/rust/src/utils.rs
+++ b/cip25/rust/src/utils.rs
@@ -109,6 +109,87 @@ impl From<&ChunkableString> for String {
     }
 }
 
+
+/// A subset of MetadataDetails where the keys are optional
+/// Useful to extract the key fields (name & image) of incorrectly formatted cip25
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MiniMetadataDetails {
+    pub name: Option<String64>,
+    pub image: Option<ChunkableString>,
+}
+
+impl MiniMetadataDetails {
+    pub fn new(name: Option<String64>, image: Option<ChunkableString>) -> Self {
+        Self {
+            name,
+            image,
+        }
+    }
+
+    /// loose parsing of CIP25 metadata to allow for common exceptions to the format
+    /// TODO: this is not an ideal solution
+    ///       ideally: we would have a function that takes in a policy ID
+    ///       and would have a lookup map to know which lambda to call to get the name & image depending on the policy ID
+    ///       with a fallback to the standard CIP25 definition
+    ///       however, since this is a lot of work, we use this temporary solution instead
+    pub fn loose_parse(data: Vec<u8>) -> Result<Self, DeserializeError> {
+        let metadatum = TransactionMetadatum::from_bytes(
+            data,
+        )?;
+        match metadatum {
+            TransactionMetadatum::Map { entries, .. } => {
+                let name: Option<String64> = entries
+                .get(&TransactionMetadatum::new_text("name".to_owned()))
+                .or_else(|| entries.get(&TransactionMetadatum::new_text("name".to_owned())))
+                // for some reason, 1% of NFTs seem to use the wrong case
+                .or_else(|| entries.get(&TransactionMetadatum::new_text("Name".to_owned())))
+                // for some reason, 0.5% of NFTs use "title" instead of name
+                .or_else(|| entries.get(&TransactionMetadatum::new_text("title".to_owned())))
+                // for some reason, 0.3% of NFTs use "id" instead of name
+                .or_else(|| entries.get(&TransactionMetadatum::new_text("id".to_owned())))
+                .map(|result| match result {
+                    TransactionMetadatum::Text { text, .. } => String64::new_str(&text).ok(),
+                    _ => None,
+                })
+                .flatten();
+    
+                let image_base = entries
+                .get(&TransactionMetadatum::new_text("image".to_owned()));
+                let image = match image_base {
+                    None => None,
+                    Some(base) => match base {
+                        TransactionMetadatum::Text { text, .. } => match String64::new_str(&text) {
+                            Ok(str64) => Some(ChunkableString::Single(str64)),
+                            Err(_) => None,
+                        },
+                        TransactionMetadatum::List { elements, .. } => {
+                            (|| {
+                                let mut chunks: Vec<String64> = vec![];
+                                for i in 0..elements.len() {
+                                    match elements.get(i) {
+                                        Some(TransactionMetadatum::Text { text, .. }) => {
+                                            match String64::new_str(&text) {
+                                                Ok(str64) => chunks.push(str64),
+                                                Err(_) => return None,
+                                            }
+                                        },
+                                        _ => return None
+                                    };
+                                };
+                                Some(ChunkableString::Chunked(chunks))
+                            })()
+                        },
+                        _ => None,
+                    },
+                };
+    
+                Ok(MiniMetadataDetails::new(name, image))
+            },
+            _ => Err(DeserializeError::new("MiniMetadataDetails", DeserializeFailure::NoVariantMatched))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -174,6 +255,34 @@ mod tests {
             let bytes = "a365636f6c6f72672345433937423665696d616765783a697066733a2f2f697066732f516d557662463273694846474752745a357a613156774e51387934396262746a6d59664659686745383968437132646e616d656a426572727920416c6261";
             MetadataDetails::from_bytes(hex::decode(bytes).unwrap()).unwrap();
         }
+    }
+
+    #[test]
+    fn just_name() {
+        // {"name":"Metaverse"}
+        let details = MiniMetadataDetails::loose_parse(hex::decode("a1646e616d65694d6574617665727365").unwrap()).unwrap();
+        assert_eq!(details.name.unwrap().0, "Metaverse");
+    }
+
+    #[test]
+    fn uppercase_name() {
+        // {"Date":"9 May 2021","Description":"Happy Mother's Day to all the Cardano Moms!","Image":"ipfs.io/ipfs/Qmah6QPKUKvp6K9XQB2SA42Q3yrffCbYBbk8EoRrB7FN2g","Name":"Mother's Day 2021","Ticker":"MOM21","URL":"ipfs.io/ipfs/Qmah6QPKUKvp6K9XQB2SA42Q3yrffCbYBbk8EoRrB7FN2g"}
+        let details = MiniMetadataDetails::loose_parse(hex::decode("a664446174656a39204d617920323032316b4465736372697074696f6e782b4861707079204d6f7468657227732044617920746f20616c6c207468652043617264616e6f204d6f6d732165496d616765783b697066732e696f2f697066732f516d61683651504b554b7670364b39585142325341343251337972666643625942626b38456f52724237464e3267644e616d65714d6f746865722773204461792032303231665469636b6572654d4f4d32316355524c783b697066732e696f2f697066732f516d61683651504b554b7670364b39585142325341343251337972666643625942626b38456f52724237464e3267").unwrap()).unwrap();
+        assert_eq!(details.name.unwrap().0, "Mother's Day 2021");
+    }
+
+    #[test]
+    fn id_no_name() {
+        // {"id":"00","image":"ipfs://QmSfYTF8B4ua6hFdr6URdRDZBZ9FjCQNUdDcLr2f7P8xn3"}
+        let details = MiniMetadataDetails::loose_parse(hex::decode("a262696462303065696d6167657835697066733a2f2f516d5366595446384234756136684664723655526452445a425a39466a43514e556444634c723266375038786e33").unwrap()).unwrap();
+        assert_eq!(details.name.unwrap().0, "00");
+    }
+
+    #[test]
+    fn just_image() {
+        // {"image":"ipfs://QmSfYTF8B4ua6hFdr6URdRDZBZ9FjCQNUdDcLr2f7P8xn3"}
+        let details = MiniMetadataDetails::loose_parse(hex::decode("a165696d6167657835697066733a2f2f516d5366595446384234756136684664723655526452445a425a39466a43514e556444634c723266375038786e33").unwrap()).unwrap();
+        assert_eq!(String::from(&details.image.unwrap()), "ipfs://QmSfYTF8B4ua6hFdr6URdRDZBZ9FjCQNUdDcLr2f7P8xn3");
     }
 
     #[test]

--- a/cip25/wasm/Cargo.toml
+++ b/cip25/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cml-cip25-wasm"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2018"
 keywords = ["cardano"]
 

--- a/cip25/wasm/README.md
+++ b/cip25/wasm/README.md
@@ -45,3 +45,10 @@ for (var i = 0; i < policies.len(); ++i) {
   }
 }
 ```
+
+We also support loose NFT parsing to try and parse key information out of potentially incorrectly formatted CIP25
+
+```typescript
+const details = wasm.CIP25.MiniMetadataDetails.loose_parse(Buffer.from("a1646e616d65694d6574617665727365", "hex"));
+console.log(details.name());
+```

--- a/cip25/wasm/package.json
+++ b/cip25/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cml-cip25",
-  "version": "3.1.3",
+  "version": "1.0.0",
   "description": "Cardano Multiplatform SDK for CIP25 (Cardano NFT Metadata)",
   "keywords": [
     "cardano"

--- a/cip25/wasm/src/utils.rs
+++ b/cip25/wasm/src/utils.rs
@@ -53,3 +53,61 @@ impl ChunkableString {
         String::from(&self.0)
     }
 }
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MiniMetadataDetails(pub(crate) core::utils::MiniMetadataDetails);
+
+#[wasm_bindgen]
+impl MiniMetadataDetails {
+    pub fn new() -> Self {
+        MiniMetadataDetails(core::utils::MiniMetadataDetails {
+            name: None,
+            image: None
+        })
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MiniMetadataDetails, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_name(&mut self, name: &String64) {
+        self.0.name = Some(name.clone().into())
+    }
+
+    pub fn name(&self) -> Option<String64> {
+        self.0.name.clone().map(String64)
+    }
+
+    pub fn set_image(&mut self, image: &ChunkableString) {
+        self.0.image = Some(image.clone().into())
+    }
+
+    pub fn image(&self) -> Option<ChunkableString> {
+        self.0.image.clone().map(ChunkableString)
+    }
+}
+
+impl From<core::utils::MiniMetadataDetails> for MiniMetadataDetails {
+    fn from(native: core::utils::MiniMetadataDetails) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MiniMetadataDetails> for core::utils::MiniMetadataDetails {
+    fn from(wasm: MiniMetadataDetails) -> Self {
+        wasm.0
+    }
+}


### PR DESCRIPTION
Not all NFTs properly follow CIP25. Notably, some NFTs
- Are missing mandatory keys
- Use different names for the fields for some reason

To tackle this, I created loose NFT parsing logic so that we can use it in Flint to try and detect more NFTs properly