### PR TITLE
Update/fix tests (Address/Byron)

### DIFF
--- a/chain/rust/src/address.rs
+++ b/chain/rust/src/address.rs
@@ -858,12 +858,13 @@ impl Deserialize for RewardAccount {
         }
     }
 }
-/*
+
 #[cfg(test)]
 mod tests {
-    use crate::{byron::AddressContent, ledger::common::hash::ScriptHashNamespace};
+    use crate::{byron::AddressContent, transaction::NativeScript};
 
     use super::*;
+    use cml_core::serialization::ToBytes;
     use cml_crypto::*;
 
     #[test]
@@ -881,53 +882,53 @@ mod tests {
     fn base_serialize_consistency() {
         let base = BaseAddress::new(
             5,
-            StakeCredential::from_keyhash(Ed25519KeyHash::from([23; Ed25519KeyHash::BYTE_COUNT])),
-            StakeCredential::from_scripthash(ScriptHash::from([42; ScriptHash::BYTE_COUNT])),
+            StakeCredential::new_pub_key(Ed25519KeyHash::from([23; Ed25519KeyHash::BYTE_COUNT])),
+            StakeCredential::new_script(ScriptHash::from([42; ScriptHash::BYTE_COUNT])),
         );
         let addr = base.to_address();
-        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
-        assert_eq!(addr.to_bytes(), addr2.to_bytes());
+        let addr2 = Address::from_cbor_bytes(&addr.to_cbor_bytes()).unwrap();
+        assert_eq!(addr.to_cbor_bytes(), addr2.to_cbor_bytes());
     }
 
     #[test]
     fn ptr_serialize_consistency() {
         let ptr = PointerAddress::new(
             25,
-            StakeCredential::from_keyhash(Ed25519KeyHash::from([23; Ed25519KeyHash::BYTE_COUNT])),
+            StakeCredential::new_pub_key(Ed25519KeyHash::from([23; Ed25519KeyHash::BYTE_COUNT])),
             Pointer::new(2354556573, 127, 0),
         );
         let addr = ptr.to_address();
-        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
-        assert_eq!(addr.to_bytes(), addr2.to_bytes());
+        let addr2 = Address::from_cbor_bytes(&addr.to_cbor_bytes()).unwrap();
+        assert_eq!(addr.to_cbor_bytes(), addr2.to_cbor_bytes());
     }
 
     #[test]
     fn enterprise_serialize_consistency() {
         let enterprise = EnterpriseAddress::new(
             64,
-            StakeCredential::from_keyhash(Ed25519KeyHash::from([23; Ed25519KeyHash::BYTE_COUNT])),
+            StakeCredential::new_pub_key(Ed25519KeyHash::from([23; Ed25519KeyHash::BYTE_COUNT])),
         );
         let addr = enterprise.to_address();
-        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
-        assert_eq!(addr.to_bytes(), addr2.to_bytes());
+        let addr2 = Address::from_cbor_bytes(&addr.to_cbor_bytes()).unwrap();
+        assert_eq!(addr.to_cbor_bytes(), addr2.to_cbor_bytes());
     }
 
     #[test]
     fn reward_serialize_consistency() {
         let reward = RewardAddress::new(
             9,
-            StakeCredential::from_scripthash(ScriptHash::from([127; Ed25519KeyHash::BYTE_COUNT])),
+            StakeCredential::new_script(ScriptHash::from([127; Ed25519KeyHash::BYTE_COUNT])),
         );
         let addr = reward.to_address();
-        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
-        assert_eq!(addr.to_bytes(), addr2.to_bytes());
+        let addr2 = Address::from_cbor_bytes(&addr.to_cbor_bytes()).unwrap();
+        assert_eq!(addr.to_cbor_bytes(), addr2.to_cbor_bytes());
     }
 
     #[test]
     fn address_header_matching() {
         let reward = RewardAddress::new(
             0b1001,
-            StakeCredential::from_scripthash(ScriptHash::from([127; Ed25519KeyHash::BYTE_COUNT])),
+            StakeCredential::new_script(ScriptHash::from([127; Ed25519KeyHash::BYTE_COUNT])),
         )
         .to_address();
         assert_eq!(reward.header(), 0b1111_1001);
@@ -995,8 +996,8 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
-        let stake_cred = StakeCredential::from_keyhash(stake.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
+        let stake_cred = StakeCredential::new_pub_key(stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
@@ -1019,7 +1020,7 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
         let addr_net_0 =
             EnterpriseAddress::new(NetworkInfo::testnet().network_id(), spend_cred.clone())
                 .to_address();
@@ -1044,7 +1045,7 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
         let addr_net_0 = PointerAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
@@ -1083,8 +1084,8 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
-        let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
+        let stake_cred = StakeCredential::new_pub_key(stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
@@ -1107,7 +1108,7 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
         let addr_net_0 =
             EnterpriseAddress::new(NetworkInfo::testnet().network_id(), spend_cred.clone())
                 .to_address();
@@ -1132,7 +1133,7 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
         let addr_net_0 = PointerAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
@@ -1165,7 +1166,7 @@ mod tests {
             .derive(0)
             .to_public();
         let byron_addr =
-            AddressContent::icarus_from_key(&byron_key, NetworkInfo::mainnet().protocol_magic());
+            AddressContent::icarus_from_key(byron_key, NetworkInfo::mainnet().protocol_magic());
         assert_eq!(
             byron_addr.to_address().to_base58(),
             "Ae2tdPwUPEZHtBmjZBF4YpMkK9tMSPTE2ADEZTPN97saNkhG78TvXdp3GDk"
@@ -1176,8 +1177,8 @@ mod tests {
         assert_eq!(byron_addr.network_id().unwrap(), 0b0001);
 
         // round-trip from generic address type and back
-        let generic_addr = Address::from_bytes(byron_addr.to_address().to_bytes()).unwrap();
-        let byron_addr_2 = ByronAddress::from_address(generic_addr).unwrap();
+        let generic_addr = Address::from_raw_bytes(&byron_addr.to_address().to_bytes()).unwrap();
+        let byron_addr_2 = ByronAddress::from_address(&generic_addr).unwrap();
         assert_eq!(
             byron_addr.to_address().to_base58(),
             byron_addr_2.to_base58()
@@ -1200,8 +1201,8 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
-        let stake_cred = StakeCredential::from_keyhash(stake.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
+        let stake_cred = StakeCredential::new_pub_key(stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
@@ -1224,7 +1225,7 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
         let addr_net_0 =
             EnterpriseAddress::new(NetworkInfo::testnet().network_id(), spend_cred.clone())
                 .to_address();
@@ -1249,11 +1250,11 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
         let addr_net_0 = PointerAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
-            &Pointer::new(1, 2, 3),
+            Pointer::new(1, 2, 3),
         )
         .to_address();
         assert_eq!(
@@ -1263,7 +1264,7 @@ mod tests {
         let addr_net_3 = PointerAddress::new(
             NetworkInfo::mainnet().network_id(),
             spend_cred,
-            &Pointer::new(24157, 177, 42),
+            Pointer::new(24157, 177, 42),
         )
         .to_address();
         assert_eq!(
@@ -1281,7 +1282,7 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let staking_cred = StakeCredential::from_keyhash(staking_key.to_raw_key().hash());
+        let staking_cred = StakeCredential::new_pub_key(staking_key.to_raw_key().hash());
         let addr_net_0 =
             RewardAddress::new(NetworkInfo::testnet().network_id(), staking_cred.clone())
                 .to_address();
@@ -1313,8 +1314,8 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.to_raw_key().hash());
-        let stake_cred = StakeCredential::from_keyhash(stake.to_raw_key().hash());
+        let spend_cred = StakeCredential::new_pub_key(spend.to_raw_key().hash());
+        let stake_cred = StakeCredential::new_pub_key(stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
@@ -1338,19 +1339,17 @@ mod tests {
             .derive(0)
             .to_public();
 
-        let mut pubkey_native_scripts = NativeScripts::new();
+        let mut pubkey_native_scripts = Vec::new();
 
         let spending_hash = spend.to_raw_key().hash();
-        pubkey_native_scripts.add(NativeScript::new_script_pubkey(ScriptPubkey::new(
-            spending_hash,
-        )));
+        pubkey_native_scripts.push(NativeScript::new_script_pubkey(spending_hash));
         let oneof_native_script =
-            NativeScript::new_script_n_of_k(ScriptNOfK::new(1, pubkey_native_scripts));
+            NativeScript::new_script_n_of_k(1, pubkey_native_scripts);
 
-        let script_hash = ScriptHash::from_bytes(oneof_native_script.hash().to_bytes()).unwrap();
+        let script_hash = ScriptHash::from_raw_bytes(oneof_native_script.hash().to_raw_bytes()).unwrap();
 
-        let spend_cred = StakeCredential::from_scripthash(script_hash);
-        let stake_cred = StakeCredential::from_scripthash(script_hash);
+        let spend_cred = StakeCredential::new_script(script_hash.clone());
+        let stake_cred = StakeCredential::new_script(script_hash);
         let addr_net_0 = BaseAddress::new(
             NetworkInfo::testnet().network_id(),
             spend_cred.clone(),
@@ -1367,7 +1366,7 @@ mod tests {
     #[test]
     fn pointer_address_big() {
         let addr = Address::from_bech32("addr_test1grqe6lg9ay8wkcu5k5e38lne63c80h3nq6xxhqfmhewf645pllllllllllll7lupllllllllllll7lupllllllllllll7lc9wayvj").unwrap();
-        let ptr = PointerAddress::from_address(addr).unwrap().stake;
+        let ptr = PointerAddress::from_address(&addr).unwrap().stake;
         let u64_max = num_bigint::BigUint::from(u64::MAX);
         assert_eq!(u64_max, ptr.slot);
         assert_eq!(u64_max, ptr.tx_index);
@@ -1380,14 +1379,17 @@ mod tests {
         let long_trimmed = Address::from_bech32("addr1q9d66zzs27kppmx8qc8h43q7m4hkxp5d39377lvxefvxd8j7eukjsdqc5c97t2zg5guqadepqqx6rc9m7wtnxy6tajjq6r54x9").unwrap();
         assert_eq!(long, long_trimmed);
         assert_eq!(
-            long.trailing,
+            long.encoding().unwrap().trailing,
             Some(vec![
                 203u8, 87, 175, 176, 179, 95, 200, 156, 99, 6, 28, 153, 20, 224, 85, 0, 26, 81,
                 140, 117, 22
             ])
         );
-        assert_eq!(long_trimmed.trailing, None);
-        assert_eq!(long.to_bytes(), hex::decode("015bad085057ac10ecc7060f7ac41edd6f63068d8963ef7d86ca58669e5ecf2d283418a60be5a848a2380eb721000da1e0bbf39733134beca4cb57afb0b35fc89c63061c9914e055001a518c7516").unwrap());
+        assert_eq!(long_trimmed.encoding().and_then(|enc| enc.trailing.clone()), None);
+        assert_eq!(
+            hex::encode(long.to_raw_bytes()),
+            "015bad085057ac10ecc7060f7ac41edd6f63068d8963ef7d86ca58669e5ecf2d283418a60be5a848a2380eb721000da1e0bbf39733134beca4cb57afb0b35fc89c63061c9914e055001a518c7516"
+        );
         let long_not_whitelisted = Address::from_bech32(
             "addr_test1vqt3w9chzut3w9chzut3w9chzut3w9chzut3w9chzut3w9cqqspqvqcqsmxqdssg97",
         );
@@ -1411,8 +1413,7 @@ mod tests {
             255, 255, 255, 255, 255, 255, 255, 255, 127, 129, 255, 255, 255, 255, 255, 255, 255,
             255, 127, 129, 255, 255, 255, 255, 255, 255, 255, 255, 127,
         ];
-        let addr = Address::from_bytes(addr_bytes.clone()).unwrap();
-        assert_eq!(addr_bytes, addr.to_bytes());
+        let addr = Address::from_raw_bytes(&addr_bytes.clone()).unwrap();
+        assert_eq!(addr_bytes, addr.to_raw_bytes());
     }
 }
-*/

--- a/chain/rust/src/byron/utils.rs
+++ b/chain/rust/src/byron/utils.rs
@@ -153,9 +153,9 @@ impl AddressContent {
     }
 
     // icarus-style address (Ae2)
-    pub fn icarus_from_key(key: Bip32PublicKey, protocol_magic: u32) -> AddressContent {
+    pub fn icarus_from_key(key: Bip32PublicKey, protocol_magic: ProtocolMagic) -> AddressContent {
         // need to ensure we use None for mainnet since Byron-era addresses omitted the network id
-        let filtered_protocol_magic = if protocol_magic == NetworkInfo::mainnet().protocol_magic().0 { None } else { Some(ProtocolMagic(protocol_magic)) };
+        let filtered_protocol_magic = if protocol_magic == NetworkInfo::mainnet().protocol_magic() { None } else { Some(protocol_magic) };
         AddressContent::new_simple( key, filtered_protocol_magic)
     }
 
@@ -339,20 +339,18 @@ pub fn make_icarus_bootstrap_witness(
     )
 }
 
-/*
 #[cfg(test)]
 mod tests {
+    use cml_core::serialization::ToBytes;
     use cml_crypto::{
-        Bip32PublicKey,
-        chain_crypto::{self, Ed25519Bip32}
+        chain_crypto::{self, Ed25519Bip32}, Deserialize
     };
     use crate::genesis::network_info::NetworkInfo;
     use super::{ByronAddress};
 
     fn assert_same_address(address: ByronAddress, xpub: chain_crypto::PublicKey<Ed25519Bip32>) {
-        assert_eq!(
-            address.address_content().identical_with_pubkey(&Bip32PublicKey(xpub.clone())),
-            true,
+        assert!(
+            address.content.identical_with_pubkey(xpub.clone().into()),
             "expected public key {} to match address {}",
             xpub,
             address,
@@ -361,8 +359,7 @@ mod tests {
 
     #[test]
     fn test_vector_1() {
-        let address: ByronAddress     = "DdzFFzCqrhsrcTVhLygT24QwTnNqQqQ8mZrq5jykUzMveU26sxaH529kMpo7VhPrt5pwW3dXeB2k3EEvKcNBRmzCfcQ7dTkyGzTs658C".parse().unwrap();
-        println!("{}", hex::encode(address.addr()));
+        let address: ByronAddress = "DdzFFzCqrhsrcTVhLygT24QwTnNqQqQ8mZrq5jykUzMveU26sxaH529kMpo7VhPrt5pwW3dXeB2k3EEvKcNBRmzCfcQ7dTkyGzTs658C".parse().unwrap();
         let public_key = chain_crypto::PublicKey::<Ed25519Bip32>::from_binary(&[
             0x6a, 0x50, 0x96, 0x89, 0xc6, 0x53, 0x17, 0x58, 0x65, 0x98, 0x5a, 0xd1, 0xe0, 0xeb,
             0x5f, 0xf9, 0xad, 0xa6, 0x99, 0x7a, 0xa4, 0x03, 0xe6, 0x48, 0x61, 0x4b, 0x3b, 0x78,
@@ -494,16 +491,13 @@ mod tests {
     fn byron_magic_parsing() {
         // mainnet address w/ protocol magic omitted
         let addr = ByronAddress::from_base58("Ae2tdPwUPEZ4YjgvykNpoFeYUxoyhNj2kg8KfKWN2FizsSpLUPv68MpTVDo").unwrap();
-        println!("{}", hex::encode(addr.addr()));
-        let content = addr.address_content();
-        assert_eq!(content.byron_protocol_magic(), NetworkInfo::mainnet().protocol_magic());
-        assert_eq!(content.network_id().unwrap(), NetworkInfo::mainnet().network_id());
+        assert_eq!(addr.content.byron_protocol_magic(), NetworkInfo::mainnet().protocol_magic());
+        assert_eq!(addr.content.network_id().unwrap(), NetworkInfo::mainnet().network_id());
 
         // original Byron testnet address
         let addr = ByronAddress::from_base58("2cWKMJemoBaipzQe9BArYdo2iPUfJQdZAjm4iCzDA1AfNxJSTgm9FZQTmFCYhKkeYrede").unwrap();
-        let content = addr.address_content();
-        assert_eq!(content.byron_protocol_magic(), NetworkInfo::testnet().protocol_magic());
-        assert_eq!(content.network_id().unwrap(), NetworkInfo::testnet().network_id());
+        assert_eq!(addr.content.byron_protocol_magic(), NetworkInfo::testnet().protocol_magic());
+        assert_eq!(addr.content.network_id().unwrap(), NetworkInfo::testnet().network_id());
     }
 
     #[test]
@@ -511,29 +505,25 @@ mod tests {
         // mainnet address
         let start = "DdzFFzCqrhsqTG4t3uq5UBqFrxhxGVM6bvF4q1QcZXqUpizFddEEip7dx5rbife2s9o2fRU3hVKhRp4higog7As8z42s4AMw6Pcu8vL4";
         let addr = ByronAddress::from_base58(start).unwrap();
-        let content = addr.address_content();
-        let end = content.to_address().to_base58();
+        let end = addr.content.to_address().to_base58();
         assert_eq!(start, end);
 
         // mainnet address w/ protocol magic omitted
         let start = "Ae2tdPwUPEZ4YjgvykNpoFeYUxoyhNj2kg8KfKWN2FizsSpLUPv68MpTVDo";
         let addr = ByronAddress::from_base58(start).unwrap();
-        let content = addr.address_content();
-        let end = content.to_address().to_base58();
+        let end = addr.content.to_address().to_base58();
         assert_eq!(start, end);
 
         // original Byron testnet address
         let start = "2cWKMJemoBaipzQe9BArYdo2iPUfJQdZAjm4iCzDA1AfNxJSTgm9FZQTmFCYhKkeYrede";
         let addr = ByronAddress::from_base58(start).unwrap();
-        let content = addr.address_content();
-        let end = content.to_address().to_base58();
+        let end = addr.content.to_address().to_base58();
         assert_eq!(start, end);
 
          // testnet genesis address
          let start = "37btjrVyb4KEg6anTcJ9E4EAvYtNV9xXL6LNpA15YLhgvm9zJ1D2jwme574HikZ36rKdTwaUmpEicCoL1bDw4CtH5PNcFnTRGQNaFd5ai6Wvo6CZsi";
          let addr = ByronAddress::from_base58(start).unwrap();
-         let content = addr.address_content();
-         let end = content.to_address().to_base58();
+         let end = addr.content.to_address().to_base58();
          assert_eq!(start, end);
     }
 
@@ -542,8 +532,7 @@ mod tests {
         assert!(ByronAddress::is_valid("Ae2tdPwUPEZ3MHKkpT5Bpj549vrRH7nBqYjNXnCV8G2Bc2YxNcGHEa8ykDp"));
         let byron_addr = ByronAddress::from_base58("Ae2tdPwUPEZ3MHKkpT5Bpj549vrRH7nBqYjNXnCV8G2Bc2YxNcGHEa8ykDp").unwrap();
         assert_eq!(byron_addr.to_base58(), "Ae2tdPwUPEZ3MHKkpT5Bpj549vrRH7nBqYjNXnCV8G2Bc2YxNcGHEa8ykDp");
-        let byron_addr2 = ByronAddress::from_bytes(byron_addr.to_bytes()).unwrap();
+        let byron_addr2 = ByronAddress::from_cbor_bytes(&byron_addr.to_bytes()).unwrap();
         assert_eq!(byron_addr2.to_base58(), "Ae2tdPwUPEZ3MHKkpT5Bpj549vrRH7nBqYjNXnCV8G2Bc2YxNcGHEa8ykDp");
     }
 }
-*/

--- a/crypto/rust/src/lib.rs
+++ b/crypto/rust/src/lib.rs
@@ -286,11 +286,13 @@ impl PrivateKey {
 
     /// Get private key from its bech32 representation
     /// ```rust
-    /// PrivateKey::from_bech32(&#39;ed25519_sk1ahfetf02qwwg4dkq7mgp4a25lx5vh9920cr5wnxmpzz9906qvm8qwvlts0&#39;);
+    /// use cml_crypto::PrivateKey;
+    /// let key = PrivateKey::from_bech32("ed25519_sk1ahfetf02qwwg4dkq7mgp4a25lx5vh9920cr5wnxmpzz9906qvm8qwvlts0").unwrap();
     /// ```
     /// For an extended 25519 key
     /// ```rust
-    /// PrivateKey::from_bech32(&#39;ed25519e_sk1gqwl4szuwwh6d0yk3nsqcc6xxc3fpvjlevgwvt60df59v8zd8f8prazt8ln3lmz096ux3xvhhvm3ca9wj2yctdh3pnw0szrma07rt5gl748fp&#39;);
+    /// use cml_crypto::PrivateKey;
+    /// let key = PrivateKey::from_bech32("ed25519e_sk1gqwl4szuwwh6d0yk3nsqcc6xxc3fpvjlevgwvt60df59v8zd8f8prazt8ln3lmz096ux3xvhhvm3ca9wj2yctdh3pnw0szrma07rt5gl748fp").unwrap();
     /// ```
     pub fn from_bech32(bech32_str: &str) -> Result<PrivateKey, CryptoError> {
         chain_crypto::SecretKey::try_from_bech32_str(&bech32_str)
@@ -358,7 +360,8 @@ impl PublicKey {
     /// Get public key from its bech32 representation
     /// Example:
     /// ```rust
-    /// let pkey = PublicKey::from_bech32(&#39;ed25519_pk1dgaagyh470y66p899txcl3r0jaeaxu6yd7z2dxyk55qcycdml8gszkxze2&#39;)?;
+    /// use cml_crypto::PublicKey;
+    /// let key = PublicKey::from_bech32("ed25519_pk1dgaagyh470y66p899txcl3r0jaeaxu6yd7z2dxyk55qcycdml8gszkxze2").unwrap();
     /// ```
     pub fn from_bech32(bech32_str: &str) -> Result<PublicKey, CryptoError> {
         chain_crypto::PublicKey::try_from_bech32_str(&bech32_str)
@@ -624,6 +627,7 @@ impl_hash_type!(KESVkey, 32);
 //impl_hash_type!(KESSignature, 448);
 impl_hash_type!(NonceHash, 32);
 
+#[derive(Clone)]
 pub struct LegacyDaedalusPrivateKey(chain_crypto::SecretKey<chain_crypto::LegacyDaedalus>);
 
 impl LegacyDaedalusPrivateKey {


### PR DESCRIPTION
Update byron tests

Update address tests + fix for byron address serialization (old code would ommit bootstrap in addr attributes contrary to the stated byron.cddl)

Fix doc-tests in crypto lib

Fixes #219 