### PR TITLE
CIP25 version-independent access

### DIFF
--- a/chain/rust/src/lib.rs
+++ b/chain/rust/src/lib.rs
@@ -71,11 +71,7 @@ pub struct AssetName {
 }
 
 impl AssetName {
-    pub fn get(&self) -> &Vec<u8> {
-        &self.inner
-    }
-
-    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+    pub fn new(inner: &[u8]) -> Result<Self, DeserializeError> {
         if inner.len() > 32 {
             return Err(DeserializeError::new(
                 "AssetName",
@@ -87,16 +83,16 @@ impl AssetName {
             ));
         }
         Ok(Self {
-            inner,
+            inner: inner.to_vec(),
             encodings: None,
         })
     }
 }
 
-impl TryFrom<Vec<u8>> for AssetName {
+impl TryFrom<&[u8]> for AssetName {
     type Error = DeserializeError;
 
-    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(inner: &[u8]) -> Result<Self, Self::Error> {
         AssetName::new(inner)
     }
 }

--- a/chain/rust/src/utils.rs
+++ b/chain/rust/src/utils.rs
@@ -7,6 +7,18 @@ use cml_core::{
 use derivative::Derivative;
 use std::io::{BufRead, Seek, Write};
 
+use cml_crypto::RawBytesEncoding;
+
+impl RawBytesEncoding for AssetName {
+    fn to_raw_bytes(&self) -> &[u8] {
+        &self.inner
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Result<Self, cml_crypto::CryptoError> {
+        Self::new(bytes).map_err(Into::into)
+    }
+}
+
 const BOUNDED_BYTES_CHUNK_SIZE: usize = 64;
 
 // to get around not having access from outside the library we just write the raw CBOR indefinite byte string code here

--- a/chain/wasm/src/lib.rs
+++ b/chain/wasm/src/lib.rs
@@ -70,7 +70,7 @@ impl AssetName {
     }
 
     pub fn get(&self) -> Vec<u8> {
-        self.0.get().clone()
+        self.0.inner.clone()
     }
 }
 

--- a/cip25/rust/Cargo.toml
+++ b/cip25/rust/Cargo.toml
@@ -9,10 +9,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cml-core = { "path" = "../../core/rust" }
+cml-crypto = { "path" = "../../crypto/rust" }
+cml-chain = { "path" = "../../chain/rust" }
 cbor_event = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 schemars = "0.8.8"
-
-[dev-dependencies]
 hex = "0.4.0"

--- a/cip25/rust/src/lib.rs
+++ b/cip25/rust/src/lib.rs
@@ -212,21 +212,33 @@ impl MetadataDetails {
     Ord,
     PartialOrd,
 )]
-pub struct PolicyIdV1(pub String64);
+pub struct PolicyIdV1(pub String);
 
 impl PolicyIdV1 {
-    pub fn get(&self) -> &String64 {
+    pub fn get(&self) -> &String {
         &self.0
     }
 
-    pub fn new(inner: String64) -> Self {
-        Self(inner)
+    pub fn new(inner: String) -> Result<Self, DeserializeError> {
+        if inner.len() != 56 {
+            return Err(DeserializeError::new(
+                "PolicyIdV1",
+                DeserializeFailure::RangeCheck {
+                    found: inner.len(),
+                    min: Some(56),
+                    max: Some(56),
+                },
+            ));
+        }
+        Ok(Self(inner))
     }
 }
 
-impl From<String64> for PolicyIdV1 {
-    fn from(inner: String64) -> Self {
-        PolicyIdV1::new(inner.clone().into())
+impl TryFrom<String> for PolicyIdV1 {
+    type Error = DeserializeError;
+
+    fn try_from(inner: String) -> Result<Self, Self::Error> {
+        PolicyIdV1::new(inner)
     }
 }
 
@@ -250,13 +262,25 @@ impl PolicyIdV2 {
         &self.0
     }
 
-    pub fn new(inner: Vec<u8>) -> Self {
-        Self(inner)
+    pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
+        if inner.len() != 28 {
+            return Err(DeserializeError::new(
+                "PolicyIdV2",
+                DeserializeFailure::RangeCheck {
+                    found: inner.len(),
+                    min: Some(28),
+                    max: Some(28),
+                },
+            ));
+        }
+        Ok(Self(inner))
     }
 }
 
-impl From<Vec<u8>> for PolicyIdV2 {
-    fn from(inner: Vec<u8>) -> Self {
+impl TryFrom<Vec<u8>> for PolicyIdV2 {
+    type Error = DeserializeError;
+
+    fn try_from(inner: Vec<u8>) -> Result<Self, Self::Error> {
         PolicyIdV2::new(inner)
     }
 }
@@ -290,12 +314,6 @@ pub struct String64(pub String);
 
 impl From<AssetNameV1> for String64 {
     fn from(wrapper: AssetNameV1) -> Self {
-        wrapper.0
-    }
-}
-
-impl From<PolicyIdV1> for String64 {
-    fn from(wrapper: PolicyIdV1) -> Self {
         wrapper.0
     }
 }

--- a/cip25/rust/src/serialization.rs
+++ b/cip25/rust/src/serialization.rs
@@ -800,13 +800,24 @@ impl cbor_event::se::Serialize for PolicyIdV1 {
         &self,
         serializer: &'se mut Serializer<W>,
     ) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize(serializer)
+        serializer.write_text(&self.0)
     }
 }
 
 impl Deserialize for PolicyIdV1 {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(String64::deserialize(raw)?))
+        let inner = raw.text()? as String;
+        if inner.len() != 56 {
+            return Err(DeserializeError::new(
+                "PolicyIdV1",
+                DeserializeFailure::RangeCheck {
+                    found: inner.len(),
+                    min: Some(56),
+                    max: Some(56),
+                },
+            ));
+        }
+        Ok(Self(inner))
     }
 }
 
@@ -821,7 +832,18 @@ impl cbor_event::se::Serialize for PolicyIdV2 {
 
 impl Deserialize for PolicyIdV2 {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(raw.bytes()? as Vec<u8>))
+        let inner = raw.bytes()? as Vec<u8>;
+        if inner.len() != 28 {
+            return Err(DeserializeError::new(
+                "PolicyIdV2",
+                DeserializeFailure::RangeCheck {
+                    found: inner.len(),
+                    min: Some(28),
+                    max: Some(28),
+                },
+            ));
+        }
+        Ok(Self(inner))
     }
 }
 

--- a/cip25/wasm/Cargo.toml
+++ b/cip25/wasm/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 core = { path = "../rust", package = "cml-cip25" }
 cml-core-wasm = { path = "../../core/wasm" }
+cml-chain-wasm = { path = "../../chain/wasm" }
 cbor_event = "2.2.0"
 wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
 linked-hash-map = "0.5.3"

--- a/cip25/wasm/src/lib.rs
+++ b/cip25/wasm/src/lib.rs
@@ -889,8 +889,8 @@ impl PolicyIdV1 {
             .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
     }
 
-    pub fn get(&self) -> String64 {
-        self.0.get().clone().into()
+    pub fn get(&self) -> String {
+        self.0.get().clone()
     }
 }
 

--- a/cip25/wasm/src/utils.rs
+++ b/cip25/wasm/src/utils.rs
@@ -25,6 +25,48 @@ impl CIP25Metadata {
             .add_to_metadata(metadata.as_mut())
             .map_err(Into::into)
     }
+
+    /// Version-independant access to an NFT's MetadataDetails
+    /// Converts based on cml-chain's PolicyId/AssetName
+    pub fn get(
+        &self,
+        policy_id: &cml_chain_wasm::PolicyId,
+        asset_name: &cml_chain_wasm::AssetName,
+    ) -> Option<MetadataDetails> {
+        self.0
+            .get(policy_id.as_ref(), asset_name.as_ref())
+            .cloned()
+            .map(Into::into)
+    }
+
+    /// Version-independant insertion of an NFT's MetadataDetails
+    /// Converts based on cml-chain's PolicyId/AssetName
+    /// Errors when the AssetName can't be represented by the CIP25 version (i.e. v1)
+    pub fn set(
+        &mut self,
+        policy_id: &cml_chain_wasm::PolicyId,
+        asset_name: &cml_chain_wasm::AssetName,
+        details: MetadataDetails,
+    ) -> Result<(), JsError> {
+        self.0
+            .set(policy_id.as_ref(), asset_name.as_ref(), details.into())
+            .map_err(Into::into)
+    }
+
+    /// Version-independant access to all policy IDs in this schema
+    /// Converts based on cml-chain's PolicyId/AssetName
+    pub fn policies(&self) -> Result<cml_chain_wasm::PolicyIdList, JsError> {
+        self.0.policies().map(Into::into).map_err(Into::into)
+    }
+
+    /// Version-independant access to all Asset names for a given PolicyId
+    /// Converts based on cml-chain's PolicyId/AssetName
+    pub fn asset_names(
+        &self,
+        policy_id: &cml_chain_wasm::PolicyId,
+    ) -> Option<cml_chain_wasm::AssetNameList> {
+        self.0.asset_names(policy_id.as_ref()).map(Into::into)
+    }
 }
 
 #[wasm_bindgen]
@@ -63,7 +105,7 @@ impl MiniMetadataDetails {
     pub fn new() -> Self {
         MiniMetadataDetails(core::utils::MiniMetadataDetails {
             name: None,
-            image: None
+            image: None,
         })
     }
 

--- a/specs/cip25.cddl
+++ b/specs/cip25.cddl
@@ -1,10 +1,14 @@
 string64 = text .size (0..64)
 
-policy_id_v1 = string64 ; @newtype
-asset_name_v1 = string64 ; @newtype utf-8
+; actually also has to be a hex string
+policy_id_v1 = text .size 56 ; @newtype
+; utf8 text
+asset_name_v1 = string64 ; @newtype
 
-policy_id_v2 = bytes ; @newtype no longer in text
-asset_name_v2 = bytes ; @newtype no longer in text and utf-8
+; no longer in text
+policy_id_v2 = bytes .size 28 ; @newtype
+; no longer in text/utf8
+asset_name_v2 = bytes .size (0..64) ; @newtype
 
 files_details = 
   {


### PR DESCRIPTION
Wraps the version differences for access/insertion/iteration at the top-level (`CIP25Metadata`) so users can interop with the regular chain types (`AssetName`/`PolicyId`) and ignore `PolicyIdV1`, `PolicyIdV2`, `AssetNameV1`, `AssetNameV2`, `LabelMetadata`, `LabelMetadataV1`, `LabelMetadataV2` and `Data` types as serialiation details for their respective versions.