### PR TITLE
Duplicate key support for Metadatums + PlutusDatums

### DIFF
--- a/chain/rust/src/plutus/mod.rs
+++ b/chain/rust/src/plutus/mod.rs
@@ -15,7 +15,7 @@ use cml_core::ordered_hash_map::OrderedHashMap;
 use cml_core::serialization::{LenEncoding, StringEncoding};
 use cml_core::Int;
 
-pub use utils::{ConstrPlutusData, PlutusScript};
+pub use utils::{ConstrPlutusData, PlutusMap, PlutusScript};
 
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
@@ -113,17 +113,7 @@ pub enum Language {
 )]
 pub enum PlutusData {
     ConstrPlutusData(ConstrPlutusData),
-    Map {
-        map: OrderedHashMap<PlutusData, PlutusData>,
-        #[derivative(
-            PartialEq = "ignore",
-            Ord = "ignore",
-            PartialOrd = "ignore",
-            Hash = "ignore"
-        )]
-        #[serde(skip)]
-        map_encoding: LenEncoding,
-    },
+    Map(PlutusMap),
     List {
         list: Vec<PlutusData>,
         #[derivative(
@@ -154,11 +144,8 @@ impl PlutusData {
         Self::ConstrPlutusData(constr_plutus_data)
     }
 
-    pub fn new_map(map: OrderedHashMap<PlutusData, PlutusData>) -> Self {
-        Self::Map {
-            map,
-            map_encoding: LenEncoding::default(),
-        }
+    pub fn new_map(map: PlutusMap) -> Self {
+        Self::Map(map)
     }
 
     pub fn new_list(list: Vec<PlutusData>) -> Self {

--- a/chain/wasm/src/lib.rs
+++ b/chain/wasm/src/lib.rs
@@ -35,7 +35,7 @@ use plutus::{
 use transaction::{
     NativeScript, TransactionBody, TransactionInput, TransactionOutput, TransactionWitnessSet,
 };
-use cml_chain::NetworkId;
+pub use cml_chain::{Epoch, NetworkId};
 
 //extern crate serde_wasm_bindgen;
 // Code below here was code-generated using an experimental CDDL to rust tool:
@@ -209,8 +209,6 @@ impl AsRef<Vec<cml_chain::crypto::Ed25519KeyHash>> for Ed25519KeyHashList {
     }
 }
 
-pub type Epoch = u64;
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct GenesisHashList(Vec<cml_chain::crypto::GenesisHash>);
@@ -334,65 +332,6 @@ impl From<MapAssetNameToI64> for OrderedHashMap<cml_chain::assets::AssetName, i6
 
 impl AsRef<OrderedHashMap<cml_chain::assets::AssetName, i64>> for MapAssetNameToI64 {
     fn as_ref(&self) -> &OrderedHashMap<cml_chain::assets::AssetName, i64> {
-        &self.0
-    }
-}
-
-#[derive(Clone, Debug)]
-#[wasm_bindgen]
-pub struct MapPlutusDataToPlutusData(
-    OrderedHashMap<cml_chain::plutus::PlutusData, cml_chain::plutus::PlutusData>,
-);
-
-#[wasm_bindgen]
-impl MapPlutusDataToPlutusData {
-    pub fn new() -> Self {
-        Self(OrderedHashMap::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn insert(&mut self, key: &PlutusData, value: &PlutusData) -> Option<PlutusData> {
-        self.0
-            .insert(key.clone().into(), value.clone().into())
-            .map(Into::into)
-    }
-
-    pub fn get(&self, key: &PlutusData) -> Option<PlutusData> {
-        self.0.get(key.as_ref()).map(|v| v.clone().into())
-    }
-
-    pub fn keys(&self) -> PlutusDataList {
-        PlutusDataList(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
-    }
-}
-
-impl From<OrderedHashMap<cml_chain::plutus::PlutusData, cml_chain::plutus::PlutusData>>
-    for MapPlutusDataToPlutusData
-{
-    fn from(
-        native: OrderedHashMap<cml_chain::plutus::PlutusData, cml_chain::plutus::PlutusData>,
-    ) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MapPlutusDataToPlutusData>
-    for OrderedHashMap<cml_chain::plutus::PlutusData, cml_chain::plutus::PlutusData>
-{
-    fn from(wasm: MapPlutusDataToPlutusData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<OrderedHashMap<cml_chain::plutus::PlutusData, cml_chain::plutus::PlutusData>>
-    for MapPlutusDataToPlutusData
-{
-    fn as_ref(
-        &self,
-    ) -> &OrderedHashMap<cml_chain::plutus::PlutusData, cml_chain::plutus::PlutusData> {
         &self.0
     }
 }

--- a/chain/wasm/src/plutus/mod.rs
+++ b/chain/wasm/src/plutus/mod.rs
@@ -5,9 +5,9 @@ pub mod utils;
 
 use crate::utils::BigInt;
 
-use super::{IntList, MapPlutusDataToPlutusData, PlutusDataList, SubCoin};
+use super::{IntList, PlutusDataList, SubCoin};
 pub use cml_chain::plutus::{Language, RedeemerTag};
-pub use utils::ConstrPlutusData;
+pub use utils::{ConstrPlutusData, PlutusMap};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[derive(Clone, Debug)]
@@ -248,7 +248,7 @@ impl PlutusData {
         ))
     }
 
-    pub fn new_map(map: &MapPlutusDataToPlutusData) -> Self {
+    pub fn new_map(map: &PlutusMap) -> Self {
         Self(cml_chain::plutus::PlutusData::new_map(map.clone().into()))
     }
 
@@ -285,9 +285,9 @@ impl PlutusData {
         }
     }
 
-    pub fn as_map(&self) -> Option<MapPlutusDataToPlutusData> {
+    pub fn as_map(&self) -> Option<PlutusMap> {
         match &self.0 {
-            cml_chain::plutus::PlutusData::Map { map, .. } => Some(map.clone().into()),
+            cml_chain::plutus::PlutusData::Map(map) => Some(map.clone().into()),
             _ => None,
         }
     }


### PR DESCRIPTION
metadatum dup keys have been found on mainnet

plutus dup keys have been found only on preprod

Fixes #209 (the remaining issues - metadatum labels was already fixed)