### PR TITLE
BigInt + bounded bytes + ConstrPlutusData

### DIFF
--- a/chain/rust/src/lib.rs
+++ b/chain/rust/src/lib.rs
@@ -14,6 +14,7 @@ pub mod crypto;
 pub mod plutus;
 pub mod serialization;
 pub mod transaction;
+pub mod utils;
 
 use address::*;
 use auxdata::*;
@@ -38,11 +39,6 @@ extern crate derivative;
 
 pub(crate) use derivative::Derivative;
 //#![allow(clippy::too_many_arguments)]
-
-// TODO: replace with real bigint type
-pub type BigInt = Int;
-// TODO: same ^
-pub type BoundedBytes = Int;
 
 // This file was code-generated using an experimental CDDL to rust tool:
 // https://github.com/dcSpark/cddl-codegen

--- a/chain/rust/src/plutus/cbor_encodings.rs
+++ b/chain/rust/src/plutus/cbor_encodings.rs
@@ -5,14 +5,6 @@ use cml_core::serialization::{LenEncoding, StringEncoding};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Default)]
-pub struct ConstrPlutusDataEncoding {
-    pub len_encoding: LenEncoding,
-    pub tag_encoding: Option<cbor_event::Sz>,
-    pub constructor_encoding: Option<cbor_event::Sz>,
-    pub fields_encoding: LenEncoding,
-}
-
-#[derive(Clone, Debug, Default)]
 pub struct CostModelsEncoding {
     pub len_encoding: LenEncoding,
     pub orig_deser_order: Vec<usize>,

--- a/chain/rust/src/plutus/mod.rs
+++ b/chain/rust/src/plutus/mod.rs
@@ -3,8 +3,10 @@
 
 pub mod cbor_encodings;
 pub mod serialization;
+pub mod utils;
 
-use super::{BigInt, BoundedBytes, PositiveInterval, SubCoin};
+use super::{PositiveInterval, SubCoin};
+use crate::utils::BigInt;
 use cbor_encodings::{
     ConstrPlutusDataEncoding, CostModelsEncoding, ExUnitPricesEncoding, ExUnitsEncoding,
     PlutusV1ScriptEncoding, PlutusV2ScriptEncoding, RedeemerEncoding,
@@ -156,7 +158,17 @@ pub enum PlutusData {
         list_encoding: LenEncoding,
     },
     BigInt(BigInt),
-    Bytes(BoundedBytes),
+    Bytes {
+        bytes: Vec<u8>,
+        #[derivative(
+            PartialEq = "ignore",
+            Ord = "ignore",
+            PartialOrd = "ignore",
+            Hash = "ignore"
+        )]
+        #[serde(skip)]
+        bytes_encoding: StringEncoding,
+    },
 }
 
 impl PlutusData {
@@ -182,8 +194,11 @@ impl PlutusData {
         Self::BigInt(big_int)
     }
 
-    pub fn new_bytes(bytes: BoundedBytes) -> Self {
-        Self::Bytes(bytes)
+    pub fn new_bytes(bytes: Vec<u8>) -> Self {
+        Self::Bytes {
+            bytes,
+            bytes_encoding: StringEncoding::default(),
+        }
     }
 }
 

--- a/chain/rust/src/plutus/mod.rs
+++ b/chain/rust/src/plutus/mod.rs
@@ -8,8 +8,8 @@ pub mod utils;
 use super::{PositiveInterval, SubCoin};
 use crate::utils::BigInt;
 use cbor_encodings::{
-    ConstrPlutusDataEncoding, CostModelsEncoding, ExUnitPricesEncoding, ExUnitsEncoding,
-    PlutusV1ScriptEncoding, PlutusV2ScriptEncoding, RedeemerEncoding,
+    CostModelsEncoding, ExUnitPricesEncoding, ExUnitsEncoding, PlutusV1ScriptEncoding,
+    PlutusV2ScriptEncoding, RedeemerEncoding,
 };
 use cml_core::error::*;
 use cml_core::ordered_hash_map::OrderedHashMap;
@@ -18,32 +18,8 @@ use cml_core::Int;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
-#[derive(
-    Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, derivative::Derivative,
-)]
-#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct ConstrPlutusData {
-    pub constructor: u64,
-    pub fields: Vec<PlutusData>,
-    #[derivative(
-        PartialEq = "ignore",
-        Ord = "ignore",
-        PartialOrd = "ignore",
-        Hash = "ignore"
-    )]
-    #[serde(skip)]
-    pub encodings: Option<ConstrPlutusDataEncoding>,
-}
+pub use utils::ConstrPlutusData;
 
-impl ConstrPlutusData {
-    pub fn new(constructor: u64, fields: Vec<PlutusData>) -> Self {
-        Self {
-            constructor,
-            fields,
-            encodings: None,
-        }
-    }
-}
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct CostModels {

--- a/chain/rust/src/plutus/utils.rs
+++ b/chain/rust/src/plutus/utils.rs
@@ -1,0 +1,255 @@
+use super::PlutusData;
+use cbor_event::de::Deserializer;
+use cbor_event::se::Serializer;
+use cml_core::error::*;
+use cml_core::serialization::*;
+use std::io::{BufRead, Seek, SeekFrom, Write};
+
+#[derive(
+    Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, derivative::Derivative,
+)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ConstrPlutusData {
+    pub alternative: u64,
+    pub fields: Vec<PlutusData>,
+    #[derivative(
+        PartialEq = "ignore",
+        Ord = "ignore",
+        PartialOrd = "ignore",
+        Hash = "ignore"
+    )]
+    #[serde(skip)]
+    pub encodings: Option<ConstrPlutusDataEncoding>,
+}
+
+impl ConstrPlutusData {
+    // see: https://github.com/input-output-hk/plutus/blob/1f31e640e8a258185db01fa899da63f9018c0e85/plutus-core/plutus-core/src/PlutusCore/Data.hs#L61
+    // We don't directly serialize the alternative in the tag, instead the scheme is:
+    // - Alternatives 0-6 -> tags 121-127, followed by the arguments in a list
+    // - Alternatives 7-127 -> tags 1280-1400, followed by the arguments in a list
+    // - Any alternatives, including those that don't fit in the above -> tag 102 followed by a list containing
+    //   an unsigned integer for the actual alternative, and then the arguments in a (nested!) list.
+    const GENERAL_FORM_TAG: u64 = 102;
+
+    // None -> needs general tag serialization, not compact
+    fn alternative_to_compact_cbor_tag(alt: u64) -> Option<u64> {
+        if alt <= 6 {
+            Some(121 + alt)
+        } else if alt >= 7 && alt <= 127 {
+            Some(1280 - 7 + alt)
+        } else {
+            None
+        }
+    }
+
+    // None -> General tag(=102) OR Invalid CBOR tag for this scheme
+    fn compact_cbor_tag_to_alternative(cbor_tag: u64) -> Option<u64> {
+        if cbor_tag >= 121 && cbor_tag <= 127 {
+            Some(cbor_tag - 121)
+        } else if cbor_tag >= 1280 && cbor_tag <= 1400 {
+            Some(cbor_tag - 1280 + 7)
+        } else {
+            None
+        }
+    }
+
+    pub fn new(alternative: u64, fields: Vec<PlutusData>) -> Self {
+        Self {
+            alternative,
+            fields,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ConstrPlutusDataEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<cbor_event::Sz>,
+    pub alternative_encoding: Option<cbor_event::Sz>,
+    pub fields_encoding: LenEncoding,
+}
+
+impl Serialize for ConstrPlutusData {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        if let Some(compact_tag) = Self::alternative_to_compact_cbor_tag(self.alternative) {
+            // compact form
+            serializer.write_tag_sz(
+                compact_tag as u64,
+                fit_sz(
+                    compact_tag as u64,
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.tag_encoding)
+                        .unwrap_or_default(),
+                    force_canonical,
+                ),
+            )?;
+            serializer.write_array_sz(
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.fields_encoding)
+                    .unwrap_or_default()
+                    .to_len_sz(self.fields.len() as u64, force_canonical),
+            )?;
+            for element in self.fields.iter() {
+                element.serialize(serializer, force_canonical)?;
+            }
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.fields_encoding)
+                .unwrap_or_default()
+                .end(serializer, force_canonical)
+        } else {
+            // general form
+            serializer.write_tag_sz(
+                Self::GENERAL_FORM_TAG,
+                fit_sz(
+                    Self::GENERAL_FORM_TAG,
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.tag_encoding)
+                        .unwrap_or_default(),
+                    force_canonical,
+                ),
+            )?;
+            serializer.write_array_sz(
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.len_encoding)
+                    .unwrap_or_default()
+                    .to_len_sz(2, force_canonical),
+            )?;
+            serializer.write_unsigned_integer_sz(
+                self.alternative,
+                fit_sz(
+                    self.alternative,
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.alternative_encoding)
+                        .unwrap_or_default(),
+                    force_canonical,
+                ),
+            )?;
+            serializer.write_array_sz(
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.fields_encoding)
+                    .unwrap_or_default()
+                    .to_len_sz(self.fields.len() as u64, force_canonical),
+            )?;
+            for element in self.fields.iter() {
+                element.serialize(serializer, force_canonical)?;
+            }
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.fields_encoding)
+                .unwrap_or_default()
+                .end(serializer, force_canonical)?;
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .end(serializer, force_canonical)
+        }
+    }
+}
+
+impl Deserialize for ConstrPlutusData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let (tag, tag_encoding) = raw.tag_sz()?;
+            match tag {
+                // general form
+                Self::GENERAL_FORM_TAG => {
+                    let len = raw.array_sz()?;
+                    let len_encoding: LenEncoding = len.into();
+                    let mut read_len = CBORReadLen::new(len);
+                    read_len.read_elems(2)?;
+                    let (alternative, alternative_encoding) = raw
+                        .unsigned_integer_sz()
+                        .map(|(x, enc)| (x, Some(enc)))
+                        .map_err(Into::<DeserializeError>::into)
+                        .map_err(|e: DeserializeError| e.annotate("alternative"))?;
+                    let (fields, fields_encoding) = (|| -> Result<_, DeserializeError> {
+                        let mut fields_arr = Vec::new();
+                        let len = raw.array_sz()?;
+                        let fields_encoding = len.into();
+                        while match len {
+                            cbor_event::LenSz::Len(n, _) => (fields_arr.len() as u64) < n,
+                            cbor_event::LenSz::Indefinite => true,
+                        } {
+                            if raw.cbor_type()? == cbor_event::Type::Special {
+                                assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                break;
+                            }
+                            fields_arr.push(PlutusData::deserialize(raw)?);
+                        }
+                        Ok((fields_arr, fields_encoding))
+                    })()
+                    .map_err(|e| e.annotate("fields"))?;
+                    match len {
+                        cbor_event::LenSz::Len(_, _) => (),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => (),
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    }
+                    Ok(ConstrPlutusData {
+                        alternative,
+                        fields,
+                        encodings: Some(ConstrPlutusDataEncoding {
+                            len_encoding,
+                            tag_encoding: Some(tag_encoding),
+                            alternative_encoding,
+                            fields_encoding,
+                        }),
+                    })
+                }
+                // concise form
+                tag => {
+                    if let Some(alternative) = Self::compact_cbor_tag_to_alternative(tag) {
+                        let (fields, fields_encoding) = (|| -> Result<_, DeserializeError> {
+                            let mut fields_arr = Vec::new();
+                            let len = raw.array_sz()?;
+                            let fields_encoding = len.into();
+                            while match len {
+                                cbor_event::LenSz::Len(n, _) => (fields_arr.len() as u64) < n,
+                                cbor_event::LenSz::Indefinite => true,
+                            } {
+                                if raw.cbor_type()? == cbor_event::Type::Special {
+                                    assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                    break;
+                                }
+                                fields_arr.push(PlutusData::deserialize(raw)?);
+                            }
+                            Ok((fields_arr, fields_encoding))
+                        })()
+                        .map_err(|e| e.annotate("fields"))?;
+                        Ok(ConstrPlutusData {
+                            alternative,
+                            fields,
+                            encodings: Some(ConstrPlutusDataEncoding {
+                                len_encoding: LenEncoding::default(),
+                                tag_encoding: Some(tag_encoding),
+                                alternative_encoding: None,
+                                fields_encoding,
+                            }),
+                        })
+                    } else {
+                        return Err(DeserializeFailure::TagMismatch {
+                            found: tag,
+                            expected: Self::GENERAL_FORM_TAG,
+                        }
+                        .into());
+                    }
+                }
+            }
+        })()
+        .map_err(|e| e.annotate("ConstrPlutusData"))
+    }
+}

--- a/chain/rust/src/utils.rs
+++ b/chain/rust/src/utils.rs
@@ -1,86 +1,413 @@
-use std::io::{BufRead, Seek, Write};
+use cbor_event::{de::Deserializer, se::Serializer};
 use cml_core::{
-    error::{DeserializeFailure, DeserializeError},
+    error::{DeserializeError, DeserializeFailure},
+    serialization::{fit_sz, sz_max, Deserialize, Serialize},
+    Int,
 };
-use cbor_event::{se::Serializer, de::Deserializer};
+use derivative::Derivative;
+use std::io::{BufRead, Seek, Write};
 
 const BOUNDED_BYTES_CHUNK_SIZE: usize = 64;
 
-pub (crate) fn write_bounded_bytes<'se, W: Write>(serializer: &'se mut Serializer<W>, bytes: &[u8]) -> cbor_event::Result<&'se mut Serializer<W>> {
+// to get around not having access from outside the library we just write the raw CBOR indefinite byte string code here
+fn write_cbor_indefinite_byte_tag<'se, W: Write>(
+    serializer: &'se mut Serializer<W>,
+) -> cbor_event::Result<&'se mut Serializer<W>> {
+    serializer.write_raw_bytes(&[0x5f])
+}
+
+use cml_core::serialization::StringEncoding;
+
+fn valid_indefinite_string_encoding(chunks: &Vec<(u64, cbor_event::Sz)>, total_len: usize) -> bool {
+    let mut len_counter = 0;
+    let valid_sz = chunks.iter().all(|(len, sz)| {
+        len_counter += len;
+        *len <= sz_max(*sz)
+    });
+    valid_sz && len_counter == total_len as u64
+}
+
+/// Write bounded bytes according to Cardano's special format:
+/// bounded_bytes = bytes .size (0..64)
+///  ; the real bounded_bytes does not have this limit. it instead has a different
+///   ; limit which cannot be expressed in CDDL.
+///   ; The limit is as follows:
+///   ;  - bytes with a definite-length encoding are limited to size 0..64
+///   ;  - for bytes with an indefinite-length CBOR encoding, each chunk is
+///   ;    limited to size 0..64
+///   ;  ( reminder: in CBOR, the indefinite-length encoding of bytestrings
+///   ;    consists of a token #2.31 followed by a sequence of definite-length
+///   ;    encoded bytestrings and a stop code )
+pub fn write_bounded_bytes<'se, W: Write>(
+    serializer: &'se mut Serializer<W>,
+    bytes: &[u8],
+    enc: &StringEncoding,
+    force_canonical: bool,
+) -> cbor_event::Result<&'se mut Serializer<W>> {
+    match enc {
+        StringEncoding::Definite(sz) if !force_canonical => {
+            if bytes.len() <= BOUNDED_BYTES_CHUNK_SIZE {
+                let fit_sz = fit_sz(bytes.len() as u64, Some(*sz), force_canonical);
+                return serializer.write_bytes_sz(bytes, cbor_event::StringLenSz::Len(fit_sz));
+            }
+        }
+        StringEncoding::Indefinite(chunks) if !force_canonical => {
+            if valid_indefinite_string_encoding(chunks, bytes.len()) {
+                write_cbor_indefinite_byte_tag(serializer)?;
+                let mut start = 0;
+                for (len, sz) in chunks {
+                    let end = start + *len as usize;
+                    serializer
+                        .write_bytes_sz(&bytes[start..end], cbor_event::StringLenSz::Len(*sz))?;
+                    start = end;
+                }
+                return serializer.write_special(cbor_event::Special::Break);
+            }
+        }
+        _ =>
+        /* handled below */
+        {
+            ()
+        }
+    };
+    // This is a fallback for when either it's canonical or the passed in encoding isn't
+    // compatible with the passed in bytes (e.g. someone deserialized then modified the bytes)
+    // If we truly need to encode canonical CBOR there's really no way to abide by both canonical
+    // CBOR as well as following the Cardano format. So this is the best attempt at it while keeping
+    // chunks when len > 64
     if bytes.len() <= BOUNDED_BYTES_CHUNK_SIZE {
         serializer.write_bytes(bytes)
     } else {
-        // to get around not having access from outside the library we just write the raw CBOR indefinite byte string code here
-        serializer.write_raw_bytes(&[0x5f])?;
+        write_cbor_indefinite_byte_tag(serializer)?;
         for chunk in bytes.chunks(BOUNDED_BYTES_CHUNK_SIZE) {
             serializer.write_bytes(chunk)?;
         }
-        serializer.write_special(CBORSpecial::Break)
+        serializer.write_special(cbor_event::Special::Break)
     }
 }
 
-pub (crate) fn read_bounded_bytes<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Vec<u8>, DeserializeError> {
-    use std::io::Read;
-    let t = raw.cbor_type()?;
-    if t != CBORType::Bytes {
-        return Err(cbor_event::Error::Expected(CBORType::Bytes, t).into());
-    }
-    let (len, len_sz) = raw.cbor_len()?;
-    match len {
-        cbor_event::Len::Len(_) => {
-            let bytes = raw.bytes()?;
+/// Read bounded bytes according to Cardano's special format:
+/// bounded_bytes = bytes .size (0..64)
+///  ; the real bounded_bytes does not have this limit. it instead has a different
+///  ; limit which cannot be expressed in CDDL.
+///  ; The limit is as follows:
+///  ;  - bytes with a definite-length encoding are limited to size 0..64
+///  ;  - for bytes with an indefinite-length CBOR encoding, each chunk is
+///  ;    limited to size 0..64
+///  ;  ( reminder: in CBOR, the indefinite-length encoding of bytestrings
+///  ;    consists of a token #2.31 followed by a sequence of definite-length
+///  ;    encoded bytestrings and a stop code )
+pub fn read_bounded_bytes<R: BufRead + Seek>(
+    raw: &mut Deserializer<R>,
+) -> Result<(Vec<u8>, StringEncoding), DeserializeError> {
+    let (bytes, bytes_enc) = raw.bytes_sz()?;
+    match &bytes_enc {
+        cbor_event::StringLenSz::Len(_sz) => {
             if bytes.len() > BOUNDED_BYTES_CHUNK_SIZE {
-                return Err(DeserializeFailure::OutOfRange{
+                return Err(DeserializeFailure::OutOfRange {
                     min: 0,
                     max: BOUNDED_BYTES_CHUNK_SIZE,
                     found: bytes.len(),
-                }.into());
-            }
-            Ok(bytes)
-        },
-        cbor_event::Len::Indefinite => {
-            // this is CBOR indefinite encoding, but we must check that each chunk
-            // is at most 64 big so we can't just use cbor_event's implementation
-            // and check after the fact.
-            // This is a slightly adopted version of what I made internally in cbor_event
-            // but with the extra checks and not having access to non-pub methods.
-            let mut bytes = Vec::new();
-            raw.advance(1 + len_sz)?;
-            // TODO: also change this + check at end of loop to the following after we update cbor_event
-            //while raw.cbor_type()? != CBORType::Special || !raw.special_break()? {
-            while raw.cbor_type()? != CBORType::Special {
-                let chunk_t = raw.cbor_type()?;
-                if chunk_t != CBORType::Bytes {
-                    return Err(cbor_event::Error::Expected(CBORType::Bytes, chunk_t).into());
                 }
-                let (chunk_len, chunk_len_sz) = raw.cbor_len()?;
-                match chunk_len {
-                    // TODO: use this error instead once that PR is merged into cbor_event
-                    //cbor_event::Len::Indefinite => return Err(cbor_event::Error::InvalidIndefiniteString.into()),
-                    cbor_event::Len::Indefinite => return Err(cbor_event::Error::CustomError(String::from("Illegal CBOR: Indefinite string found inside indefinite string")).into()),
-                    cbor_event::Len::Len(len) => {
-                        if chunk_len_sz > BOUNDED_BYTES_CHUNK_SIZE {
-                            return Err(DeserializeFailure::OutOfRange{
-                                min: 0,
-                                max: BOUNDED_BYTES_CHUNK_SIZE,
-                                found: chunk_len_sz,
-                            }.into());
-                        }
-                        raw.advance(1 + chunk_len_sz)?;
-                        raw
-                            .as_mut_ref()
-                            .by_ref()
-                            .take(len)
-                            .read_to_end(&mut bytes)
-                            .map_err(|e| cbor_event::Error::IoError(e))?;
+                .into());
+            }
+        }
+        cbor_event::StringLenSz::Indefinite(chunks) => {
+            for (chunk_len, _chunk_len_sz) in chunks.iter() {
+                if *chunk_len as usize > BOUNDED_BYTES_CHUNK_SIZE {
+                    return Err(DeserializeFailure::OutOfRange {
+                        min: 0,
+                        max: BOUNDED_BYTES_CHUNK_SIZE,
+                        found: *chunk_len as usize,
                     }
+                    .into());
                 }
             }
-            if raw.special()? != CBORSpecial::Break {
-                return Err(DeserializeFailure::EndingBreakMissing.into());
-            }
-            Ok(bytes)
-        },
+        }
+    }
+    Ok((bytes, bytes_enc.into()))
+}
+
+#[derive(Clone, Debug)]
+enum BigIntEncoding {
+    Int(cbor_event::Sz),
+    Bytes(StringEncoding),
+}
+
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct BigInt {
+    num: num_bigint::BigInt,
+    #[derivative(
+        PartialEq = "ignore",
+        Ord = "ignore",
+        PartialOrd = "ignore",
+        Hash = "ignore"
+    )]
+    encoding: Option<BigIntEncoding>,
+}
+
+impl serde::Serialize for BigInt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for BigInt {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        use std::str::FromStr;
+        let s = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        BigInt::from_str(&s).map_err(|_e| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&s),
+                &"string rep of a big int",
+            )
+        })
+    }
+}
+
+impl schemars::JsonSchema for BigInt {
+    fn schema_name() -> String {
+        String::from("BigInt")
+    }
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
+    }
+}
+
+impl std::fmt::Display for BigInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.num.fmt(f)
+    }
+}
+
+impl std::str::FromStr for BigInt {
+    type Err = num_bigint::ParseBigIntError;
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        num_bigint::BigInt::from_str(string).map(|num| Self {
+            num,
+            encoding: None,
+        })
+    }
+}
+
+impl BigInt {
+    // can't be a trait due to being in other crate
+    pub fn from_int(x: &Int) -> Self {
+        Self {
+            num: Into::<i128>::into(x).into(),
+            encoding: x.encoding().map(BigIntEncoding::Int),
+        }
     }
 
+    /// Converts to a u64
+    /// Returns None if the number was negative or too big for a u64
+    pub fn as_u64(&self) -> Option<u64> {
+        let (sign, u64_digits) = self.num.to_u64_digits();
+        if sign == num_bigint::Sign::Minus {
+            return None;
+        }
+        match u64_digits.len() {
+            0 => Some(0),
+            1 => Some(*u64_digits.first().unwrap()),
+            _ => None,
+        }
+    }
+
+    /// Converts to an Int
+    /// Returns None when the number is too big for an Int (outside +/- 64-bit unsigned)
+    /// Retains encoding info if the original was encoded as an Int
+    pub fn as_int(&self) -> Option<Int> {
+        let (sign, u64_digits) = self.num.to_u64_digits();
+        let u64_digit = match u64_digits.len() {
+            0 => 0u64,
+            1 => *u64_digits.first().unwrap(),
+            _ => return None,
+        };
+        let encoding = match &self.encoding {
+            Some(BigIntEncoding::Int(sz)) => Some(*sz),
+            _ => None,
+        };
+        match sign {
+            num_bigint::Sign::NoSign | num_bigint::Sign::Plus => Some(Int::Uint {
+                value: u64_digit,
+                encoding,
+            }),
+            num_bigint::Sign::Minus => Some(Int::Nint {
+                value: u64_digit,
+                encoding,
+            }),
+        }
+    }
 }
+
+impl Serialize for BigInt {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        let write_self_as_bytes = |serializer: &'se mut Serializer<W>,
+                                   enc: &StringEncoding|
+         -> cbor_event::Result<&'se mut Serializer<W>> {
+            let (sign, bytes) = self.num.to_bytes_be();
+            match sign {
+                // positive bigint
+                num_bigint::Sign::Plus | num_bigint::Sign::NoSign => {
+                    serializer.write_tag(2u64)?;
+                    write_bounded_bytes(serializer, &bytes, enc, force_canonical)
+                }
+                // negative bigint
+                num_bigint::Sign::Minus => {
+                    serializer.write_tag(3u64)?;
+                    use std::ops::Neg;
+                    // CBOR RFC defines this as the bytes of -n -1
+                    let adjusted = self
+                        .num
+                        .clone()
+                        .neg()
+                        .checked_sub(&num_bigint::BigInt::from(1u32))
+                        .unwrap()
+                        .to_biguint()
+                        .unwrap();
+                    write_bounded_bytes(serializer, &adjusted.to_bytes_be(), enc, force_canonical)
+                }
+            }
+        };
+        // use encoding if possible
+        match &self.encoding {
+            Some(BigIntEncoding::Int(sz)) if !force_canonical => {
+                // as_int() retains encoding info so we can direclty use Int::serialize()
+                if let Some(int) = self.as_int() {
+                    return int.serialize(serializer, force_canonical);
+                }
+            }
+            Some(BigIntEncoding::Bytes(str_enc)) if !force_canonical => {
+                let (_sign, bytes) = self.num.to_bytes_be();
+                let valid_non_canonical = match str_enc {
+                    StringEncoding::Canonical => false,
+                    StringEncoding::Definite(sz) => bytes.len() <= sz_max(*sz) as usize,
+                    StringEncoding::Indefinite(chunks) => {
+                        valid_indefinite_string_encoding(&chunks, bytes.len())
+                    }
+                };
+                if valid_non_canonical {
+                    return write_self_as_bytes(serializer, &str_enc);
+                }
+            }
+            _ =>
+            /* always fallback to default */
+            {
+                ()
+            }
+        }
+        // fallback for:
+        // 1) canonical bytes needed
+        // 2) no encoding specified (never deseiralized)
+        // 3) deserialized but data changed and no longer compatible
+        let (sign, u64_digits) = self.num.to_u64_digits();
+        match u64_digits.len() {
+            0 => serializer.write_unsigned_integer(0),
+            // we use the uint/nint encodings to use a minimum of space
+            1 => match sign {
+                // uint
+                num_bigint::Sign::Plus | num_bigint::Sign::NoSign => {
+                    serializer.write_unsigned_integer(*u64_digits.first().unwrap())
+                }
+                // nint
+                num_bigint::Sign::Minus => serializer
+                    .write_negative_integer(-(*u64_digits.first().unwrap() as i128) as i64),
+            },
+            _ => {
+                // Small edge case: nint's minimum is -18446744073709551616 but in this bigint lib
+                // that takes 2 u64 bytes so we put that as a special case here:
+                if sign == num_bigint::Sign::Minus && u64_digits == vec![0, 1] {
+                    serializer.write_negative_integer(-18446744073709551616i128 as i64)
+                } else {
+                    write_self_as_bytes(serializer, &StringEncoding::Canonical)
+                }
+            }
+        }
+    }
+}
+
+impl Deserialize for BigInt {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            match raw.cbor_type()? {
+                // bigint
+                cbor_event::Type::Tag => {
+                    let tag = raw.tag()?;
+                    let (bytes, bytes_enc) = read_bounded_bytes(raw)?;
+                    match tag {
+                        // positive bigint
+                        2 => Ok(Self {
+                            num: num_bigint::BigInt::from_bytes_be(num_bigint::Sign::Plus, &bytes),
+                            encoding: Some(BigIntEncoding::Bytes(bytes_enc)),
+                        }),
+                        // negative bigint
+                        3 => {
+                            // CBOR RFC defines this as the bytes of -n -1
+                            let initial =
+                                num_bigint::BigInt::from_bytes_be(num_bigint::Sign::Plus, &bytes);
+                            use std::ops::Neg;
+                            let adjusted = initial
+                                .checked_add(&num_bigint::BigInt::from(1u32))
+                                .unwrap()
+                                .neg();
+                            Ok(Self {
+                                num: adjusted,
+                                encoding: Some(BigIntEncoding::Bytes(bytes_enc)),
+                            })
+                        }
+                        _ => Err(DeserializeFailure::TagMismatch {
+                            found: tag,
+                            expected: 2,
+                        }
+                        .into()),
+                    }
+                }
+                // uint
+                cbor_event::Type::UnsignedInteger => {
+                    let (num, num_enc) = raw.unsigned_integer_sz()?;
+                    Ok(Self {
+                        num: num_bigint::BigInt::from(num),
+                        encoding: Some(BigIntEncoding::Int(num_enc)),
+                    })
+                }
+                // nint
+                cbor_event::Type::NegativeInteger => {
+                    let (num, num_enc) = raw.negative_integer_sz()?;
+                    Ok(Self {
+                        num: num_bigint::BigInt::from(num),
+                        encoding: Some(BigIntEncoding::Int(num_enc)),
+                    })
+                }
+                _ => Err(DeserializeFailure::NoVariantMatched.into()),
+            }
+        })()
+        .map_err(|e| e.annotate("BigInt"))
+    }
+}
+
+impl<T> std::convert::From<T> for BigInt
+where
+    T: std::convert::Into<num_bigint::BigInt>,
+{
+    fn from(x: T) -> Self {
+        Self {
+            num: x.into(),
+            encoding: None,
+        }
+    }
+}
+

--- a/chain/rust/src/utils.rs
+++ b/chain/rust/src/utils.rs
@@ -1,0 +1,86 @@
+use std::io::{BufRead, Seek, Write};
+use cml_core::{
+    error::{DeserializeFailure, DeserializeError},
+};
+use cbor_event::{se::Serializer, de::Deserializer};
+
+const BOUNDED_BYTES_CHUNK_SIZE: usize = 64;
+
+pub (crate) fn write_bounded_bytes<'se, W: Write>(serializer: &'se mut Serializer<W>, bytes: &[u8]) -> cbor_event::Result<&'se mut Serializer<W>> {
+    if bytes.len() <= BOUNDED_BYTES_CHUNK_SIZE {
+        serializer.write_bytes(bytes)
+    } else {
+        // to get around not having access from outside the library we just write the raw CBOR indefinite byte string code here
+        serializer.write_raw_bytes(&[0x5f])?;
+        for chunk in bytes.chunks(BOUNDED_BYTES_CHUNK_SIZE) {
+            serializer.write_bytes(chunk)?;
+        }
+        serializer.write_special(CBORSpecial::Break)
+    }
+}
+
+pub (crate) fn read_bounded_bytes<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Vec<u8>, DeserializeError> {
+    use std::io::Read;
+    let t = raw.cbor_type()?;
+    if t != CBORType::Bytes {
+        return Err(cbor_event::Error::Expected(CBORType::Bytes, t).into());
+    }
+    let (len, len_sz) = raw.cbor_len()?;
+    match len {
+        cbor_event::Len::Len(_) => {
+            let bytes = raw.bytes()?;
+            if bytes.len() > BOUNDED_BYTES_CHUNK_SIZE {
+                return Err(DeserializeFailure::OutOfRange{
+                    min: 0,
+                    max: BOUNDED_BYTES_CHUNK_SIZE,
+                    found: bytes.len(),
+                }.into());
+            }
+            Ok(bytes)
+        },
+        cbor_event::Len::Indefinite => {
+            // this is CBOR indefinite encoding, but we must check that each chunk
+            // is at most 64 big so we can't just use cbor_event's implementation
+            // and check after the fact.
+            // This is a slightly adopted version of what I made internally in cbor_event
+            // but with the extra checks and not having access to non-pub methods.
+            let mut bytes = Vec::new();
+            raw.advance(1 + len_sz)?;
+            // TODO: also change this + check at end of loop to the following after we update cbor_event
+            //while raw.cbor_type()? != CBORType::Special || !raw.special_break()? {
+            while raw.cbor_type()? != CBORType::Special {
+                let chunk_t = raw.cbor_type()?;
+                if chunk_t != CBORType::Bytes {
+                    return Err(cbor_event::Error::Expected(CBORType::Bytes, chunk_t).into());
+                }
+                let (chunk_len, chunk_len_sz) = raw.cbor_len()?;
+                match chunk_len {
+                    // TODO: use this error instead once that PR is merged into cbor_event
+                    //cbor_event::Len::Indefinite => return Err(cbor_event::Error::InvalidIndefiniteString.into()),
+                    cbor_event::Len::Indefinite => return Err(cbor_event::Error::CustomError(String::from("Illegal CBOR: Indefinite string found inside indefinite string")).into()),
+                    cbor_event::Len::Len(len) => {
+                        if chunk_len_sz > BOUNDED_BYTES_CHUNK_SIZE {
+                            return Err(DeserializeFailure::OutOfRange{
+                                min: 0,
+                                max: BOUNDED_BYTES_CHUNK_SIZE,
+                                found: chunk_len_sz,
+                            }.into());
+                        }
+                        raw.advance(1 + chunk_len_sz)?;
+                        raw
+                            .as_mut_ref()
+                            .by_ref()
+                            .take(len)
+                            .read_to_end(&mut bytes)
+                            .map_err(|e| cbor_event::Error::IoError(e))?;
+                    }
+                }
+            }
+            if raw.special()? != CBORSpecial::Break {
+                return Err(DeserializeFailure::EndingBreakMissing.into());
+            }
+            Ok(bytes)
+        },
+    }
+
+}

--- a/chain/wasm/src/lib.rs
+++ b/chain/wasm/src/lib.rs
@@ -17,11 +17,6 @@ pub mod crypto;
 pub mod plutus;
 pub mod transaction;
 
-// TODO: replace with real bigint type
-pub type BigInt = Int;
-// TODO: same ^
-pub type BoundedBytes = Int;
-
 use address::RewardAccount;
 use auxdata::{AuxiliaryData, TransactionMetadatum};
 use block::ProtocolVersion;
@@ -35,6 +30,8 @@ use plutus::{
 use transaction::{
     NativeScript, TransactionBody, TransactionInput, TransactionOutput, TransactionWitnessSet,
 };
+
+pub mod utils;
 
 //extern crate serde_wasm_bindgen;
 // Code below here was code-generated using an experimental CDDL to rust tool:

--- a/chain/wasm/src/plutus/mod.rs
+++ b/chain/wasm/src/plutus/mod.rs
@@ -4,7 +4,6 @@
 use super::{IntList, MapPlutusDataToPlutusData, PlutusDataList, SubCoin};
 use crate::utils::BigInt;
 pub use cml_chain::plutus::{Language, RedeemerTag};
-use cml_core::ordered_hash_map::OrderedHashMap;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[derive(Clone, Debug)]
@@ -39,17 +38,17 @@ impl ConstrPlutusData {
             .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
     }
 
-    pub fn constructor(&self) -> u64 {
-        self.0.constructor
+    pub fn alternative(&self) -> u64 {
+        self.0.alternative
     }
 
     pub fn fields(&self) -> PlutusDataList {
         self.0.fields.clone().into()
     }
 
-    pub fn new(constructor: u64, fields: &PlutusDataList) -> Self {
+    pub fn new(alternative: u64, fields: &PlutusDataList) -> Self {
         Self(cml_chain::plutus::ConstrPlutusData::new(
-            constructor,
+            alternative,
             fields.clone().into(),
         ))
     }

--- a/chain/wasm/src/plutus/mod.rs
+++ b/chain/wasm/src/plutus/mod.rs
@@ -1,7 +1,8 @@
 // This file was code-generated using an experimental CDDL to rust tool:
 // https://github.com/dcSpark/cddl-codegen
 
-use super::{BigInt, BoundedBytes, IntList, MapPlutusDataToPlutusData, PlutusDataList, SubCoin};
+use super::{IntList, MapPlutusDataToPlutusData, PlutusDataList, SubCoin};
+use crate::utils::BigInt;
 pub use cml_chain::plutus::{Language, RedeemerTag};
 use cml_core::ordered_hash_map::OrderedHashMap;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
@@ -324,10 +325,8 @@ impl PlutusData {
         ))
     }
 
-    pub fn new_bytes(bytes: &BoundedBytes) -> Self {
-        Self(cml_chain::plutus::PlutusData::new_bytes(
-            bytes.clone().into(),
-        ))
+    pub fn new_bytes(bytes: Vec<u8>) -> Self {
+        Self(cml_chain::plutus::PlutusData::new_bytes(bytes))
     }
 
     pub fn kind(&self) -> PlutusDataKind {
@@ -336,7 +335,7 @@ impl PlutusData {
             cml_chain::plutus::PlutusData::Map { .. } => PlutusDataKind::Map,
             cml_chain::plutus::PlutusData::List { .. } => PlutusDataKind::List,
             cml_chain::plutus::PlutusData::BigInt(_) => PlutusDataKind::BigInt,
-            cml_chain::plutus::PlutusData::Bytes(_) => PlutusDataKind::Bytes,
+            cml_chain::plutus::PlutusData::Bytes{ .. } => PlutusDataKind::Bytes,
         }
     }
 
@@ -370,9 +369,9 @@ impl PlutusData {
         }
     }
 
-    pub fn as_bytes(&self) -> Option<BoundedBytes> {
+    pub fn as_bytes(&self) -> Option<Vec<u8>> {
         match &self.0 {
-            cml_chain::plutus::PlutusData::Bytes(bytes) => Some(bytes.clone().into()),
+            cml_chain::plutus::PlutusData::Bytes{ bytes, .. } => Some(bytes.clone().into()),
             _ => None,
         }
     }

--- a/chain/wasm/src/utils.rs
+++ b/chain/wasm/src/utils.rs
@@ -1,0 +1,81 @@
+
+use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
+use super::Int;
+#[wasm_bindgen]
+#[derive(Clone, Debug)]
+pub struct BigInt(cml_chain::utils::BigInt);
+
+#[wasm_bindgen]
+impl BigInt {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<BigInt, JsValue> {
+        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<BigInt, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn from_int(x: &Int) -> Self {
+        Self(cml_chain::utils::BigInt::from_int(x.as_ref()))
+    }
+
+    pub fn from_str(s: &str) -> Result<BigInt, JsError> {
+        use std::str::FromStr;
+        cml_chain::utils::BigInt::from_str(s)
+            .map(Self)
+            .map_err(Into::into)
+    }
+
+    pub fn to_str(&self) -> String {
+        self.0.to_string()
+    }
+
+    /// Converts to a u64
+    /// Returns None if the number was negative or too big for a u64
+    pub fn as_u64(&self) -> Option<u64> {
+        self.0.as_u64()
+    }
+
+    /// Converts to an Int
+    /// Returns None when the number is too big for an Int (outside +/- 64-bit unsigned)
+    /// Retains encoding info if the original was encoded as an Int
+    pub fn as_int(&self) -> Option<Int> {
+        self.0.as_int().map(Into::into)
+    }
+}
+
+impl From<cml_chain::utils::BigInt> for BigInt {
+    fn from(native: cml_chain::utils::BigInt) -> Self {
+        Self(native)
+    }
+}
+
+impl From<BigInt> for cml_chain::utils::BigInt {
+    fn from(wasm: BigInt) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_chain::utils::BigInt> for BigInt {
+    fn as_ref(&self) -> &cml_chain::utils::BigInt {
+        &self.0
+    }
+}

--- a/core/rust/src/error.rs
+++ b/core/rust/src/error.rs
@@ -30,6 +30,11 @@ pub enum DeserializeFailure {
     InvalidStructure(Box<dyn std::error::Error>),
     MandatoryFieldMissing(Key),
     NoVariantMatched,
+    OutOfRange{
+        min: usize,
+        max: usize,
+        found: usize
+    },
     RangeCheck {
         found: usize,
         min: Option<isize>,
@@ -104,6 +109,7 @@ impl std::fmt::Display for DeserializeError {
                 write!(f, "Mandatory field {} not found", key)
             }
             DeserializeFailure::NoVariantMatched => write!(f, "No variant matched"),
+            DeserializeFailure::OutOfRange{ min, max, found } => write!(f, "Out of range: {} - must be in range {} - {}", found, min, max),
             DeserializeFailure::RangeCheck { found, min, max } => match (min, max) {
                 (Some(min), Some(max)) => write!(f, "{} not in range {} - {}", found, min, max),
                 (Some(min), None) => write!(f, "{} not at least {}", found, min),

--- a/core/rust/src/lib.rs
+++ b/core/rust/src/lib.rs
@@ -77,6 +77,13 @@ impl Int {
             encoding: None,
         }
     }
+
+    pub fn encoding(&self) -> &Option<cbor_event::Sz> {
+        match self {
+            Self::Uint { encoding, .. } => encoding,
+            Self::Nint { encoding, .. } => encoding,
+        }
+    }
 }
 
 impl std::fmt::Display for Int {
@@ -112,6 +119,15 @@ impl std::convert::TryFrom<i128> for Int {
                 value: x,
                 encoding: None,
             })
+        }
+    }
+}
+
+impl Into<i128> for &Int {
+    fn into(self) -> i128 {
+        match self {
+            Int::Uint { value, .. } => (*value).into(),
+            Int::Nint { value, .. } => -((*value + 1) as i128),
         }
     }
 }

--- a/specs/babbage/lib.cddl
+++ b/specs/babbage/lib.cddl
@@ -60,18 +60,6 @@ protocol_param_update = {
   ? 24: uint,               ; @name max_collateral_inputs
 }
 
-; bounded_bytes = bytes .size (0..64)
-;  ; the real bounded_bytes does not have this limit. it instead has a different
-;  ; limit which cannot be expressed in CDDL.
-;  ; The limit is as follows:
-;  ;  - bytes with a definite-length encoding are limited to size 0..64
-;  ;  - for bytes with an indefinite-length CBOR encoding, each chunk is
-;  ;    limited to size 0..64
-;  ;  ( reminder: in CBOR, the indefinite-length encoding of bytestrings
-;  ;    consists of a token #2.31 followed by a sequence of definite-length
-;  ;    encoded bytestrings and a stop code )
-bounded_bytes = _CDDL_CODEGEN_EXTERN_TYPE_
-
 sub_coin = positive_interval
 
 multiasset = { * policy_id => { * asset_name => uint } }

--- a/specs/babbage/plutus.cddl
+++ b/specs/babbage/plutus.cddl
@@ -22,7 +22,18 @@ plutus_data =
 
 big_int = _CDDL_CODEGEN_EXTERN_TYPE_
 
-constr_plutus_data = #6.102([constructor: uint, fields: [* plutus_data]])
+; original definition not used to avoid hundreds of variants:
+; constr<a> =
+;    #6.121([* a])
+;  / #6.122([* a])
+;  / #6.123([* a])
+;  / #6.124([* a])
+;  / #6.125([* a])
+;  / #6.126([* a])
+;  / #6.127([* a])
+;  ; similarly for tag range: 6.1280 .. 6.1400 inclusive
+;  / #6.102([alternative: uint, fields: [* a]])
+constr_plutus_data = _CDDL_CODEGEN_EXTERN_TYPE_
 
 redeemer = [ tag: redeemer_tag, index: uint, data: plutus_data, ex_units: ex_units ]
 redeemer_tag =

--- a/specs/babbage/plutus.cddl
+++ b/specs/babbage/plutus.cddl
@@ -1,3 +1,15 @@
+; bounded_bytes = bytes .size (0..64)
+;  ; the real bounded_bytes does not have this limit. it instead has a different
+;  ; limit which cannot be expressed in CDDL.
+;  ; The limit is as follows:
+;  ;  - bytes with a definite-length encoding are limited to size 0..64
+;  ;  - for bytes with an indefinite-length CBOR encoding, each chunk is
+;  ;    limited to size 0..64
+;  ;  ( reminder: in CBOR, the indefinite-length encoding of bytestrings
+;  ;    consists of a token #2.31 followed by a sequence of definite-length
+;  ;    encoded bytestrings and a stop code )
+bounded_bytes = bytes ; @no_alias
+
 plutus_v1_script = bytes ; @newtype
 plutus_v2_script = bytes ; @newtype
 


### PR DESCRIPTION
#  BigInt + bounded bytes

bounded-bytes logic including adapting for preserving encodings.
This is 100% an encoding detail as we can express the chunking logic in
the encoding variable and expose just a simple bytes type.

bigint hand-written struct to cover the specific big integer encoding
(which can be `Int` too), and also is chunked i.e. bounded bytes


#  ConstrPlutusData

written by hand to avoid having hundreds of variants