### PR TITLE
CIP36 use RawBytesEncoding directly + refactoring

### DIFF
--- a/cip36/rust/Cargo.toml
+++ b/cip36/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cml-cip36"
 version = "0.1.0"
 edition = "2018"
-keywords = ["cardano"]
+keywords = ["cardano", "cip36"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/cip36/rust/src/cbor_encodings.rs
+++ b/cip36/rust/src/cbor_encodings.rs
@@ -1,27 +1,36 @@
-use super::*;
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_core::serialization::{LenEncoding, StringEncoding};
 
 #[derive(Clone, Debug, Default)]
 pub struct DelegationEncoding {
     pub len_encoding: LenEncoding,
+    pub voting_pub_key_encoding: StringEncoding,
     pub weight_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DeregistrationCborEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub key_deregistration_key_encoding: Option<cbor_event::Sz>,
+    pub deregistration_witness_key_encoding: Option<cbor_event::Sz>,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct DeregistrationWitnessEncoding {
     pub len_encoding: LenEncoding,
     pub orig_deser_order: Vec<usize>,
+    pub stake_witness_encoding: StringEncoding,
     pub stake_witness_key_encoding: Option<cbor_event::Sz>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct Ed25519SignatureEncoding {
-    pub inner_encoding: StringEncoding,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct KeyDeregistrationEncoding {
     pub len_encoding: LenEncoding,
     pub orig_deser_order: Vec<usize>,
+    pub stake_credential_encoding: StringEncoding,
     pub stake_credential_key_encoding: Option<cbor_event::Sz>,
     pub nonce_encoding: Option<cbor_event::Sz>,
     pub nonce_key_encoding: Option<cbor_event::Sz>,
@@ -35,6 +44,7 @@ pub struct KeyRegistrationEncoding {
     pub len_encoding: LenEncoding,
     pub orig_deser_order: Vec<usize>,
     pub delegation_key_encoding: Option<cbor_event::Sz>,
+    pub stake_credential_encoding: StringEncoding,
     pub stake_credential_key_encoding: Option<cbor_event::Sz>,
     pub reward_address_key_encoding: Option<cbor_event::Sz>,
     pub nonce_encoding: Option<cbor_event::Sz>,
@@ -45,18 +55,17 @@ pub struct KeyRegistrationEncoding {
 }
 
 #[derive(Clone, Debug, Default)]
+pub struct RegistrationCborEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub key_registration_key_encoding: Option<cbor_event::Sz>,
+    pub registration_witness_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct RegistrationWitnessEncoding {
     pub len_encoding: LenEncoding,
     pub orig_deser_order: Vec<usize>,
+    pub stake_witness_encoding: StringEncoding,
     pub stake_witness_key_encoding: Option<cbor_event::Sz>,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct StakingPubKeyEncoding {
-    pub inner_encoding: StringEncoding,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct VotingPubKeyEncoding {
-    pub inner_encoding: StringEncoding,
 }

--- a/cip36/rust/src/error.rs
+++ b/cip36/rust/src/error.rs
@@ -1,0 +1,10 @@
+#[derive(Debug, thiserror::Error)]
+pub enum CIP36Error {
+    #[error("Empty delegation array")]
+    EmptyDelegationArray,
+    // TODO: can we check this somehow against anything? I don't believe so, so maybe remove this
+    // #[error("Reward wrong network")]
+    // RewardWrongNetwork,
+    #[error("Invalid delegation weights")]
+    DelegationWeightsZero,
+}

--- a/cip36/rust/src/lib.rs
+++ b/cip36/rust/src/lib.rs
@@ -1,11 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
-// This library was partially code-generated using an experimental CDDL to rust tool:
+// This file was partially code-generated using an experimental CDDL to rust tool:
 // https://github.com/dcSpark/cddl-codegen
-
-use cml_chain::TransactionMetadatum;
-use cml_core;
-use cml_crypto;
 
 pub use cml_core::{
     error::{DeserializeError, DeserializeFailure},
@@ -16,38 +12,23 @@ pub use cml_core::{
 
 pub use cml_chain::{address::RewardAddress, NetworkId};
 
-use cbor_event::{self, de::Deserializer, se::Serializer};
-
-use std::io::{BufRead, Write};
-
-use cbor_event::Type as CBORType;
-
-use cbor_event::Special as CBORSpecial;
-
-use serialization::*;
-
-use std::collections::BTreeMap;
-
-use std::convert::{From, TryFrom};
-
-pub mod serialization;
-
-use cbor_event::Sz;
+use std::convert::From;
 
 pub mod cbor_encodings;
+pub mod error;
+pub mod serialization;
+pub mod utils;
 
 use cbor_encodings::*;
 
 extern crate derivative;
 
-use derivative::Derivative;
-
 /// To avoid linking voting keys directly with Cardano spending keys,
 /// the voting key derivation path must start with a specific segment:
 /// m / 1694' / 1815' / account' / chain / address_index
-pub type VotingPubKey = cml_crypto::chain::ChainCrypto<cml_crypto::PublicKey>;
+pub type VotingPubKey = cml_crypto::PublicKey;
 
-pub type StakingPubKey = cml_crypto::chain::ChainCrypto<cml_crypto::PublicKey>;
+pub type StakingPubKey = cml_crypto::PublicKey;
 
 pub type LegacyKeyRegistration = VotingPubKey;
 
@@ -58,53 +39,11 @@ pub type Nonce = u64;
 
 pub type StakeCredential = StakingPubKey;
 
-pub type StakeWitness = cml_crypto::chain::ChainCrypto<cml_crypto::Ed25519Signature>;
+pub type StakeWitness = cml_crypto::Ed25519Signature;
 
 pub type VotingPurpose = u64;
 
 pub type Weight = u32;
-
-pub static KEY_REGISTRATION_LABEL: u64 = 61284;
-pub static REGISTRATION_WITNESS_LABEL: u64 = 61285;
-pub static DEREGISTRATION_WITNESS_LABEL: u64 = REGISTRATION_WITNESS_LABEL;
-pub static KEY_DEREGISTRATION_LABEL: u64 = 61286;
-
-#[derive(Debug, thiserror::Error)]
-pub enum CIP36Error {
-    #[error("Empty delegation array")]
-    EmptyDelegationArray,
-    // TODO: can we check this somehow against anything? I don't believe so, so maybe remove this
-    // #[error("Reward wrong network")]
-    // RewardWrongNetwork,
-    #[error("Invalid delegation weights")]
-    DelegationWeightsZero,
-}
-
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
-pub enum DelegationDistribution {
-    Weighted {
-        delegations: Vec<Delegation>,
-        #[serde(skip)]
-        delegations_encoding: LenEncoding,
-    },
-    LegacyKeyRegistration(LegacyKeyRegistration),
-}
-
-impl DelegationDistribution {
-    /// Create a new weighted delegation. Weights are relative to all others and will be rounded down.
-    /// Leftover ADA will be delegated to the last item in the array.
-    pub fn new_weighted(delegations: Vec<Delegation>) -> Self {
-        Self::Weighted {
-            delegations,
-            delegations_encoding: LenEncoding::default(),
-        }
-    }
-
-    /// Delegate to a single key i.e. CIP-15.
-    pub fn new_legacy_key_registration(legacy_key_registration: LegacyKeyRegistration) -> Self {
-        Self::LegacyKeyRegistration(legacy_key_registration)
-    }
-}
 
 /// Weighted delegation input.
 /// This is the proportion of weight to assign to this public key relative to the weights
@@ -127,199 +66,45 @@ impl Delegation {
     }
 }
 
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum DelegationDistribution {
+    Weighted {
+        delegations: Vec<Delegation>,
+        #[serde(skip)]
+        delegations_encoding: LenEncoding,
+    },
+    Legacy {
+        legacy: LegacyKeyRegistration,
+        #[serde(skip)]
+        legacy_encoding: StringEncoding,
+    },
+}
+
+impl DelegationDistribution {
+    /// Create a new delegations delegation. Weights are relative to all others and will be rounded down.
+    /// Leftover ADA will be delegated to the last item in the array.
+    pub fn new_weighted(delegations: Vec<Delegation>) -> Self {
+        Self::Weighted {
+            delegations,
+            delegations_encoding: LenEncoding::default(),
+        }
+    }
+
+    /// Delegate to a single key i.e. CIP-15.
+    pub fn new_legacy(legacy: LegacyKeyRegistration) -> Self {
+        Self::Legacy {
+            legacy,
+            legacy_encoding: StringEncoding::default(),
+        }
+    }
+}
+
 /// This is the entire metadata schema for CIP-36 deregistration.
 /// It can be parsed by passing in the CBOR bytes of the entire transaction metadatum
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct DeregistrationCbor {
     pub key_deregistration: KeyDeregistration,
     pub deregistration_witness: DeregistrationWitness,
-}
-
-impl DeregistrationCbor {
-    pub fn new(
-        key_deregistration: KeyDeregistration,
-        deregistration_witness: DeregistrationWitness,
-    ) -> Self {
-        Self {
-            key_deregistration,
-            deregistration_witness,
-        }
-    }
-
-    /// Add to an existing metadata (could be empty) the full CIP36 deregistration metadata
-    pub fn add_to_metadata(&self, metadata: &mut Metadata) -> Result<(), DeserializeError> {
-        let dereg_metadatum = TransactionMetadatum::from_cbor_bytes(
-            &self.key_deregistration.to_original_cbor_bytes(),
-        )?;
-        metadata.insert(KEY_DEREGISTRATION_LABEL, dereg_metadatum);
-        let witness_metadatum = TransactionMetadatum::from_cbor_bytes(
-            &self.deregistration_witness.to_original_cbor_bytes(),
-        )?;
-        metadata.insert(DEREGISTRATION_WITNESS_LABEL, witness_metadatum);
-        Ok(())
-    }
-
-    // these are not implementing Serialize/Deserialize as we do not keep track of the rest of the encoding metadata
-    // so it would be disingenuous to implement them if users called to_original_cbor_bytes() and we skip the rest of
-    // the metadata, as well as when creating from a Metadata object its outer encoding (e.g. map len, key encodings)
-    // is not present as that is simply an OrderedHashMap<TransactionMetadatumLabel, TransactionMetadatum>
-
-    /// Serializes to bytes compatable with Metadata, but containing ONLY the relevant fields for CIP36.
-    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
-    /// the encodings but only from the metadatums themselves within the keys 61285 and 61286
-    pub fn to_metadata_bytes(&self) -> Vec<u8> {
-        let mut buf = Serializer::new_vec();
-        self.serialize(&mut buf, false).unwrap();
-        buf.finalize()
-    }
-
-    /// Create a CIP36 view from the bytes of a Metadata.
-    /// The resulting DeregistrationCbor will contain ONLY the relevant fields for CIP36 from the Metadata
-    pub fn from_metadata_bytes(
-        &self,
-        metadata_cbor_bytes: &[u8],
-    ) -> Result<Self, DeserializeError> {
-        let mut raw = Deserializer::from(std::io::Cursor::new(metadata_cbor_bytes));
-        Self::deserialize(&mut raw)
-    }
-
-    /// Serializes as a Metadata structure containing ONLY the relevant fields for CIP36
-    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
-    /// the encodings but only from the metadatums themselves within the keys 61285 and 61286
-    /// * `force_canonical` - Whether to force canonical CBOR encodings. ONLY applies to the metadatums within labels 61285 and 61286
-    pub fn serialize<'se, W: Write>(
-        &self,
-        serializer: &'se mut Serializer<W>,
-        force_canonical: bool,
-    ) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Len(2))?;
-        serializer.write_unsigned_integer(DEREGISTRATION_WITNESS_LABEL)?;
-        self.deregistration_witness
-            .serialize(serializer, force_canonical)?;
-        serializer.write_unsigned_integer(KEY_DEREGISTRATION_LABEL)?;
-        self.key_deregistration
-            .serialize(serializer, force_canonical)
-    }
-
-    /// Deserializes a CIP36 view from either a Metadata or a DeregistrationCbor
-    /// This contains ONLY the relevant fields for CIP36 if created from a Metadata
-    pub fn deserialize<R: BufRead + std::io::Seek>(
-        raw: &mut Deserializer<R>,
-    ) -> Result<Self, DeserializeError> {
-        use cml_core::{serialization::CBORReadLen, Key};
-
-        let len = raw.map_sz()?;
-        let mut read_len = CBORReadLen::new(len);
-        read_len.read_elems(2)?;
-        (|| -> Result<_, DeserializeError> {
-            let mut deregistration_witness = None;
-            let mut key_deregistration = None;
-            let mut read = 0;
-            while match len {
-                cbor_event::LenSz::Len(n, _enc) => read < n,
-                cbor_event::LenSz::Indefinite => true,
-            } {
-                match raw.cbor_type()? {
-                    CBORType::UnsignedInteger => match raw.unsigned_integer()? {
-                        61285 => {
-                            if deregistration_witness.is_some() {
-                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
-                                    DEREGISTRATION_WITNESS_LABEL,
-                                ))
-                                .into());
-                            }
-                            deregistration_witness =
-                                Some(DeregistrationWitness::deserialize(raw).map_err(
-                                    |e: DeserializeError| e.annotate("deregistration_witness"),
-                                )?);
-                        }
-                        61286 => {
-                            if key_deregistration.is_some() {
-                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
-                                    KEY_DEREGISTRATION_LABEL,
-                                ))
-                                .into());
-                            }
-                            key_deregistration =
-                                Some(KeyDeregistration::deserialize(raw).map_err(
-                                    |e: DeserializeError| e.annotate("key_deregistration"),
-                                )?);
-                        }
-                        _unknown_key => (), /* ignore all other metadatum labels */
-                    },
-                    CBORType::Special => match len {
-                        cbor_event::LenSz::Len(_, _) => {
-                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
-                        }
-                        cbor_event::LenSz::Indefinite => match raw.special()? {
-                            CBORSpecial::Break => break,
-                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                        },
-                    },
-                    other_type => {
-                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
-                    }
-                }
-                read += 1;
-            }
-            let key_deregistration = match key_deregistration {
-                Some(x) => x,
-                None => {
-                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
-                        KEY_DEREGISTRATION_LABEL,
-                    ))
-                    .into())
-                }
-            };
-            let deregistration_witness = match deregistration_witness {
-                Some(x) => x,
-                None => {
-                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
-                        DEREGISTRATION_WITNESS_LABEL,
-                    ))
-                    .into())
-                }
-            };
-            read_len.finish()?;
-            Ok(Self {
-                key_deregistration,
-                deregistration_witness,
-            })
-        })()
-        .map_err(|e| e.annotate("DeregistrationCbor"))
-    }
-}
-
-impl std::convert::TryFrom<&Metadata> for DeregistrationCbor {
-    type Error = DeserializeError;
-
-    fn try_from(metadata: &Metadata) -> Result<Self, Self::Error> {
-        use cml_core::error::Key;
-        let dereg_metadatum = metadata.get(&KEY_DEREGISTRATION_LABEL).ok_or_else(|| {
-            DeserializeFailure::MandatoryFieldMissing(Key::Uint(KEY_DEREGISTRATION_LABEL))
-        })?;
-        let witness_metadatum = metadata.get(&DEREGISTRATION_WITNESS_LABEL).ok_or_else(|| {
-            DeserializeFailure::MandatoryFieldMissing(Key::Uint(DEREGISTRATION_WITNESS_LABEL))
-        })?;
-        Ok(Self {
-            key_deregistration: KeyDeregistration::from_cbor_bytes(
-                &dereg_metadatum.to_original_cbor_bytes(),
-            )?,
-            deregistration_witness: DeregistrationWitness::from_cbor_bytes(
-                &witness_metadatum.to_original_cbor_bytes(),
-            )?,
-        })
-    }
-}
-
-impl std::convert::TryInto<Metadata> for &DeregistrationCbor {
-    type Error = DeserializeError;
-
-    fn try_into(self) -> Result<Metadata, Self::Error> {
-        let mut metadata = Metadata::new();
-        self.add_to_metadata(&mut metadata)?;
-        Ok(metadata)
-    }
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
@@ -347,37 +132,6 @@ pub struct KeyDeregistration {
     pub encodings: Option<KeyDeregistrationEncoding>,
 }
 
-impl KeyDeregistration {
-    /// Creates a new KeyDeregistration. You must then sign self.hash_to_sign() to make a `DeregistrationWitness`.
-    ///
-    /// # Arguments
-    ///
-    /// * `stake_credential` - stake address for the network that this transaction is submitted to (to point to the Ada that was being delegated).
-    /// * `nonce` - Monotonically rising across all transactions with the same staking key. Recommended to just use the slot of this tx.
-    pub fn new(stake_credential: StakeCredential, nonce: Nonce) -> Self {
-        Self {
-            stake_credential,
-            nonce,
-            voting_purpose: 0,
-            encodings: None,
-        }
-    }
-
-    /// Create bytes to sign to make a `DeregistrationWitness` from.
-    ///
-    /// # Arguments
-    ///
-    /// * `force_canonical` - Whether to encode the inner registration canonically. Should be true for hardware wallets and false otherwise.
-    pub fn hash_to_sign(&self, force_canonical: bool) -> cbor_event::Result<Vec<u8>> {
-        let mut buf = Serializer::new_vec();
-        buf.write_map(cbor_event::Len::Len(1))?;
-        buf.write_unsigned_integer(KEY_DEREGISTRATION_LABEL)?;
-        self.serialize(&mut buf, force_canonical)?;
-        let sign_data = buf.finalize();
-        Ok(cml_crypto::blake2b256(&sign_data).to_vec())
-    }
-}
-
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct KeyRegistration {
     pub delegation: DelegationDistribution,
@@ -389,263 +143,12 @@ pub struct KeyRegistration {
     pub encodings: Option<KeyRegistrationEncoding>,
 }
 
-impl KeyRegistration {
-    /// Creates a new KeyRegistration. You must then sign self.hash_to_sign() to make a `RegistrationWitness`.
-    ///
-    /// # Arguments
-    ///
-    /// * `delegation` - Delegation
-    /// * `stake_credential` - stake address for the network that this transaction is submitted to (to point to the Ada that is being delegated).
-    /// * `reward_address` - Shelley address discriminated for the same network this transaction is submitted to for receiving awairds.
-    /// * `nonce` - Monotonically rising across all transactions with the same staking key. Recommended to just use the slot of this tx.
-    pub fn new(
-        delegation: DelegationDistribution,
-        stake_credential: StakeCredential,
-        reward_address: RewardAddress,
-        nonce: Nonce,
-    ) -> Self {
-        Self {
-            delegation,
-            stake_credential,
-            reward_address,
-            nonce,
-            voting_purpose: 0,
-            encodings: None,
-        }
-    }
-
-    /// Create bytes to sign to make a `RegistrationWitness` from.
-    ///
-    /// # Arguments
-    ///
-    /// * `force_canonical` - Whether to encode the inner registration canonically. Should be true for hardware wallets and false otherwise.
-    pub fn hash_to_sign(&self, force_canonical: bool) -> cbor_event::Result<Vec<u8>> {
-        let mut buf = Serializer::new_vec();
-        buf.write_map(cbor_event::Len::Len(1))?;
-        buf.write_unsigned_integer(KEY_REGISTRATION_LABEL)?;
-        self.serialize(&mut buf, force_canonical)?;
-        let sign_data = buf.finalize();
-        Ok(cml_crypto::blake2b256(&sign_data).to_vec())
-    }
-}
-
 /// This is the entire metadata schema for CIP-36 registration.
 /// It can be parsed by passing in the CBOR bytes of the entire transaction metadatum
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct RegistrationCbor {
     pub key_registration: KeyRegistration,
     pub registration_witness: RegistrationWitness,
-}
-
-impl RegistrationCbor {
-    pub fn new(
-        key_registration: KeyRegistration,
-        registration_witness: RegistrationWitness,
-    ) -> Self {
-        Self {
-            key_registration,
-            registration_witness,
-        }
-    }
-
-    /// Add to an existing metadata (could be empty) the full CIP36 registration metadata
-    pub fn add_to_metadata(&self, metadata: &mut Metadata) -> Result<(), DeserializeError> {
-        self.verify()
-            .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)))?;
-        let reg_metadatum =
-            TransactionMetadatum::from_cbor_bytes(&self.key_registration.to_original_cbor_bytes())?;
-        metadata.insert(KEY_REGISTRATION_LABEL, reg_metadatum);
-        let witness_metadatum = TransactionMetadatum::from_cbor_bytes(
-            &self.registration_witness.to_original_cbor_bytes(),
-        )?;
-        metadata.insert(REGISTRATION_WITNESS_LABEL, witness_metadatum);
-        Ok(())
-    }
-
-    /// Verifies invariants in CIP36.
-    pub fn verify(&self) -> Result<(), CIP36Error> {
-        if let DelegationDistribution::Weighted { delegations, .. } =
-            &self.key_registration.delegation
-        {
-            if delegations.is_empty() {
-                return Err(CIP36Error::EmptyDelegationArray);
-            }
-            if delegations.iter().any(|d| d.weight != 0) {
-                return Err(CIP36Error::DelegationWeightsZero);
-            }
-        }
-        Ok(())
-    }
-
-    // these are not implementing Serialize/Deserialize as we do not keep track of the rest of the encoding metadata
-    // so it would be disingenuous to implement them if users called to_original_cbor_bytes() and we skip the rest of
-    // the metadata, as well as when creating from a Metadata object its outer encoding (e.g. map len, key encodings)
-    // is not present as that is simply an OrderedHashMap<TransactionMetadatumLabel, TransactionMetadatum>
-
-    /// Serializes to bytes compatable with Metadata, but containing ONLY the relevant fields for CIP36.
-    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
-    /// the encodings but only from the metadatums themselves within the keys 61284 and 61285
-    pub fn to_metadata_bytes(&self) -> Vec<u8> {
-        let mut buf = Serializer::new_vec();
-        self.serialize(&mut buf, false).unwrap();
-        buf.finalize()
-    }
-
-    /// Create a CIP36 view from the bytes of a Metadata.
-    /// The resulting RegistrationCbor will contain ONLY the relevant fields for CIP36 from the Metadata
-    pub fn from_metadata_bytes(
-        &self,
-        metadata_cbor_bytes: &[u8],
-    ) -> Result<Self, DeserializeError> {
-        let mut raw = Deserializer::from(std::io::Cursor::new(metadata_cbor_bytes));
-        Self::deserialize(&mut raw)
-    }
-
-    /// Serializes as a Metadata structure containing ONLY the relevant fields for CIP36
-    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
-    /// the encodings but only from the metadatums themselves within the keys 61284 and 61285
-    /// * `force_canonical` - Whether to force canonical CBOR encodings. ONLY applies to the metadatums within labels 61285 and 61286
-    fn serialize<'se, W: Write>(
-        &self,
-        serializer: &'se mut Serializer<W>,
-        force_canonical: bool,
-    ) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.verify()
-            .map_err(|e| cbor_event::Error::CustomError(e.to_string()))?;
-        serializer.write_map(cbor_event::Len::Len(2))?;
-        serializer.write_unsigned_integer(KEY_REGISTRATION_LABEL)?;
-        self.key_registration
-            .serialize(serializer, force_canonical)?;
-        serializer.write_unsigned_integer(REGISTRATION_WITNESS_LABEL)?;
-        self.registration_witness
-            .serialize(serializer, force_canonical)
-    }
-
-    /// Deserializes a CIP36 view from either a Metadata or a RegistrationCbor
-    /// This contains ONLY the relevant fields for CIP36 if created from a Metadata
-    fn deserialize<R: BufRead + std::io::Seek>(
-        raw: &mut Deserializer<R>,
-    ) -> Result<Self, DeserializeError> {
-        use cml_core::{error::Key, serialization::CBORReadLen};
-        let len = raw.map_sz()?;
-        let mut read_len = CBORReadLen::new(len);
-        read_len.read_elems(2)?;
-        (|| -> Result<_, DeserializeError> {
-            let mut key_registration = None;
-            let mut registration_witness = None;
-            let mut read = 0;
-            while match len {
-                cbor_event::LenSz::Len(n, _) => read < n,
-                cbor_event::LenSz::Indefinite => true,
-            } {
-                match raw.cbor_type()? {
-                    CBORType::UnsignedInteger => match raw.unsigned_integer()? {
-                        61284 => {
-                            if key_registration.is_some() {
-                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
-                                    KEY_REGISTRATION_LABEL,
-                                ))
-                                .into());
-                            }
-                            key_registration =
-                                Some(KeyRegistration::deserialize(raw).map_err(
-                                    |e: DeserializeError| e.annotate("key_registration"),
-                                )?);
-                        }
-                        61285 => {
-                            if registration_witness.is_some() {
-                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
-                                    REGISTRATION_WITNESS_LABEL,
-                                ))
-                                .into());
-                            }
-                            registration_witness =
-                                Some(RegistrationWitness::deserialize(raw).map_err(
-                                    |e: DeserializeError| e.annotate("registration_witness"),
-                                )?);
-                        }
-                        _unknown_key => (), /* permissive of other metadatum labels */
-                    },
-                    CBORType::Text => {
-                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
-                    }
-                    CBORType::Special => match len {
-                        cbor_event::LenSz::Len(_, _) => {
-                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
-                        }
-                        cbor_event::LenSz::Indefinite => match raw.special()? {
-                            CBORSpecial::Break => break,
-                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                        },
-                    },
-                    other_type => {
-                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
-                    }
-                }
-                read += 1;
-            }
-            let key_registration = match key_registration {
-                Some(x) => x,
-                None => {
-                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
-                        KEY_REGISTRATION_LABEL,
-                    ))
-                    .into())
-                }
-            };
-            let registration_witness = match registration_witness {
-                Some(x) => x,
-                None => {
-                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
-                        REGISTRATION_WITNESS_LABEL,
-                    ))
-                    .into())
-                }
-            };
-            read_len.finish()?;
-            let reg_cbor = Self {
-                key_registration,
-                registration_witness,
-            };
-            reg_cbor
-                .verify()
-                .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)))?;
-            Ok(reg_cbor)
-        })()
-        .map_err(|e| e.annotate("RegistrationCbor"))
-    }
-}
-
-impl std::convert::TryFrom<&Metadata> for RegistrationCbor {
-    type Error = DeserializeError;
-
-    fn try_from(metadata: &Metadata) -> Result<Self, Self::Error> {
-        use cml_core::error::Key;
-        let reg_metadatum = metadata.get(&KEY_REGISTRATION_LABEL).ok_or_else(|| {
-            DeserializeFailure::MandatoryFieldMissing(Key::Uint(KEY_REGISTRATION_LABEL))
-        })?;
-        let witness_metadatum = metadata.get(&REGISTRATION_WITNESS_LABEL).ok_or_else(|| {
-            DeserializeFailure::MandatoryFieldMissing(Key::Uint(REGISTRATION_WITNESS_LABEL))
-        })?;
-        Ok(Self {
-            key_registration: KeyRegistration::from_cbor_bytes(
-                &reg_metadatum.to_original_cbor_bytes(),
-            )?,
-            registration_witness: RegistrationWitness::from_cbor_bytes(
-                &witness_metadatum.to_original_cbor_bytes(),
-            )?,
-        })
-    }
-}
-
-impl std::convert::TryInto<Metadata> for &RegistrationCbor {
-    type Error = DeserializeError;
-
-    fn try_into(self) -> Result<Metadata, Self::Error> {
-        let mut metadata = Metadata::new();
-        self.add_to_metadata(&mut metadata)?;
-        Ok(metadata)
-    }
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
@@ -702,7 +205,7 @@ mod tests {
 
         // legacy format
         let legacy_reg = KeyRegistration::new(
-            DelegationDistribution::new_legacy_key_registration(
+            DelegationDistribution::new_legacy(
                 LegacyKeyRegistration::from_raw_hex(
                     "a6a3c0447aeb9cc54cf6422ba32b294e5e1c3ef6d782f2acff4a70694c4d1663",
                 )

--- a/cip36/rust/src/utils.rs
+++ b/cip36/rust/src/utils.rs
@@ -1,0 +1,494 @@
+use cbor_event::{self, de::Deserializer, se::Serializer};
+
+use crate::error::CIP36Error;
+
+pub use cml_core::{
+    error::{DeserializeError, DeserializeFailure},
+    metadata::{Metadata, TransactionMetadatum},
+    ordered_hash_map::OrderedHashMap,
+    serialization::{Deserialize, LenEncoding, Serialize, StringEncoding},
+};
+
+pub use cml_chain::{address::RewardAddress, NetworkId};
+
+use std::convert::From;
+
+use super::{
+    DelegationDistribution, DeregistrationCbor, DeregistrationWitness, KeyDeregistration,
+    KeyRegistration, Nonce, RegistrationCbor, RegistrationWitness, StakeCredential,
+};
+
+use std::io::{BufRead, Write};
+
+use cbor_event::Type as CBORType;
+
+use cbor_event::Special as CBORSpecial;
+
+pub static KEY_REGISTRATION_LABEL: u64 = 61284;
+pub static REGISTRATION_WITNESS_LABEL: u64 = 61285;
+pub static DEREGISTRATION_WITNESS_LABEL: u64 = REGISTRATION_WITNESS_LABEL;
+pub static KEY_DEREGISTRATION_LABEL: u64 = 61286;
+
+impl DeregistrationCbor {
+    pub fn new(
+        key_deregistration: KeyDeregistration,
+        deregistration_witness: DeregistrationWitness,
+    ) -> Self {
+        Self {
+            key_deregistration,
+            deregistration_witness,
+        }
+    }
+
+    /// Add to an existing metadata (could be empty) the full CIP36 deregistration metadata
+    pub fn add_to_metadata(&self, metadata: &mut Metadata) -> Result<(), DeserializeError> {
+        let dereg_metadatum =
+            TransactionMetadatum::from_cbor_bytes(&self.key_deregistration.to_cbor_bytes())?;
+        metadata.insert(KEY_DEREGISTRATION_LABEL, dereg_metadatum);
+        let witness_metadatum =
+            TransactionMetadatum::from_cbor_bytes(&self.deregistration_witness.to_cbor_bytes())?;
+        metadata.insert(DEREGISTRATION_WITNESS_LABEL, witness_metadatum);
+        Ok(())
+    }
+
+    // these are not implementing Serialize/Deserialize as we do not keep track of the rest of the encoding metadata
+    // so it would be disingenuous to implement them if users called to_cbor_bytes() and we skip the rest of
+    // the metadata, as well as when creating from a Metadata object its outer encoding (e.g. map len, key encodings)
+    // is not present as that is simply an OrderedHashMap<TransactionMetadatumLabel, TransactionMetadatum>
+
+    /// Serializes to bytes compatable with Metadata, but containing ONLY the relevant fields for CIP36.
+    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
+    /// the encodings but only from the metadatums themselves within the keys 61285 and 61286
+    pub fn to_metadata_bytes(&self) -> Vec<u8> {
+        let mut buf = Serializer::new_vec();
+        self.serialize(&mut buf, false).unwrap();
+        buf.finalize()
+    }
+
+    /// Create a CIP36 view from the bytes of a Metadata.
+    /// The resulting DeregistrationCbor will contain ONLY the relevant fields for CIP36 from the Metadata
+    pub fn from_metadata_bytes(
+        &self,
+        metadata_cbor_bytes: &[u8],
+    ) -> Result<Self, DeserializeError> {
+        let mut raw = Deserializer::from(std::io::Cursor::new(metadata_cbor_bytes));
+        Self::deserialize(&mut raw)
+    }
+
+    /// Serializes as a Metadata structure containing ONLY the relevant fields for CIP36
+    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
+    /// the encodings but only from the metadatums themselves within the keys 61285 and 61286
+    /// * `force_canonical` - Whether to force canonical CBOR encodings. ONLY applies to the metadatums within labels 61285 and 61286
+    pub fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(2))?;
+        serializer.write_unsigned_integer(DEREGISTRATION_WITNESS_LABEL)?;
+        self.deregistration_witness
+            .serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer(KEY_DEREGISTRATION_LABEL)?;
+        self.key_deregistration
+            .serialize(serializer, force_canonical)
+    }
+
+    /// Deserializes a CIP36 view from either a Metadata or a DeregistrationCbor
+    /// This contains ONLY the relevant fields for CIP36 if created from a Metadata
+    pub fn deserialize<R: BufRead + std::io::Seek>(
+        raw: &mut Deserializer<R>,
+    ) -> Result<Self, DeserializeError> {
+        use cml_core::{serialization::CBORReadLen, Key};
+
+        let len = raw.map_sz()?;
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        (|| -> Result<_, DeserializeError> {
+            let mut deregistration_witness = None;
+            let mut key_deregistration = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _enc) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer()? {
+                        61285 => {
+                            if deregistration_witness.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
+                                    DEREGISTRATION_WITNESS_LABEL,
+                                ))
+                                .into());
+                            }
+                            deregistration_witness =
+                                Some(DeregistrationWitness::deserialize(raw).map_err(
+                                    |e: DeserializeError| e.annotate("deregistration_witness"),
+                                )?);
+                        }
+                        61286 => {
+                            if key_deregistration.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
+                                    KEY_DEREGISTRATION_LABEL,
+                                ))
+                                .into());
+                            }
+                            key_deregistration =
+                                Some(KeyDeregistration::deserialize(raw).map_err(
+                                    |e: DeserializeError| e.annotate("key_deregistration"),
+                                )?);
+                        }
+                        _unknown_key => (), /* ignore all other metadatum labels */
+                    },
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            let key_deregistration = match key_deregistration {
+                Some(x) => x,
+                None => {
+                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
+                        KEY_DEREGISTRATION_LABEL,
+                    ))
+                    .into())
+                }
+            };
+            let deregistration_witness = match deregistration_witness {
+                Some(x) => x,
+                None => {
+                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
+                        DEREGISTRATION_WITNESS_LABEL,
+                    ))
+                    .into())
+                }
+            };
+            read_len.finish()?;
+            Ok(Self {
+                key_deregistration,
+                deregistration_witness,
+            })
+        })()
+        .map_err(|e| e.annotate("DeregistrationCbor"))
+    }
+}
+
+impl std::convert::TryFrom<&Metadata> for DeregistrationCbor {
+    type Error = DeserializeError;
+
+    fn try_from(metadata: &Metadata) -> Result<Self, Self::Error> {
+        use cml_core::error::Key;
+        let dereg_metadatum = metadata.get(&KEY_DEREGISTRATION_LABEL).ok_or_else(|| {
+            DeserializeFailure::MandatoryFieldMissing(Key::Uint(KEY_DEREGISTRATION_LABEL))
+        })?;
+        let witness_metadatum = metadata.get(&DEREGISTRATION_WITNESS_LABEL).ok_or_else(|| {
+            DeserializeFailure::MandatoryFieldMissing(Key::Uint(DEREGISTRATION_WITNESS_LABEL))
+        })?;
+        Ok(Self {
+            key_deregistration: KeyDeregistration::from_cbor_bytes(
+                &dereg_metadatum.to_cbor_bytes(),
+            )?,
+            deregistration_witness: DeregistrationWitness::from_cbor_bytes(
+                &witness_metadatum.to_cbor_bytes(),
+            )?,
+        })
+    }
+}
+
+impl std::convert::TryInto<Metadata> for &DeregistrationCbor {
+    type Error = DeserializeError;
+
+    fn try_into(self) -> Result<Metadata, Self::Error> {
+        let mut metadata = Metadata::new();
+        self.add_to_metadata(&mut metadata)?;
+        Ok(metadata)
+    }
+}
+
+impl KeyDeregistration {
+    /// Creates a new KeyDeregistration. You must then sign self.hash_to_sign() to make a `DeregistrationWitness`.
+    ///
+    /// # Arguments
+    ///
+    /// * `stake_credential` - stake address for the network that this transaction is submitted to (to point to the Ada that was being delegated).
+    /// * `nonce` - Monotonically rising across all transactions with the same staking key. Recommended to just use the slot of this tx.
+    pub fn new(stake_credential: StakeCredential, nonce: Nonce) -> Self {
+        Self {
+            stake_credential,
+            nonce,
+            voting_purpose: 0,
+            encodings: None,
+        }
+    }
+
+    /// Create bytes to sign to make a `DeregistrationWitness` from.
+    ///
+    /// # Arguments
+    ///
+    /// * `force_canonical` - Whether to encode the inner registration canonically. Should be true for hardware wallets and false otherwise.
+    pub fn hash_to_sign(&self, force_canonical: bool) -> cbor_event::Result<Vec<u8>> {
+        let mut buf = Serializer::new_vec();
+        buf.write_map(cbor_event::Len::Len(1))?;
+        buf.write_unsigned_integer(KEY_DEREGISTRATION_LABEL)?;
+        self.serialize(&mut buf, force_canonical)?;
+        let sign_data = buf.finalize();
+        Ok(cml_crypto::blake2b256(&sign_data).to_vec())
+    }
+}
+
+impl KeyRegistration {
+    /// Creates a new KeyRegistration. You must then sign self.hash_to_sign() to make a `RegistrationWitness`.
+    ///
+    /// # Arguments
+    ///
+    /// * `delegation` - Delegation
+    /// * `stake_credential` - stake address for the network that this transaction is submitted to (to point to the Ada that is being delegated).
+    /// * `reward_address` - Shelley address discriminated for the same network this transaction is submitted to for receiving awairds.
+    /// * `nonce` - Monotonically rising across all transactions with the same staking key. Recommended to just use the slot of this tx.
+    pub fn new(
+        delegation: DelegationDistribution,
+        stake_credential: StakeCredential,
+        reward_address: RewardAddress,
+        nonce: Nonce,
+    ) -> Self {
+        Self {
+            delegation,
+            stake_credential,
+            reward_address,
+            nonce,
+            voting_purpose: 0,
+            encodings: None,
+        }
+    }
+
+    /// Create bytes to sign to make a `RegistrationWitness` from.
+    ///
+    /// # Arguments
+    ///
+    /// * `force_canonical` - Whether to encode the inner registration canonically. Should be true for hardware wallets and false otherwise.
+    pub fn hash_to_sign(&self, force_canonical: bool) -> cbor_event::Result<Vec<u8>> {
+        let mut buf = Serializer::new_vec();
+        buf.write_map(cbor_event::Len::Len(1))?;
+        buf.write_unsigned_integer(KEY_REGISTRATION_LABEL)?;
+        self.serialize(&mut buf, force_canonical)?;
+        let sign_data = buf.finalize();
+        Ok(cml_crypto::blake2b256(&sign_data).to_vec())
+    }
+}
+
+impl RegistrationCbor {
+    pub fn new(
+        key_registration: KeyRegistration,
+        registration_witness: RegistrationWitness,
+    ) -> Self {
+        Self {
+            key_registration,
+            registration_witness,
+        }
+    }
+
+    /// Add to an existing metadata (could be empty) the full CIP36 registration metadata
+    pub fn add_to_metadata(&self, metadata: &mut Metadata) -> Result<(), DeserializeError> {
+        self.verify()
+            .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)))?;
+        let reg_metadatum =
+            TransactionMetadatum::from_cbor_bytes(&self.key_registration.to_cbor_bytes())?;
+        metadata.insert(KEY_REGISTRATION_LABEL, reg_metadatum);
+        let witness_metadatum =
+            TransactionMetadatum::from_cbor_bytes(&self.registration_witness.to_cbor_bytes())?;
+        metadata.insert(REGISTRATION_WITNESS_LABEL, witness_metadatum);
+        Ok(())
+    }
+
+    /// Verifies invariants in CIP36.
+    pub fn verify(&self) -> Result<(), CIP36Error> {
+        if let DelegationDistribution::Weighted { delegations, .. } =
+            &self.key_registration.delegation
+        {
+            if delegations.is_empty() {
+                return Err(CIP36Error::EmptyDelegationArray);
+            }
+            if delegations.iter().any(|d| d.weight != 0) {
+                return Err(CIP36Error::DelegationWeightsZero);
+            }
+        }
+        Ok(())
+    }
+
+    // these are not implementing Serialize/Deserialize as we do not keep track of the rest of the encoding metadata
+    // so it would be disingenuous to implement them if users called to_cbor_bytes() and we skip the rest of
+    // the metadata, as well as when creating from a Metadata object its outer encoding (e.g. map len, key encodings)
+    // is not present as that is simply an OrderedHashMap<TransactionMetadatumLabel, TransactionMetadatum>
+
+    /// Serializes to bytes compatable with Metadata, but containing ONLY the relevant fields for CIP36.
+    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
+    /// the encodings but only from the metadatums themselves within the keys 61284 and 61285
+    pub fn to_metadata_bytes(&self) -> Vec<u8> {
+        let mut buf = Serializer::new_vec();
+        self.serialize(&mut buf, false).unwrap();
+        buf.finalize()
+    }
+
+    /// Create a CIP36 view from the bytes of a Metadata.
+    /// The resulting RegistrationCbor will contain ONLY the relevant fields for CIP36 from the Metadata
+    pub fn from_metadata_bytes(
+        &self,
+        metadata_cbor_bytes: &[u8],
+    ) -> Result<Self, DeserializeError> {
+        let mut raw = Deserializer::from(std::io::Cursor::new(metadata_cbor_bytes));
+        Self::deserialize(&mut raw)
+    }
+
+    /// Serializes as a Metadata structure containing ONLY the relevant fields for CIP36
+    /// If this was created from bytes or from a Metadata that was created from bytes, it will preserve
+    /// the encodings but only from the metadatums themselves within the keys 61284 and 61285
+    /// * `force_canonical` - Whether to force canonical CBOR encodings. ONLY applies to the metadatums within labels 61285 and 61286
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.verify()
+            .map_err(|e| cbor_event::Error::CustomError(e.to_string()))?;
+        serializer.write_map(cbor_event::Len::Len(2))?;
+        serializer.write_unsigned_integer(KEY_REGISTRATION_LABEL)?;
+        self.key_registration
+            .serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer(REGISTRATION_WITNESS_LABEL)?;
+        self.registration_witness
+            .serialize(serializer, force_canonical)
+    }
+
+    /// Deserializes a CIP36 view from either a Metadata or a RegistrationCbor
+    /// This contains ONLY the relevant fields for CIP36 if created from a Metadata
+    fn deserialize<R: BufRead + std::io::Seek>(
+        raw: &mut Deserializer<R>,
+    ) -> Result<Self, DeserializeError> {
+        use cml_core::{error::Key, serialization::CBORReadLen};
+        let len = raw.map_sz()?;
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        (|| -> Result<_, DeserializeError> {
+            let mut key_registration = None;
+            let mut registration_witness = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    CBORType::UnsignedInteger => match raw.unsigned_integer()? {
+                        61284 => {
+                            if key_registration.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
+                                    KEY_REGISTRATION_LABEL,
+                                ))
+                                .into());
+                            }
+                            key_registration =
+                                Some(KeyRegistration::deserialize(raw).map_err(
+                                    |e: DeserializeError| e.annotate("key_registration"),
+                                )?);
+                        }
+                        61285 => {
+                            if registration_witness.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(
+                                    REGISTRATION_WITNESS_LABEL,
+                                ))
+                                .into());
+                            }
+                            registration_witness =
+                                Some(RegistrationWitness::deserialize(raw).map_err(
+                                    |e: DeserializeError| e.annotate("registration_witness"),
+                                )?);
+                        }
+                        _unknown_key => (), /* permissive of other metadatum labels */
+                    },
+                    CBORType::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    CBORType::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            CBORSpecial::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            let key_registration = match key_registration {
+                Some(x) => x,
+                None => {
+                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
+                        KEY_REGISTRATION_LABEL,
+                    ))
+                    .into())
+                }
+            };
+            let registration_witness = match registration_witness {
+                Some(x) => x,
+                None => {
+                    return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(
+                        REGISTRATION_WITNESS_LABEL,
+                    ))
+                    .into())
+                }
+            };
+            read_len.finish()?;
+            let reg_cbor = Self {
+                key_registration,
+                registration_witness,
+            };
+            reg_cbor
+                .verify()
+                .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)))?;
+            Ok(reg_cbor)
+        })()
+        .map_err(|e| e.annotate("RegistrationCbor"))
+    }
+}
+
+impl std::convert::TryFrom<&Metadata> for RegistrationCbor {
+    type Error = DeserializeError;
+
+    fn try_from(metadata: &Metadata) -> Result<Self, Self::Error> {
+        use cml_core::error::Key;
+        let reg_metadatum = metadata.get(&KEY_REGISTRATION_LABEL).ok_or_else(|| {
+            DeserializeFailure::MandatoryFieldMissing(Key::Uint(KEY_REGISTRATION_LABEL))
+        })?;
+        let witness_metadatum = metadata.get(&REGISTRATION_WITNESS_LABEL).ok_or_else(|| {
+            DeserializeFailure::MandatoryFieldMissing(Key::Uint(REGISTRATION_WITNESS_LABEL))
+        })?;
+        Ok(Self {
+            key_registration: KeyRegistration::from_cbor_bytes(&reg_metadatum.to_cbor_bytes())?,
+            registration_witness: RegistrationWitness::from_cbor_bytes(
+                &witness_metadatum.to_cbor_bytes(),
+            )?,
+        })
+    }
+}
+
+impl std::convert::TryInto<Metadata> for &RegistrationCbor {
+    type Error = DeserializeError;
+
+    fn try_into(self) -> Result<Metadata, Self::Error> {
+        let mut metadata = Metadata::new();
+        self.add_to_metadata(&mut metadata)?;
+        Ok(metadata)
+    }
+}

--- a/cip36/wasm/Cargo.toml
+++ b/cip36/wasm/Cargo.toml
@@ -2,16 +2,17 @@
 name = "cml-cip36-wasm"
 version = "0.1.0"
 edition = "2018"
-keywords = ["cardano"]
+keywords = ["cardano", "cip36"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-core = { path = "../rust", package = "cml-cip36" }
-core_crypto = { path = "../../crypto/rust", package = "cml-crypto" }
-wasm_crypto = { path = "../../crypto/wasm", package = "cml-crypto-wasm" }
-wasm_chain = { path = "../../chain/wasm", package = "cml-chain-wasm" }
+cml-cip36 = { path = "../rust" }
+cml-crypto = { path = "../../crypto/rust" }
+cml-crypto-wasm = { path = "../../crypto/wasm" }
+cml-chain-wasm = { path = "../../chain/wasm" }
+cml-core = { path = "../../core/rust" }
 cbor_event = "2.2.0"
 wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
 linked-hash-map = "0.5.3"

--- a/cip36/wasm/src/utils.rs
+++ b/cip36/wasm/src/utils.rs
@@ -1,0 +1,1 @@
+// TODO: wasm bindings for the rust utils.rs

--- a/specs/cip36.cddl
+++ b/specs/cip36.cddl
@@ -3,38 +3,43 @@ registration_cbor = {
   61285: registration_witness, ; @name registration_witness
 }
 
-$voting_pub_key /= bytes .size 32
-$reward_address /= bytes
-$nonce /= uint
-$weight /= uint .size 4
-$voting_purpose /= uint
-legacy_key_registration = $voting_pub_key
-delegation = ($voting_pub_key, $weight)
+public_key = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+
+voting_pub_key = public_key
+reward_address = _CDDL_CODEGEN_EXTERN_TYPE_
+nonce = uint
+weight = uint .size 4
+voting_purpose = uint
+legacy_key_registration = voting_pub_key
+delegation = [voting_pub_key, weight]
 
 ; May support other stake credentials in the future.
 ; Such additional credentials should be tagged at the CDDL/CBOR level
 ; so that parsing is not ambiguous and future proof.
 ; However, to avoid breaking changes, the simple key credential is
 ; left untagged.
-$stake_credential /= $staking_pub_key
-$stake_witness /= $ed25519_signature
+stake_credential = staking_pub_key
+stake_witness = ed25519_signature
 ; A stake key credential, not tagged for backward compatibility
-$staking_pub_key /= bytes .size 32
+staking_pub_key = public_key
 ; Witness for a stake key credential, not tagged for backward compatibility
-$ed25519_signature /= bytes .size 64
+ed25519_signature = _CDDL_CODEGEN_RAW_BYTES_TYPE_
 
+delegation_distribution =
+    [+delegation] ; @name weighted
+  / legacy_key_registration ; @name legacy 
 
 key_registration = {
-  1 : [+delegation] / legacy_key_registration, ; @name delegation
-  2 : $stake_credential, ; @name stake_credential
-  3 : $reward_address, ; @name reward_address
-  4 : $nonce, ; @name nonce
-  ? 5 : $voting_purpose .default 0, ; @name voting_purpose
+  1 : delegation_distribution, ; @name delegation
+  2 : stake_credential, ; @name stake_credential
+  3 : reward_address, ; @name reward_address
+  4 : nonce, ; @name nonce
+  ? 5 : voting_purpose .default 0, ; @name voting_purpose
 }
 
 
 registration_witness = {
-  1 : $stake_witness, ; @name stake_witness
+  1 : stake_witness, ; @name stake_witness
 }
 
 
@@ -44,11 +49,11 @@ deregistration_cbor = {
 }
 
 key_deregistration = {
-  1 : $stake_credential, ; @name stake_credential
-  2 : $nonce, ; @name nonce
-  ? 3 : $voting_purpose .default 0, ; @name voting_purpose
+  1 : stake_credential, ; @name stake_credential
+  2 : nonce, ; @name nonce
+  ? 3 : voting_purpose .default 0, ; @name voting_purpose
 }
 
 deregistration_witness = {
-  1 : $stake_witness, ; @name stake_witness
+  1 : stake_witness, ; @name stake_witness
 }


### PR DESCRIPTION
Refactor CIP36 to use RawBytesEncoding directly e.g. #187

Refactored CIP36 to have hand-written code be in utils.rs like with CIP25

cip36.cddl updated to correctly follow the basic group clarification + have more things properly named.