### PR TITLE
Multi-Era crate support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ members = [
     "core/rust",
     "core/wasm",
     "crypto/rust",
-    "crypto/wasm"
+    "crypto/wasm",
+    "multi-era/rust",
+    "multi-era/wasm"
 ]
 
 # exclude old crate structure to avoid error in it

--- a/multi-era/rust/Cargo.toml
+++ b/multi-era/rust/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cml-multi-era"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cml-core = { path = "../../core/rust" }
+cml-crypto = { path = "../../crypto/rust" }
+cml-chain = { path = "../../chain/rust" }
+cbor_event = "2.4.0"
+linked-hash-map = "0.5.3"
+derivative = "2.2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.57"
+schemars = "0.8.8"
+wasm-bindgen = { version = "0.2", features=["serde-serialize"] }

--- a/multi-era/rust/src/allegra/cbor_encodings.rs
+++ b/multi-era/rust/src/allegra/cbor_encodings.rs
@@ -1,0 +1,56 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_core::serialization::{LenEncoding, StringEncoding};
+use std::collections::BTreeMap;
+use cml_chain::address::RewardAccount;
+
+#[derive(Clone, Debug, Default)]
+pub struct AllegraBlockEncoding {
+    pub len_encoding: LenEncoding,
+    pub transaction_bodies_encoding: LenEncoding,
+    pub transaction_witness_sets_encoding: LenEncoding,
+    pub auxiliary_data_set_encoding: LenEncoding,
+    pub auxiliary_data_set_key_encodings: BTreeMap<u16, Option<cbor_event::Sz>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AllegraTransactionBodyEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub inputs_encoding: LenEncoding,
+    pub inputs_key_encoding: Option<cbor_event::Sz>,
+    pub outputs_encoding: LenEncoding,
+    pub outputs_key_encoding: Option<cbor_event::Sz>,
+    pub fee_encoding: Option<cbor_event::Sz>,
+    pub fee_key_encoding: Option<cbor_event::Sz>,
+    pub ttl_encoding: Option<cbor_event::Sz>,
+    pub ttl_key_encoding: Option<cbor_event::Sz>,
+    pub certs_encoding: LenEncoding,
+    pub certs_key_encoding: Option<cbor_event::Sz>,
+    pub withdrawals_encoding: LenEncoding,
+    pub withdrawals_value_encodings: BTreeMap<RewardAccount, Option<cbor_event::Sz>>,
+    pub withdrawals_key_encoding: Option<cbor_event::Sz>,
+    pub update_key_encoding: Option<cbor_event::Sz>,
+    pub auxiliary_data_hash_encoding: StringEncoding,
+    pub auxiliary_data_hash_key_encoding: Option<cbor_event::Sz>,
+    pub validity_interval_start_encoding: Option<cbor_event::Sz>,
+    pub validity_interval_start_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AllegraTransactionEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AllegraTransactionWitnessSetEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub vkeywitnesses_encoding: LenEncoding,
+    pub vkeywitnesses_key_encoding: Option<cbor_event::Sz>,
+    pub native_scripts_encoding: LenEncoding,
+    pub native_scripts_key_encoding: Option<cbor_event::Sz>,
+    pub bootstrap_witnesses_encoding: LenEncoding,
+    pub bootstrap_witnesses_key_encoding: Option<cbor_event::Sz>,
+}

--- a/multi-era/rust/src/allegra/mod.rs
+++ b/multi-era/rust/src/allegra/mod.rs
@@ -1,0 +1,149 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+pub mod cbor_encodings;
+pub mod serialization;
+
+use cml_chain::TransactionIndex;
+use cml_chain::assets::Coin;
+use cml_chain::auxdata::{ShelleyAuxData, ShelleyMaAuxData};
+use cml_chain::certs::Certificate;
+use cml_chain::crypto::{AuxiliaryDataHash, BootstrapWitness, Vkeywitness};
+use cml_chain::transaction::{NativeScript, TransactionInput};
+use cml_chain::Withdrawals;
+use crate::shelley::{ShelleyHeader, ShelleyTransactionOutput, ShelleyUpdate};
+use cbor_encodings::{
+    AllegraBlockEncoding, AllegraTransactionBodyEncoding, AllegraTransactionEncoding,
+    AllegraTransactionWitnessSetEncoding,
+};
+use cml_core::ordered_hash_map::OrderedHashMap;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum AllegraAuxiliaryData {
+    ShelleyAuxData(ShelleyAuxData),
+    ShelleyMaAuxData(ShelleyMaAuxData),
+}
+
+impl AllegraAuxiliaryData {
+    pub fn new_shelley_aux_data(shelley_aux_data: ShelleyAuxData) -> Self {
+        Self::ShelleyAuxData(shelley_aux_data)
+    }
+
+    pub fn new_shelley_ma_aux_data(shelley_ma_aux_data: ShelleyMaAuxData) -> Self {
+        Self::ShelleyMaAuxData(shelley_ma_aux_data)
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AllegraBlock {
+    pub header: ShelleyHeader,
+    pub transaction_bodies: Vec<AllegraTransactionBody>,
+    pub transaction_witness_sets: Vec<AllegraTransactionWitnessSet>,
+    pub auxiliary_data_set: OrderedHashMap<TransactionIndex, AllegraAuxiliaryData>,
+    #[serde(skip)]
+    pub encodings: Option<AllegraBlockEncoding>,
+}
+
+impl AllegraBlock {
+    pub fn new(
+        header: ShelleyHeader,
+        transaction_bodies: Vec<AllegraTransactionBody>,
+        transaction_witness_sets: Vec<AllegraTransactionWitnessSet>,
+        auxiliary_data_set: OrderedHashMap<TransactionIndex, AllegraAuxiliaryData>,
+    ) -> Self {
+        Self {
+            header,
+            transaction_bodies,
+            transaction_witness_sets,
+            auxiliary_data_set,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AllegraTransaction {
+    pub body: AllegraTransactionBody,
+    pub witness_set: AllegraTransactionWitnessSet,
+    pub auxiliary_data: Option<AllegraAuxiliaryData>,
+    #[serde(skip)]
+    pub encodings: Option<AllegraTransactionEncoding>,
+}
+
+impl AllegraTransaction {
+    pub fn new(
+        body: AllegraTransactionBody,
+        witness_set: AllegraTransactionWitnessSet,
+        auxiliary_data: Option<AllegraAuxiliaryData>,
+    ) -> Self {
+        Self {
+            body,
+            witness_set,
+            auxiliary_data,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AllegraTransactionBody {
+    pub inputs: Vec<TransactionInput>,
+    pub outputs: Vec<ShelleyTransactionOutput>,
+    pub fee: Coin,
+    pub ttl: Option<u64>,
+    pub certs: Option<Vec<Certificate>>,
+    pub withdrawals: Option<Withdrawals>,
+    pub update: Option<ShelleyUpdate>,
+    pub auxiliary_data_hash: Option<AuxiliaryDataHash>,
+    pub validity_interval_start: Option<u64>,
+    #[serde(skip)]
+    pub encodings: Option<AllegraTransactionBodyEncoding>,
+}
+
+impl AllegraTransactionBody {
+    pub fn new(
+        inputs: Vec<TransactionInput>,
+        outputs: Vec<ShelleyTransactionOutput>,
+        fee: Coin,
+    ) -> Self {
+        Self {
+            inputs,
+            outputs,
+            fee,
+            ttl: None,
+            certs: None,
+            withdrawals: None,
+            update: None,
+            auxiliary_data_hash: None,
+            validity_interval_start: None,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AllegraTransactionWitnessSet {
+    pub vkeywitnesses: Option<Vec<Vkeywitness>>,
+    pub native_scripts: Option<Vec<NativeScript>>,
+    pub bootstrap_witnesses: Option<Vec<BootstrapWitness>>,
+    #[serde(skip)]
+    pub encodings: Option<AllegraTransactionWitnessSetEncoding>,
+}
+
+impl AllegraTransactionWitnessSet {
+    pub fn new() -> Self {
+        Self {
+            vkeywitnesses: None,
+            native_scripts: None,
+            bootstrap_witnesses: None,
+            encodings: None,
+        }
+    }
+}
+
+impl Default for AllegraTransactionWitnessSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/multi-era/rust/src/allegra/serialization.rs
+++ b/multi-era/rust/src/allegra/serialization.rs
@@ -1,0 +1,1204 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use super::cbor_encodings::*;
+use super::*;
+use cbor_event;
+use cbor_event::de::Deserializer;
+use cbor_event::se::Serializer;
+use cml_chain::address::RewardAccount;
+use cml_core::error::*;
+use cml_core::serialization::*;
+use cml_crypto::RawBytesEncoding;
+use std::io::{BufRead, Seek, SeekFrom, Write};
+
+impl Serialize for AllegraAuxiliaryData {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            AllegraAuxiliaryData::ShelleyAuxData(shelley_aux_data) => {
+                shelley_aux_data.serialize(serializer, force_canonical)
+            }
+            AllegraAuxiliaryData::ShelleyMaAuxData(shelley_ma_aux_data) => {
+                shelley_ma_aux_data.serialize(serializer, force_canonical)
+            }
+        }
+    }
+}
+
+impl Deserialize for AllegraAuxiliaryData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            let deser_variant: Result<_, DeserializeError> = ShelleyAuxData::deserialize(raw);
+            match deser_variant {
+                Ok(shelley_aux_data) => return Ok(Self::ShelleyAuxData(shelley_aux_data)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> = ShelleyMaAuxData::deserialize(raw);
+            match deser_variant {
+                Ok(shelley_ma_aux_data) => return Ok(Self::ShelleyMaAuxData(shelley_ma_aux_data)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            println!("trailing: {:?}", raw.as_mut_ref().fill_buf().unwrap());
+            // Err(DeserializeError::new(
+            //     "AllegraAuxiliaryData",
+            //     DeserializeFailure::NoVariantMatched,
+            // ))
+            ShelleyMaAuxData::deserialize(raw).map(Self::ShelleyMaAuxData)
+        })()
+        .map_err(|e| e.annotate("AllegraAuxiliaryData"))
+    }
+}
+
+impl Serialize for AllegraBlock {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(4, force_canonical),
+        )?;
+        self.header.serialize(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_bodies_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_bodies.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_bodies.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_bodies_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_witness_sets_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_witness_sets.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_witness_sets.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_witness_sets_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.auxiliary_data_set_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.auxiliary_data_set.len() as u64, force_canonical),
+        )?;
+        let mut key_order = self
+            .auxiliary_data_set
+            .iter()
+            .map(|(k, v)| {
+                let mut buf = cbor_event::se::Serializer::new_vec();
+                let auxiliary_data_set_key_encoding = self
+                    .encodings
+                    .as_ref()
+                    .and_then(|encs| encs.auxiliary_data_set_key_encodings.get(k))
+                    .cloned()
+                    .unwrap_or_default();
+                buf.write_unsigned_integer_sz(
+                    *k as u64,
+                    fit_sz(*k as u64, auxiliary_data_set_key_encoding, force_canonical),
+                )?;
+                Ok((buf.finalize(), k, v))
+            })
+            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, _key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.auxiliary_data_set_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AllegraBlock {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(4)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let header = ShelleyHeader::deserialize(raw).map_err(|e: DeserializeError| e.annotate("header"))?;
+            let (transaction_bodies, transaction_bodies_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_bodies_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_bodies_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => (transaction_bodies_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    transaction_bodies_arr.push(AllegraTransactionBody::deserialize(raw)?);
+                }
+                Ok((transaction_bodies_arr, transaction_bodies_encoding))
+            })().map_err(|e| e.annotate("transaction_bodies"))?;
+            let (transaction_witness_sets, transaction_witness_sets_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_witness_sets_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_witness_sets_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => (transaction_witness_sets_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    transaction_witness_sets_arr.push(AllegraTransactionWitnessSet::deserialize(raw)?);
+                }
+                Ok((transaction_witness_sets_arr, transaction_witness_sets_encoding))
+            })().map_err(|e| e.annotate("transaction_witness_sets"))?;
+            let (auxiliary_data_set, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut auxiliary_data_set_table = OrderedHashMap::new();
+                let auxiliary_data_set_len = raw.map_sz()?;
+                let auxiliary_data_set_encoding = auxiliary_data_set_len.into();
+                let mut auxiliary_data_set_key_encodings = BTreeMap::new();
+                while match auxiliary_data_set_len { cbor_event::LenSz::Len(n, _) => (auxiliary_data_set_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let (auxiliary_data_set_key, auxiliary_data_set_key_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?;
+                    let auxiliary_data_set_value = AllegraAuxiliaryData::deserialize(raw)?;
+                    if auxiliary_data_set_table.insert(auxiliary_data_set_key, auxiliary_data_set_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                    auxiliary_data_set_key_encodings.insert(auxiliary_data_set_key, auxiliary_data_set_key_encoding);
+                }
+                Ok((auxiliary_data_set_table, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings))
+            })().map_err(|e| e.annotate("auxiliary_data_set"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(AllegraBlock {
+                header,
+                transaction_bodies,
+                transaction_witness_sets,
+                auxiliary_data_set,
+                encodings: Some(AllegraBlockEncoding {
+                    len_encoding,
+                    transaction_bodies_encoding,
+                    transaction_witness_sets_encoding,
+                    auxiliary_data_set_encoding,
+                    auxiliary_data_set_key_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("AllegraBlock"))
+    }
+}
+
+impl Serialize for AllegraTransaction {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(3, force_canonical),
+        )?;
+        self.body.serialize(serializer, force_canonical)?;
+        self.witness_set.serialize(serializer, force_canonical)?;
+        match &self.auxiliary_data {
+            Some(x) => x.serialize(serializer, force_canonical),
+            None => serializer.write_special(cbor_event::Special::Null),
+        }?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AllegraTransaction {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let body = AllegraTransactionBody::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("body"))?;
+            let witness_set = AllegraTransactionWitnessSet::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("witness_set"))?;
+            let auxiliary_data = (|| -> Result<_, DeserializeError> {
+                Ok(match raw.cbor_type()? != cbor_event::Type::Special {
+                    true => Some(AllegraAuxiliaryData::deserialize(raw)?),
+                    false => {
+                        if raw.special()? != cbor_event::Special::Null {
+                            return Err(DeserializeFailure::ExpectedNull.into());
+                        }
+                        None
+                    }
+                })
+            })()
+            .map_err(|e| e.annotate("auxiliary_data"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(AllegraTransaction {
+                body,
+                witness_set,
+                auxiliary_data,
+                encodings: Some(AllegraTransactionEncoding { len_encoding }),
+            })
+        })()
+        .map_err(|e| e.annotate("AllegraTransaction"))
+    }
+}
+
+impl Serialize for AllegraTransactionBody {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    3 + match &self.ttl {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.certs {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.withdrawals {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.update {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.auxiliary_data_hash {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.validity_interval_start {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == 3 + match &self.ttl {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.certs {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.withdrawals {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.update {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.auxiliary_data_hash {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.validity_interval_start {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    serializer.write_unsigned_integer_sz(
+                        0u64,
+                        fit_sz(
+                            0u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.inputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.inputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.inputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.inputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.inputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                1 => {
+                    serializer.write_unsigned_integer_sz(
+                        1u64,
+                        fit_sz(
+                            1u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.outputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.outputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.outputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.outputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.outputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                2 => {
+                    serializer.write_unsigned_integer_sz(
+                        2u64,
+                        fit_sz(
+                            2u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_unsigned_integer_sz(
+                        self.fee,
+                        fit_sz(
+                            self.fee,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                }
+                3 => {
+                    if let Some(field) = &self.ttl {
+                        serializer.write_unsigned_integer_sz(
+                            3u64,
+                            fit_sz(
+                                3u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ttl_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ttl_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                4 => {
+                    if let Some(field) = &self.certs {
+                        serializer.write_unsigned_integer_sz(
+                            4u64,
+                            fit_sz(
+                                4u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.certs_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.certs_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.certs_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                5 => {
+                    if let Some(field) = &self.withdrawals {
+                        serializer.write_unsigned_integer_sz(
+                            5u64,
+                            fit_sz(
+                                5u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.withdrawals_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_map_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.withdrawals_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        let mut key_order = field
+                            .iter()
+                            .map(|(k, v)| {
+                                let mut buf = cbor_event::se::Serializer::new_vec();
+                                k.serialize(&mut buf, force_canonical)?;
+                                Ok((buf.finalize(), k, v))
+                            })
+                            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                        if force_canonical {
+                            key_order.sort_by(
+                                |(lhs_bytes, _, _), (rhs_bytes, _, _)| match lhs_bytes
+                                    .len()
+                                    .cmp(&rhs_bytes.len())
+                                {
+                                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                    diff_ord => diff_ord,
+                                },
+                            );
+                        }
+                        for (key_bytes, key, value) in key_order {
+                            serializer.write_raw_bytes(&key_bytes)?;
+                            let withdrawals_value_encoding = self
+                                .encodings
+                                .as_ref()
+                                .and_then(|encs| encs.withdrawals_value_encodings.get(key))
+                                .cloned()
+                                .unwrap_or_default();
+                            serializer.write_unsigned_integer_sz(
+                                *value,
+                                fit_sz(*value, withdrawals_value_encoding, force_canonical),
+                            )?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.withdrawals_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                6 => {
+                    if let Some(field) = &self.update {
+                        serializer.write_unsigned_integer_sz(
+                            6u64,
+                            fit_sz(
+                                6u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.update_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                7 => {
+                    if let Some(field) = &self.auxiliary_data_hash {
+                        serializer.write_unsigned_integer_sz(
+                            7u64,
+                            fit_sz(
+                                7u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.auxiliary_data_hash_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_bytes_sz(
+                            &field.to_raw_bytes(),
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.auxiliary_data_hash_encoding.clone())
+                                .unwrap_or_default()
+                                .to_str_len_sz(field.to_raw_bytes().len() as u64, force_canonical),
+                        )?;
+                    }
+                }
+                8 => {
+                    if let Some(field) = &self.validity_interval_start {
+                        serializer.write_unsigned_integer_sz(
+                            8u64,
+                            fit_sz(
+                                8u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.validity_interval_start_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.validity_interval_start_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AllegraTransactionBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut inputs_encoding = LenEncoding::default();
+            let mut inputs_key_encoding = None;
+            let mut inputs = None;
+            let mut outputs_encoding = LenEncoding::default();
+            let mut outputs_key_encoding = None;
+            let mut outputs = None;
+            let mut fee_encoding = None;
+            let mut fee_key_encoding = None;
+            let mut fee = None;
+            let mut ttl_encoding = None;
+            let mut ttl_key_encoding = None;
+            let mut ttl = None;
+            let mut certs_encoding = LenEncoding::default();
+            let mut certs_key_encoding = None;
+            let mut certs = None;
+            let mut withdrawals_encoding = LenEncoding::default();
+            let mut withdrawals_value_encodings = BTreeMap::new();
+            let mut withdrawals_key_encoding = None;
+            let mut withdrawals = None;
+            let mut update_key_encoding = None;
+            let mut update = None;
+            let mut auxiliary_data_hash_encoding = StringEncoding::default();
+            let mut auxiliary_data_hash_key_encoding = None;
+            let mut auxiliary_data_hash = None;
+            let mut validity_interval_start_encoding = None;
+            let mut validity_interval_start_key_encoding = None;
+            let mut validity_interval_start = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if inputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_inputs, tmp_inputs_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut inputs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let inputs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (inputs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    inputs_arr.push(TransactionInput::deserialize(raw)?);
+                                }
+                                Ok((inputs_arr, inputs_encoding))
+                            })().map_err(|e| e.annotate("inputs"))?;
+                            inputs = Some(tmp_inputs);
+                            inputs_encoding = tmp_inputs_encoding;
+                            inputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if outputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_outputs, tmp_outputs_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut outputs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let outputs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (outputs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    outputs_arr.push(ShelleyTransactionOutput::deserialize(raw)?);
+                                }
+                                Ok((outputs_arr, outputs_encoding))
+                            })().map_err(|e| e.annotate("outputs"))?;
+                            outputs = Some(tmp_outputs);
+                            outputs_encoding = tmp_outputs_encoding;
+                            outputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if fee.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into).map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            fee = Some(tmp_fee);
+                            fee_encoding = tmp_fee_encoding;
+                            fee_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if ttl.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_ttl, tmp_ttl_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                            })().map_err(|e| e.annotate("ttl"))?;
+                            ttl = Some(tmp_ttl);
+                            ttl_encoding = tmp_ttl_encoding;
+                            ttl_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (4, key_enc) =>  {
+                            if certs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_certs, tmp_certs_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut certs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let certs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (certs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    certs_arr.push(Certificate::deserialize(raw)?);
+                                }
+                                Ok((certs_arr, certs_encoding))
+                            })().map_err(|e| e.annotate("certs"))?;
+                            certs = Some(tmp_certs);
+                            certs_encoding = tmp_certs_encoding;
+                            certs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        },
+                        (5, key_enc) =>  {
+                            if withdrawals.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_withdrawals, tmp_withdrawals_encoding, tmp_withdrawals_value_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut withdrawals_table = OrderedHashMap::new();
+                                let withdrawals_len = raw.map_sz()?;
+                                let withdrawals_encoding = withdrawals_len.into();
+                                let mut withdrawals_value_encodings = BTreeMap::new();
+                                while match withdrawals_len { cbor_event::LenSz::Len(n, _) => (withdrawals_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    let withdrawals_key = RewardAccount::deserialize(raw)?;
+                                    let (withdrawals_value, withdrawals_value_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                                    if withdrawals_table.insert(withdrawals_key.clone(), withdrawals_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    withdrawals_value_encodings.insert(withdrawals_key, withdrawals_value_encoding);
+                                }
+                                Ok((withdrawals_table, withdrawals_encoding, withdrawals_value_encodings))
+                            })().map_err(|e| e.annotate("withdrawals"))?;
+                            withdrawals = Some(tmp_withdrawals);
+                            withdrawals_encoding = tmp_withdrawals_encoding;
+                            withdrawals_value_encodings = tmp_withdrawals_value_encodings;
+                            withdrawals_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        },
+                        (6, key_enc) =>  {
+                            if update.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let tmp_update = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ShelleyUpdate::deserialize(raw)
+                            })().map_err(|e| e.annotate("update"))?;
+                            update = Some(tmp_update);
+                            update_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        },
+                        (7, key_enc) =>  {
+                            if auxiliary_data_hash.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let (tmp_auxiliary_data_hash, tmp_auxiliary_data_hash_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.bytes_sz().map_err(Into::<DeserializeError>::into).and_then(|(bytes, enc)| AuxiliaryDataHash::from_raw_bytes(&bytes).map(|bytes| (bytes, StringEncoding::from(enc))).map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into()))
+                            })().map_err(|e| e.annotate("auxiliary_data_hash"))?;
+                            auxiliary_data_hash = Some(tmp_auxiliary_data_hash);
+                            auxiliary_data_hash_encoding = tmp_auxiliary_data_hash_encoding;
+                            auxiliary_data_hash_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        },
+                        (8, key_enc) =>  {
+                            if validity_interval_start.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(8)).into());
+                            }
+                            let (tmp_validity_interval_start, tmp_validity_interval_start_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                            })().map_err(|e| e.annotate("validity_interval_start"))?;
+                            validity_interval_start = Some(tmp_validity_interval_start);
+                            validity_interval_start_encoding = tmp_validity_interval_start_encoding;
+                            validity_interval_start_key_encoding = Some(key_enc);
+                            orig_deser_order.push(8);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    cbor_event::Type::Text => return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into()),
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            let inputs = match inputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(0)).into()),
+            };
+            let outputs = match outputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(1)).into()),
+            };
+            let fee = match fee {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(2)).into()),
+            };
+            read_len.finish()?;
+            Ok(Self {
+                inputs,
+                outputs,
+                fee,
+                ttl,
+                certs,
+                withdrawals,
+                update,
+                auxiliary_data_hash,
+                validity_interval_start,
+                encodings: Some(AllegraTransactionBodyEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    inputs_key_encoding,
+                    inputs_encoding,
+                    outputs_key_encoding,
+                    outputs_encoding,
+                    fee_key_encoding,
+                    fee_encoding,
+                    ttl_key_encoding,
+                    ttl_encoding,
+                    certs_key_encoding,
+                    certs_encoding,
+                    withdrawals_key_encoding,
+                    withdrawals_encoding,
+                    withdrawals_value_encodings,
+                    update_key_encoding,
+                    auxiliary_data_hash_key_encoding,
+                    auxiliary_data_hash_encoding,
+                    validity_interval_start_key_encoding,
+                    validity_interval_start_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("AllegraTransactionBody"))
+    }
+}
+
+impl Serialize for AllegraTransactionWitnessSet {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    match &self.vkeywitnesses {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.native_scripts {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.bootstrap_witnesses {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == match &self.vkeywitnesses {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.native_scripts {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.bootstrap_witnesses {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    if let Some(field) = &self.vkeywitnesses {
+                        serializer.write_unsigned_integer_sz(
+                            0u64,
+                            fit_sz(
+                                0u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.vkeywitnesses_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.vkeywitnesses_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.vkeywitnesses_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                1 => {
+                    if let Some(field) = &self.native_scripts {
+                        serializer.write_unsigned_integer_sz(
+                            1u64,
+                            fit_sz(
+                                1u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.native_scripts_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.native_scripts_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.native_scripts_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                2 => {
+                    if let Some(field) = &self.bootstrap_witnesses {
+                        serializer.write_unsigned_integer_sz(
+                            2u64,
+                            fit_sz(
+                                2u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.bootstrap_witnesses_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.bootstrap_witnesses_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.bootstrap_witnesses_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AllegraTransactionWitnessSet {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut vkeywitnesses_encoding = LenEncoding::default();
+            let mut vkeywitnesses_key_encoding = None;
+            let mut vkeywitnesses = None;
+            let mut native_scripts_encoding = LenEncoding::default();
+            let mut native_scripts_key_encoding = None;
+            let mut native_scripts = None;
+            let mut bootstrap_witnesses_encoding = LenEncoding::default();
+            let mut bootstrap_witnesses_key_encoding = None;
+            let mut bootstrap_witnesses = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if vkeywitnesses.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_vkeywitnesses, tmp_vkeywitnesses_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut vkeywitnesses_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let vkeywitnesses_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (vkeywitnesses_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        vkeywitnesses_arr.push(Vkeywitness::deserialize(raw)?);
+                                    }
+                                    Ok((vkeywitnesses_arr, vkeywitnesses_encoding))
+                                })()
+                                .map_err(|e| e.annotate("vkeywitnesses"))?;
+                            vkeywitnesses = Some(tmp_vkeywitnesses);
+                            vkeywitnesses_encoding = tmp_vkeywitnesses_encoding;
+                            vkeywitnesses_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (1, key_enc) => {
+                            if native_scripts.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_native_scripts, tmp_native_scripts_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut native_scripts_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let native_scripts_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (native_scripts_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        native_scripts_arr.push(NativeScript::deserialize(raw)?);
+                                    }
+                                    Ok((native_scripts_arr, native_scripts_encoding))
+                                })()
+                                .map_err(|e| e.annotate("native_scripts"))?;
+                            native_scripts = Some(tmp_native_scripts);
+                            native_scripts_encoding = tmp_native_scripts_encoding;
+                            native_scripts_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        }
+                        (2, key_enc) => {
+                            if bootstrap_witnesses.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_bootstrap_witnesses, tmp_bootstrap_witnesses_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut bootstrap_witnesses_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let bootstrap_witnesses_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (bootstrap_witnesses_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        bootstrap_witnesses_arr
+                                            .push(BootstrapWitness::deserialize(raw)?);
+                                    }
+                                    Ok((bootstrap_witnesses_arr, bootstrap_witnesses_encoding))
+                                })()
+                                .map_err(|e| e.annotate("bootstrap_witnesses"))?;
+                            bootstrap_witnesses = Some(tmp_bootstrap_witnesses);
+                            bootstrap_witnesses_encoding = tmp_bootstrap_witnesses_encoding;
+                            bootstrap_witnesses_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                vkeywitnesses,
+                native_scripts,
+                bootstrap_witnesses,
+                encodings: Some(AllegraTransactionWitnessSetEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    vkeywitnesses_key_encoding,
+                    vkeywitnesses_encoding,
+                    native_scripts_key_encoding,
+                    native_scripts_encoding,
+                    bootstrap_witnesses_key_encoding,
+                    bootstrap_witnesses_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("AllegraTransactionWitnessSet"))
+    }
+}

--- a/multi-era/rust/src/alonzo/cbor_encodings.rs
+++ b/multi-era/rust/src/alonzo/cbor_encodings.rs
@@ -1,0 +1,155 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_core::serialization::{LenEncoding, StringEncoding};
+use std::collections::BTreeMap;
+use cml_chain::{
+    AssetName,
+    PolicyId,
+    address::RewardAccount,
+    crypto::GenesisHash,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoBlockEncoding {
+    pub len_encoding: LenEncoding,
+    pub transaction_bodies_encoding: LenEncoding,
+    pub transaction_witness_sets_encoding: LenEncoding,
+    pub auxiliary_data_set_encoding: LenEncoding,
+    pub auxiliary_data_set_key_encodings: BTreeMap<u16, Option<cbor_event::Sz>>,
+    pub invalid_transactions_encoding: LenEncoding,
+    pub invalid_transactions_elem_encodings: Vec<Option<cbor_event::Sz>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoCostmdlsEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub plutus_v1_encoding: LenEncoding,
+    pub plutus_v1_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoOnlyAuxDataEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<cbor_event::Sz>,
+    pub orig_deser_order: Vec<usize>,
+    pub metadata_key_encoding: Option<cbor_event::Sz>,
+    pub native_scripts_encoding: LenEncoding,
+    pub native_scripts_key_encoding: Option<cbor_event::Sz>,
+    pub plutus_v1_scripts_encoding: LenEncoding,
+    pub plutus_v1_scripts_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoProtocolParamUpdateEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub minfee_a_encoding: Option<cbor_event::Sz>,
+    pub minfee_a_key_encoding: Option<cbor_event::Sz>,
+    pub minfee_b_encoding: Option<cbor_event::Sz>,
+    pub minfee_b_key_encoding: Option<cbor_event::Sz>,
+    pub max_block_body_size_encoding: Option<cbor_event::Sz>,
+    pub max_block_body_size_key_encoding: Option<cbor_event::Sz>,
+    pub max_transaction_size_encoding: Option<cbor_event::Sz>,
+    pub max_transaction_size_key_encoding: Option<cbor_event::Sz>,
+    pub max_block_header_size_encoding: Option<cbor_event::Sz>,
+    pub max_block_header_size_key_encoding: Option<cbor_event::Sz>,
+    pub key_deposit_encoding: Option<cbor_event::Sz>,
+    pub key_deposit_key_encoding: Option<cbor_event::Sz>,
+    pub pool_deposit_encoding: Option<cbor_event::Sz>,
+    pub pool_deposit_key_encoding: Option<cbor_event::Sz>,
+    pub maximum_epoch_encoding: Option<cbor_event::Sz>,
+    pub maximum_epoch_key_encoding: Option<cbor_event::Sz>,
+    pub n_opt_encoding: Option<cbor_event::Sz>,
+    pub n_opt_key_encoding: Option<cbor_event::Sz>,
+    pub pool_pledge_influence_key_encoding: Option<cbor_event::Sz>,
+    pub expansion_rate_key_encoding: Option<cbor_event::Sz>,
+    pub treasury_growth_rate_key_encoding: Option<cbor_event::Sz>,
+    pub decentralization_constant_key_encoding: Option<cbor_event::Sz>,
+    pub extra_entropy_key_encoding: Option<cbor_event::Sz>,
+    pub protocol_version_key_encoding: Option<cbor_event::Sz>,
+    pub min_pool_cost_encoding: Option<cbor_event::Sz>,
+    pub min_pool_cost_key_encoding: Option<cbor_event::Sz>,
+    pub ada_per_utxo_byte_encoding: Option<cbor_event::Sz>,
+    pub ada_per_utxo_byte_key_encoding: Option<cbor_event::Sz>,
+    pub cost_models_for_script_languages_key_encoding: Option<cbor_event::Sz>,
+    pub execution_costs_key_encoding: Option<cbor_event::Sz>,
+    pub max_tx_ex_units_key_encoding: Option<cbor_event::Sz>,
+    pub max_block_ex_units_key_encoding: Option<cbor_event::Sz>,
+    pub max_encoding: Option<cbor_event::Sz>,
+    pub max_key_encoding: Option<cbor_event::Sz>,
+    pub collateral_percentage_encoding: Option<cbor_event::Sz>,
+    pub collateral_percentage_key_encoding: Option<cbor_event::Sz>,
+    pub max_collateral_inputs_encoding: Option<cbor_event::Sz>,
+    pub max_collateral_inputs_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoTransactionBodyEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub inputs_encoding: LenEncoding,
+    pub inputs_key_encoding: Option<cbor_event::Sz>,
+    pub outputs_encoding: LenEncoding,
+    pub outputs_key_encoding: Option<cbor_event::Sz>,
+    pub fee_encoding: Option<cbor_event::Sz>,
+    pub fee_key_encoding: Option<cbor_event::Sz>,
+    pub ttl_encoding: Option<cbor_event::Sz>,
+    pub ttl_key_encoding: Option<cbor_event::Sz>,
+    pub certs_encoding: LenEncoding,
+    pub certs_key_encoding: Option<cbor_event::Sz>,
+    pub withdrawals_encoding: LenEncoding,
+    pub withdrawals_value_encodings: BTreeMap<RewardAccount, Option<cbor_event::Sz>>,
+    pub withdrawals_key_encoding: Option<cbor_event::Sz>,
+    pub update_key_encoding: Option<cbor_event::Sz>,
+    pub auxiliary_data_hash_encoding: StringEncoding,
+    pub auxiliary_data_hash_key_encoding: Option<cbor_event::Sz>,
+    pub validity_interval_start_encoding: Option<cbor_event::Sz>,
+    pub validity_interval_start_key_encoding: Option<cbor_event::Sz>,
+    pub mint_encoding: LenEncoding,
+    pub mint_key_encodings: BTreeMap<PolicyId, StringEncoding>,
+    pub mint_value_encodings:
+        BTreeMap<PolicyId, (LenEncoding, BTreeMap<AssetName, Option<cbor_event::Sz>>)>,
+    pub mint_key_encoding: Option<cbor_event::Sz>,
+    pub script_data_hash_encoding: StringEncoding,
+    pub script_data_hash_key_encoding: Option<cbor_event::Sz>,
+    pub collateral_inputs_encoding: LenEncoding,
+    pub collateral_inputs_key_encoding: Option<cbor_event::Sz>,
+    pub required_signers_encoding: LenEncoding,
+    pub required_signers_elem_encodings: Vec<StringEncoding>,
+    pub required_signers_key_encoding: Option<cbor_event::Sz>,
+    pub network_id_encoding: Option<cbor_event::Sz>,
+    pub network_id_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoTransactionEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoTransactionWitnessSetEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub vkeywitnesses_encoding: LenEncoding,
+    pub vkeywitnesses_key_encoding: Option<cbor_event::Sz>,
+    pub native_scripts_encoding: LenEncoding,
+    pub native_scripts_key_encoding: Option<cbor_event::Sz>,
+    pub bootstrap_witnesses_encoding: LenEncoding,
+    pub bootstrap_witnesses_key_encoding: Option<cbor_event::Sz>,
+    pub plutus_v1_scripts_encoding: LenEncoding,
+    pub plutus_v1_scripts_key_encoding: Option<cbor_event::Sz>,
+    pub plutus_datums_encoding: LenEncoding,
+    pub plutus_datums_key_encoding: Option<cbor_event::Sz>,
+    pub redeemers_encoding: LenEncoding,
+    pub redeemers_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AlonzoUpdateEncoding {
+    pub len_encoding: LenEncoding,
+    pub proposed_protocol_parameter_updates_encoding: LenEncoding,
+    pub proposed_protocol_parameter_updates_key_encodings: BTreeMap<GenesisHash, StringEncoding>,
+    pub epoch_encoding: Option<cbor_event::Sz>,
+}

--- a/multi-era/rust/src/alonzo/mod.rs
+++ b/multi-era/rust/src/alonzo/mod.rs
@@ -1,0 +1,334 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+pub mod cbor_encodings;
+pub mod serialization;
+
+use cml_core::Int;
+
+use cml_chain::{ProtocolVersionStruct, TransactionIndex};
+use cml_chain::assets::{Coin, Mint};
+use cml_chain::auxdata::{Metadata, ShelleyAuxData, ShelleyMaAuxData};
+use cml_chain::certs::Certificate;
+use cml_chain::crypto::{
+    AuxiliaryDataHash, BootstrapWitness, GenesisHash, Nonce, ScriptDataHash, Vkeywitness,
+};
+use cml_chain::plutus::{ExUnitPrices, ExUnits, PlutusData, PlutusV1Script, Redeemer};
+use cml_chain::transaction::{
+    AlonzoTxOut, NativeScript, RequiredSigners, TransactionInput, ShelleyTxOut,
+};
+use cml_chain::{Epoch, NetworkId, Rational, UnitInterval, Withdrawals};
+use crate::shelley::ShelleyHeader;
+use cbor_encodings::{
+    AlonzoBlockEncoding, AlonzoCostmdlsEncoding, AlonzoOnlyAuxDataEncoding,
+    AlonzoProtocolParamUpdateEncoding, AlonzoTransactionBodyEncoding, AlonzoTransactionEncoding,
+    AlonzoTransactionWitnessSetEncoding, AlonzoUpdateEncoding,
+};
+use cml_core::ordered_hash_map::OrderedHashMap;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum AlonzoAuxiliaryData {
+    Shelley(ShelleyAuxData),
+    ShelleyMA(ShelleyMaAuxData),
+    Alonzo(AlonzoOnlyAuxData),
+}
+
+impl AlonzoAuxiliaryData {
+    pub fn new_shelley(shelley: ShelleyAuxData) -> Self {
+        Self::Shelley(shelley)
+    }
+
+    pub fn new_shelley_m_a(shelley_m_a: ShelleyMaAuxData) -> Self {
+        Self::ShelleyMA(shelley_m_a)
+    }
+
+    pub fn new_alonzo(alonzo: AlonzoOnlyAuxData) -> Self {
+        Self::Alonzo(alonzo)
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoBlock {
+    pub header: ShelleyHeader,
+    pub transaction_bodies: Vec<AlonzoTransactionBody>,
+    pub transaction_witness_sets: Vec<AlonzoTransactionWitnessSet>,
+    pub auxiliary_data_set: OrderedHashMap<TransactionIndex, AlonzoAuxiliaryData>,
+    pub invalid_transactions: Vec<TransactionIndex>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoBlockEncoding>,
+}
+
+impl AlonzoBlock {
+    pub fn new(
+        header: ShelleyHeader,
+        transaction_bodies: Vec<AlonzoTransactionBody>,
+        transaction_witness_sets: Vec<AlonzoTransactionWitnessSet>,
+        auxiliary_data_set: OrderedHashMap<TransactionIndex, AlonzoAuxiliaryData>,
+        invalid_transactions: Vec<TransactionIndex>,
+    ) -> Self {
+        Self {
+            header,
+            transaction_bodies,
+            transaction_witness_sets,
+            auxiliary_data_set,
+            invalid_transactions,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoCostmdls {
+    pub plutus_v1: Vec<Int>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoCostmdlsEncoding>,
+}
+
+impl AlonzoCostmdls {
+    pub fn new(plutus_v1: Vec<Int>) -> Self {
+        Self {
+            plutus_v1,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoOnlyAuxData {
+    pub metadata: Option<Metadata>,
+    pub native_scripts: Option<Vec<NativeScript>>,
+    pub plutus_v1_scripts: Option<Vec<PlutusV1Script>>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoOnlyAuxDataEncoding>,
+}
+
+impl AlonzoOnlyAuxData {
+    pub fn new() -> Self {
+        Self {
+            metadata: None,
+            native_scripts: None,
+            plutus_v1_scripts: None,
+            encodings: None,
+        }
+    }
+}
+
+impl Default for AlonzoOnlyAuxData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub type AlonzoProposedProtocolParameterUpdates =
+    OrderedHashMap<GenesisHash, AlonzoProtocolParamUpdate>;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoProtocolParamUpdate {
+    pub minfee_a: Option<u64>,
+    pub minfee_b: Option<u64>,
+    pub max_block_body_size: Option<u64>,
+    pub max_transaction_size: Option<u64>,
+    pub max_block_header_size: Option<u64>,
+    pub key_deposit: Option<Coin>,
+    pub pool_deposit: Option<Coin>,
+    pub maximum_epoch: Option<Epoch>,
+    pub n_opt: Option<u64>,
+    pub pool_pledge_influence: Option<Rational>,
+    pub expansion_rate: Option<UnitInterval>,
+    pub treasury_growth_rate: Option<UnitInterval>,
+    pub decentralization_constant: Option<UnitInterval>,
+    pub extra_entropy: Option<Nonce>,
+    pub protocol_version: Option<ProtocolVersionStruct>,
+    pub min_pool_cost: Option<Coin>,
+    pub ada_per_utxo_byte: Option<Coin>,
+    pub cost_models_for_script_languages: Option<AlonzoCostmdls>,
+    pub execution_costs: Option<ExUnitPrices>,
+    pub max_tx_ex_units: Option<ExUnits>,
+    pub max_block_ex_units: Option<ExUnits>,
+    pub max: Option<u64>,
+    pub collateral_percentage: Option<u64>,
+    pub max_collateral_inputs: Option<u64>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoProtocolParamUpdateEncoding>,
+}
+
+impl AlonzoProtocolParamUpdate {
+    pub fn new() -> Self {
+        Self {
+            minfee_a: None,
+            minfee_b: None,
+            max_block_body_size: None,
+            max_transaction_size: None,
+            max_block_header_size: None,
+            key_deposit: None,
+            pool_deposit: None,
+            maximum_epoch: None,
+            n_opt: None,
+            pool_pledge_influence: None,
+            expansion_rate: None,
+            treasury_growth_rate: None,
+            decentralization_constant: None,
+            extra_entropy: None,
+            protocol_version: None,
+            min_pool_cost: None,
+            ada_per_utxo_byte: None,
+            cost_models_for_script_languages: None,
+            execution_costs: None,
+            max_tx_ex_units: None,
+            max_block_ex_units: None,
+            max: None,
+            collateral_percentage: None,
+            max_collateral_inputs: None,
+            encodings: None,
+        }
+    }
+}
+
+impl Default for AlonzoProtocolParamUpdate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoTransaction {
+    pub body: AlonzoTransactionBody,
+    pub witness_set: AlonzoTransactionWitnessSet,
+    pub is_valid: bool,
+    pub auxiliary_data: Option<AlonzoAuxiliaryData>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoTransactionEncoding>,
+}
+
+impl AlonzoTransaction {
+    pub fn new(
+        body: AlonzoTransactionBody,
+        witness_set: AlonzoTransactionWitnessSet,
+        is_valid: bool,
+        auxiliary_data: Option<AlonzoAuxiliaryData>,
+    ) -> Self {
+        Self {
+            body,
+            witness_set,
+            is_valid,
+            auxiliary_data,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoTransactionBody {
+    pub inputs: Vec<TransactionInput>,
+    pub outputs: Vec<AlonzoTransactionOutput>,
+    pub fee: Coin,
+    pub ttl: Option<u64>,
+    pub certs: Option<Vec<Certificate>>,
+    pub withdrawals: Option<Withdrawals>,
+    pub update: Option<AlonzoUpdate>,
+    pub auxiliary_data_hash: Option<AuxiliaryDataHash>,
+    pub validity_interval_start: Option<u64>,
+    pub mint: Option<Mint>,
+    pub script_data_hash: Option<ScriptDataHash>,
+    pub collateral_inputs: Option<Vec<TransactionInput>>,
+    pub required_signers: Option<RequiredSigners>,
+    pub network_id: Option<NetworkId>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoTransactionBodyEncoding>,
+}
+
+impl AlonzoTransactionBody {
+    pub fn new(
+        inputs: Vec<TransactionInput>,
+        outputs: Vec<AlonzoTransactionOutput>,
+        fee: Coin,
+    ) -> Self {
+        Self {
+            inputs,
+            outputs,
+            fee,
+            ttl: None,
+            certs: None,
+            withdrawals: None,
+            update: None,
+            auxiliary_data_hash: None,
+            validity_interval_start: None,
+            mint: None,
+            script_data_hash: None,
+            collateral_inputs: None,
+            required_signers: None,
+            network_id: None,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum AlonzoTransactionOutput {
+    ShelleyTxOut(ShelleyTxOut),
+    AlonzoTxOut(AlonzoTxOut),
+}
+
+impl AlonzoTransactionOutput {
+    pub fn new_shelley_tx_out(shelley_tx_out: ShelleyTxOut) -> Self {
+        Self::ShelleyTxOut(shelley_tx_out)
+    }
+
+    pub fn new_alonzo_tx_out(alonzo_tx_out: AlonzoTxOut) -> Self {
+        Self::AlonzoTxOut(alonzo_tx_out)
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoTransactionWitnessSet {
+    pub vkeywitnesses: Option<Vec<Vkeywitness>>,
+    pub native_scripts: Option<Vec<NativeScript>>,
+    pub bootstrap_witnesses: Option<Vec<BootstrapWitness>>,
+    pub plutus_v1_scripts: Option<Vec<PlutusV1Script>>,
+    pub plutus_datums: Option<Vec<PlutusData>>,
+    pub redeemers: Option<Vec<Redeemer>>,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoTransactionWitnessSetEncoding>,
+}
+
+impl AlonzoTransactionWitnessSet {
+    pub fn new() -> Self {
+        Self {
+            vkeywitnesses: None,
+            native_scripts: None,
+            bootstrap_witnesses: None,
+            plutus_v1_scripts: None,
+            plutus_datums: None,
+            redeemers: None,
+            encodings: None,
+        }
+    }
+}
+
+impl Default for AlonzoTransactionWitnessSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct AlonzoUpdate {
+    pub proposed_protocol_parameter_updates: AlonzoProposedProtocolParameterUpdates,
+    pub epoch: Epoch,
+    #[serde(skip)]
+    pub encodings: Option<AlonzoUpdateEncoding>,
+}
+
+impl AlonzoUpdate {
+    pub fn new(
+        proposed_protocol_parameter_updates: AlonzoProposedProtocolParameterUpdates,
+        epoch: Epoch,
+    ) -> Self {
+        Self {
+            proposed_protocol_parameter_updates,
+            epoch,
+            encodings: None,
+        }
+    }
+}

--- a/multi-era/rust/src/alonzo/serialization.rs
+++ b/multi-era/rust/src/alonzo/serialization.rs
@@ -1,0 +1,3840 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use super::cbor_encodings::*;
+use super::*;
+use cbor_event;
+use cbor_event::de::Deserializer;
+use cbor_event::se::Serializer;
+use cml_chain::AssetName;
+use cml_chain::PolicyId;
+use cml_chain::address::RewardAccount;
+use cml_core::error::*;
+use cml_core::serialization::*;
+use cml_crypto::Ed25519KeyHash;
+use cml_crypto::RawBytesEncoding;
+use std::io::{BufRead, Seek, SeekFrom, Write};
+
+impl Serialize for AlonzoAuxiliaryData {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            AlonzoAuxiliaryData::Shelley(shelley) => shelley.serialize(serializer, force_canonical),
+            AlonzoAuxiliaryData::ShelleyMA(shelley_m_a) => {
+                shelley_m_a.serialize(serializer, force_canonical)
+            }
+            AlonzoAuxiliaryData::Alonzo(alonzo) => alonzo.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for AlonzoAuxiliaryData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            let deser_variant: Result<_, DeserializeError> = ShelleyAuxData::deserialize(raw);
+            match deser_variant {
+                Ok(shelley) => return Ok(Self::Shelley(shelley)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> = ShelleyMaAuxData::deserialize(raw);
+            match deser_variant {
+                Ok(shelley_m_a) => return Ok(Self::ShelleyMA(shelley_m_a)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> = AlonzoOnlyAuxData::deserialize(raw);
+            match deser_variant {
+                Ok(alonzo) => return Ok(Self::Alonzo(alonzo)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            Err(DeserializeError::new(
+                "AlonzoAuxiliaryData",
+                DeserializeFailure::NoVariantMatched,
+            ))
+        })()
+        .map_err(|e| e.annotate("AlonzoAuxiliaryData"))
+    }
+}
+
+impl Serialize for AlonzoBlock {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(5, force_canonical),
+        )?;
+        self.header.serialize(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_bodies_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_bodies.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_bodies.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_bodies_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_witness_sets_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_witness_sets.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_witness_sets.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_witness_sets_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.auxiliary_data_set_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.auxiliary_data_set.len() as u64, force_canonical),
+        )?;
+        let mut key_order = self
+            .auxiliary_data_set
+            .iter()
+            .map(|(k, v)| {
+                let mut buf = cbor_event::se::Serializer::new_vec();
+                let auxiliary_data_set_key_encoding = self
+                    .encodings
+                    .as_ref()
+                    .and_then(|encs| encs.auxiliary_data_set_key_encodings.get(k))
+                    .cloned()
+                    .unwrap_or_default();
+                buf.write_unsigned_integer_sz(
+                    *k as u64,
+                    fit_sz(*k as u64, auxiliary_data_set_key_encoding, force_canonical),
+                )?;
+                Ok((buf.finalize(), k, v))
+            })
+            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, _key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.auxiliary_data_set_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.invalid_transactions_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.invalid_transactions.len() as u64, force_canonical),
+        )?;
+        for (i, element) in self.invalid_transactions.iter().enumerate() {
+            let invalid_transactions_elem_encoding = self
+                .encodings
+                .as_ref()
+                .and_then(|encs| encs.invalid_transactions_elem_encodings.get(i))
+                .cloned()
+                .unwrap_or_default();
+            serializer.write_unsigned_integer_sz(
+                *element as u64,
+                fit_sz(
+                    *element as u64,
+                    invalid_transactions_elem_encoding,
+                    force_canonical,
+                ),
+            )?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.invalid_transactions_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoBlock {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(5)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let header = ShelleyHeader::deserialize(raw).map_err(|e: DeserializeError| e.annotate("header"))?;
+            let (transaction_bodies, transaction_bodies_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_bodies_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_bodies_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => (transaction_bodies_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    transaction_bodies_arr.push(AlonzoTransactionBody::deserialize(raw)?);
+                }
+                Ok((transaction_bodies_arr, transaction_bodies_encoding))
+            })().map_err(|e| e.annotate("transaction_bodies"))?;
+            let (transaction_witness_sets, transaction_witness_sets_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_witness_sets_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_witness_sets_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => (transaction_witness_sets_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    transaction_witness_sets_arr.push(AlonzoTransactionWitnessSet::deserialize(raw)?);
+                }
+                Ok((transaction_witness_sets_arr, transaction_witness_sets_encoding))
+            })().map_err(|e| e.annotate("transaction_witness_sets"))?;
+            let (auxiliary_data_set, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut auxiliary_data_set_table = OrderedHashMap::new();
+                let auxiliary_data_set_len = raw.map_sz()?;
+                let auxiliary_data_set_encoding = auxiliary_data_set_len.into();
+                let mut auxiliary_data_set_key_encodings = BTreeMap::new();
+                while match auxiliary_data_set_len { cbor_event::LenSz::Len(n, _) => (auxiliary_data_set_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let (auxiliary_data_set_key, auxiliary_data_set_key_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?;
+                    let auxiliary_data_set_value = AlonzoAuxiliaryData::deserialize(raw)?;
+                    if auxiliary_data_set_table.insert(auxiliary_data_set_key, auxiliary_data_set_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                    auxiliary_data_set_key_encodings.insert(auxiliary_data_set_key, auxiliary_data_set_key_encoding);
+                }
+                Ok((auxiliary_data_set_table, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings))
+            })().map_err(|e| e.annotate("auxiliary_data_set"))?;
+            let (invalid_transactions, invalid_transactions_encoding, invalid_transactions_elem_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut invalid_transactions_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let invalid_transactions_encoding = len.into();
+                let mut invalid_transactions_elem_encodings = Vec::new();
+                while match len { cbor_event::LenSz::Len(n, _) => (invalid_transactions_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let (invalid_transactions_elem, invalid_transactions_elem_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?;
+                    invalid_transactions_arr.push(invalid_transactions_elem);
+                    invalid_transactions_elem_encodings.push(invalid_transactions_elem_encoding);
+                }
+                Ok((invalid_transactions_arr, invalid_transactions_encoding, invalid_transactions_elem_encodings))
+            })().map_err(|e| e.annotate("invalid_transactions"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(AlonzoBlock {
+                header,
+                transaction_bodies,
+                transaction_witness_sets,
+                auxiliary_data_set,
+                invalid_transactions,
+                encodings: Some(AlonzoBlockEncoding {
+                    len_encoding,
+                    transaction_bodies_encoding,
+                    transaction_witness_sets_encoding,
+                    auxiliary_data_set_encoding,
+                    auxiliary_data_set_key_encodings,
+                    invalid_transactions_encoding,
+                    invalid_transactions_elem_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("AlonzoBlock"))
+    }
+}
+
+impl Serialize for AlonzoCostmdls {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(1, force_canonical),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| !force_canonical && encs.orig_deser_order.len() == 1)
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    serializer.write_unsigned_integer_sz(
+                        0u64,
+                        fit_sz(
+                            0u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.plutus_v1_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.plutus_v1_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.plutus_v1.len() as u64, force_canonical),
+                    )?;
+                    for element in self.plutus_v1.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.plutus_v1_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoCostmdls {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(1)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut plutus_v1_encoding = LenEncoding::default();
+            let mut plutus_v1_key_encoding = None;
+            let mut plutus_v1 = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if plutus_v1.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_plutus_v1, tmp_plutus_v1_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    let mut plutus_v1_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let plutus_v1_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (plutus_v1_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        plutus_v1_arr.push(Int::deserialize(raw)?);
+                                    }
+                                    Ok((plutus_v1_arr, plutus_v1_encoding))
+                                })()
+                                .map_err(|e| e.annotate("plutus_v1"))?;
+                            plutus_v1 = Some(tmp_plutus_v1);
+                            plutus_v1_encoding = tmp_plutus_v1_encoding;
+                            plutus_v1_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            let plutus_v1 = match plutus_v1 {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(0)).into()),
+            };
+            ();
+            Ok(Self {
+                plutus_v1,
+                encodings: Some(AlonzoCostmdlsEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    plutus_v1_key_encoding,
+                    plutus_v1_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("AlonzoCostmdls"))
+    }
+}
+
+impl Serialize for AlonzoOnlyAuxData {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_tag_sz(
+            259u64,
+            fit_sz(
+                259u64,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.tag_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    match &self.metadata {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.native_scripts {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.plutus_v1_scripts {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == match &self.metadata {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.native_scripts {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.plutus_v1_scripts {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    if let Some(field) = &self.metadata {
+                        serializer.write_unsigned_integer_sz(
+                            0u64,
+                            fit_sz(
+                                0u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.metadata_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                1 => {
+                    if let Some(field) = &self.native_scripts {
+                        serializer.write_unsigned_integer_sz(
+                            1u64,
+                            fit_sz(
+                                1u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.native_scripts_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.native_scripts_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.native_scripts_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                2 => {
+                    if let Some(field) = &self.plutus_v1_scripts {
+                        serializer.write_unsigned_integer_sz(
+                            2u64,
+                            fit_sz(
+                                2u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.plutus_v1_scripts_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.plutus_v1_scripts_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.plutus_v1_scripts_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoOnlyAuxData {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let (tag, tag_encoding) = raw.tag_sz()?;
+        if tag != 259 {
+            return Err(DeserializeError::new(
+                "AlonzoOnlyAuxData",
+                DeserializeFailure::TagMismatch {
+                    found: tag,
+                    expected: 259,
+                },
+            ));
+        }
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut metadata_key_encoding = None;
+            let mut metadata = None;
+            let mut native_scripts_encoding = LenEncoding::default();
+            let mut native_scripts_key_encoding = None;
+            let mut native_scripts = None;
+            let mut plutus_v1_scripts_encoding = LenEncoding::default();
+            let mut plutus_v1_scripts_key_encoding = None;
+            let mut plutus_v1_scripts = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if metadata.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let tmp_metadata = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Metadata::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("metadata"))?;
+                            metadata = Some(tmp_metadata);
+                            metadata_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (1, key_enc) => {
+                            if native_scripts.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_native_scripts, tmp_native_scripts_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut native_scripts_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let native_scripts_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (native_scripts_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        native_scripts_arr.push(NativeScript::deserialize(raw)?);
+                                    }
+                                    Ok((native_scripts_arr, native_scripts_encoding))
+                                })()
+                                .map_err(|e| e.annotate("native_scripts"))?;
+                            native_scripts = Some(tmp_native_scripts);
+                            native_scripts_encoding = tmp_native_scripts_encoding;
+                            native_scripts_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        }
+                        (2, key_enc) => {
+                            if plutus_v1_scripts.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_plutus_v1_scripts, tmp_plutus_v1_scripts_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut plutus_v1_scripts_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let plutus_v1_scripts_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (plutus_v1_scripts_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        plutus_v1_scripts_arr
+                                            .push(PlutusV1Script::deserialize(raw)?);
+                                    }
+                                    Ok((plutus_v1_scripts_arr, plutus_v1_scripts_encoding))
+                                })()
+                                .map_err(|e| e.annotate("plutus_v1_scripts"))?;
+                            plutus_v1_scripts = Some(tmp_plutus_v1_scripts);
+                            plutus_v1_scripts_encoding = tmp_plutus_v1_scripts_encoding;
+                            plutus_v1_scripts_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                metadata,
+                native_scripts,
+                plutus_v1_scripts,
+                encodings: Some(AlonzoOnlyAuxDataEncoding {
+                    tag_encoding: Some(tag_encoding),
+                    len_encoding,
+                    orig_deser_order,
+                    metadata_key_encoding,
+                    native_scripts_key_encoding,
+                    native_scripts_encoding,
+                    plutus_v1_scripts_key_encoding,
+                    plutus_v1_scripts_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("AlonzoOnlyAuxData"))
+    }
+}
+
+impl Serialize for AlonzoProtocolParamUpdate {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    match &self.minfee_a {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.minfee_b {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_block_body_size {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_transaction_size {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_block_header_size {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.key_deposit {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.pool_deposit {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.maximum_epoch {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.n_opt {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.pool_pledge_influence {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.expansion_rate {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.treasury_growth_rate {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.decentralization_constant {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.extra_entropy {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.protocol_version {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.min_pool_cost {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.ada_per_utxo_byte {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.cost_models_for_script_languages {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.execution_costs {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_tx_ex_units {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_block_ex_units {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.collateral_percentage {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_collateral_inputs {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == match &self.minfee_a {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.minfee_b {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_block_body_size {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_transaction_size {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_block_header_size {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.key_deposit {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.pool_deposit {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.maximum_epoch {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.n_opt {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.pool_pledge_influence {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.expansion_rate {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.treasury_growth_rate {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.decentralization_constant {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.extra_entropy {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.protocol_version {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.min_pool_cost {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.ada_per_utxo_byte {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.cost_models_for_script_languages {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.execution_costs {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_tx_ex_units {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_block_ex_units {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.collateral_percentage {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_collateral_inputs {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| {
+                vec![
+                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+                    22, 23,
+                ]
+            });
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    if let Some(field) = &self.minfee_a {
+                        serializer.write_unsigned_integer_sz(
+                            0u64,
+                            fit_sz(
+                                0u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_a_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_a_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                1 => {
+                    if let Some(field) = &self.minfee_b {
+                        serializer.write_unsigned_integer_sz(
+                            1u64,
+                            fit_sz(
+                                1u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_b_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_b_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                2 => {
+                    if let Some(field) = &self.max_block_body_size {
+                        serializer.write_unsigned_integer_sz(
+                            2u64,
+                            fit_sz(
+                                2u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_body_size_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_body_size_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                3 => {
+                    if let Some(field) = &self.max_transaction_size {
+                        serializer.write_unsigned_integer_sz(
+                            3u64,
+                            fit_sz(
+                                3u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_transaction_size_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_transaction_size_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                4 => {
+                    if let Some(field) = &self.max_block_header_size {
+                        serializer.write_unsigned_integer_sz(
+                            4u64,
+                            fit_sz(
+                                4u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_header_size_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_header_size_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                5 => {
+                    if let Some(field) = &self.key_deposit {
+                        serializer.write_unsigned_integer_sz(
+                            5u64,
+                            fit_sz(
+                                5u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.key_deposit_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.key_deposit_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                6 => {
+                    if let Some(field) = &self.pool_deposit {
+                        serializer.write_unsigned_integer_sz(
+                            6u64,
+                            fit_sz(
+                                6u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.pool_deposit_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.pool_deposit_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                7 => {
+                    if let Some(field) = &self.maximum_epoch {
+                        serializer.write_unsigned_integer_sz(
+                            7u64,
+                            fit_sz(
+                                7u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.maximum_epoch_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.maximum_epoch_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                8 => {
+                    if let Some(field) = &self.n_opt {
+                        serializer.write_unsigned_integer_sz(
+                            8u64,
+                            fit_sz(
+                                8u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.n_opt_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.n_opt_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                9 => {
+                    if let Some(field) = &self.pool_pledge_influence {
+                        serializer.write_unsigned_integer_sz(
+                            9u64,
+                            fit_sz(
+                                9u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.pool_pledge_influence_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                10 => {
+                    if let Some(field) = &self.expansion_rate {
+                        serializer.write_unsigned_integer_sz(
+                            10u64,
+                            fit_sz(
+                                10u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.expansion_rate_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                11 => {
+                    if let Some(field) = &self.treasury_growth_rate {
+                        serializer.write_unsigned_integer_sz(
+                            11u64,
+                            fit_sz(
+                                11u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.treasury_growth_rate_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                12 => {
+                    if let Some(field) = &self.decentralization_constant {
+                        serializer.write_unsigned_integer_sz(
+                            12u64,
+                            fit_sz(
+                                12u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.decentralization_constant_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                13 => {
+                    if let Some(field) = &self.extra_entropy {
+                        serializer.write_unsigned_integer_sz(
+                            13u64,
+                            fit_sz(
+                                13u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.extra_entropy_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                14 => {
+                    if let Some(field) = &self.protocol_version {
+                        serializer.write_unsigned_integer_sz(
+                            14u64,
+                            fit_sz(
+                                14u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.protocol_version_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                15 => {
+                    if let Some(field) = &self.min_pool_cost {
+                        serializer.write_unsigned_integer_sz(
+                            16u64,
+                            fit_sz(
+                                16u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.min_pool_cost_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.min_pool_cost_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                16 => {
+                    if let Some(field) = &self.ada_per_utxo_byte {
+                        serializer.write_unsigned_integer_sz(
+                            17u64,
+                            fit_sz(
+                                17u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ada_per_utxo_byte_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ada_per_utxo_byte_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                17 => {
+                    if let Some(field) = &self.cost_models_for_script_languages {
+                        serializer.write_unsigned_integer_sz(
+                            18u64,
+                            fit_sz(
+                                18u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.cost_models_for_script_languages_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                18 => {
+                    if let Some(field) = &self.execution_costs {
+                        serializer.write_unsigned_integer_sz(
+                            19u64,
+                            fit_sz(
+                                19u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.execution_costs_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                19 => {
+                    if let Some(field) = &self.max_tx_ex_units {
+                        serializer.write_unsigned_integer_sz(
+                            20u64,
+                            fit_sz(
+                                20u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_tx_ex_units_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                20 => {
+                    if let Some(field) = &self.max_block_ex_units {
+                        serializer.write_unsigned_integer_sz(
+                            21u64,
+                            fit_sz(
+                                21u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_ex_units_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                21 => {
+                    if let Some(field) = &self.max {
+                        serializer.write_unsigned_integer_sz(
+                            22u64,
+                            fit_sz(
+                                22u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                22 => {
+                    if let Some(field) = &self.collateral_percentage {
+                        serializer.write_unsigned_integer_sz(
+                            23u64,
+                            fit_sz(
+                                23u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.collateral_percentage_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.collateral_percentage_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                23 => {
+                    if let Some(field) = &self.max_collateral_inputs {
+                        serializer.write_unsigned_integer_sz(
+                            24u64,
+                            fit_sz(
+                                24u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_collateral_inputs_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_collateral_inputs_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoProtocolParamUpdate {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut minfee_a_encoding = None;
+            let mut minfee_a_key_encoding = None;
+            let mut minfee_a = None;
+            let mut minfee_b_encoding = None;
+            let mut minfee_b_key_encoding = None;
+            let mut minfee_b = None;
+            let mut max_block_body_size_encoding = None;
+            let mut max_block_body_size_key_encoding = None;
+            let mut max_block_body_size = None;
+            let mut max_transaction_size_encoding = None;
+            let mut max_transaction_size_key_encoding = None;
+            let mut max_transaction_size = None;
+            let mut max_block_header_size_encoding = None;
+            let mut max_block_header_size_key_encoding = None;
+            let mut max_block_header_size = None;
+            let mut key_deposit_encoding = None;
+            let mut key_deposit_key_encoding = None;
+            let mut key_deposit = None;
+            let mut pool_deposit_encoding = None;
+            let mut pool_deposit_key_encoding = None;
+            let mut pool_deposit = None;
+            let mut maximum_epoch_encoding = None;
+            let mut maximum_epoch_key_encoding = None;
+            let mut maximum_epoch = None;
+            let mut n_opt_encoding = None;
+            let mut n_opt_key_encoding = None;
+            let mut n_opt = None;
+            let mut pool_pledge_influence_key_encoding = None;
+            let mut pool_pledge_influence = None;
+            let mut expansion_rate_key_encoding = None;
+            let mut expansion_rate = None;
+            let mut treasury_growth_rate_key_encoding = None;
+            let mut treasury_growth_rate = None;
+            let mut decentralization_constant_key_encoding = None;
+            let mut decentralization_constant = None;
+            let mut extra_entropy_key_encoding = None;
+            let mut extra_entropy = None;
+            let mut protocol_version_key_encoding = None;
+            let mut protocol_version = None;
+            let mut min_pool_cost_encoding = None;
+            let mut min_pool_cost_key_encoding = None;
+            let mut min_pool_cost = None;
+            let mut ada_per_utxo_byte_encoding = None;
+            let mut ada_per_utxo_byte_key_encoding = None;
+            let mut ada_per_utxo_byte = None;
+            let mut cost_models_for_script_languages_key_encoding = None;
+            let mut cost_models_for_script_languages = None;
+            let mut execution_costs_key_encoding = None;
+            let mut execution_costs = None;
+            let mut max_tx_ex_units_key_encoding = None;
+            let mut max_tx_ex_units = None;
+            let mut max_block_ex_units_key_encoding = None;
+            let mut max_block_ex_units = None;
+            let mut max_encoding = None;
+            let mut max_key_encoding = None;
+            let mut max = None;
+            let mut collateral_percentage_encoding = None;
+            let mut collateral_percentage_key_encoding = None;
+            let mut collateral_percentage = None;
+            let mut max_collateral_inputs_encoding = None;
+            let mut max_collateral_inputs_key_encoding = None;
+            let mut max_collateral_inputs = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if minfee_a.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_minfee_a, tmp_minfee_a_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("minfee_a"))?;
+                            minfee_a = Some(tmp_minfee_a);
+                            minfee_a_encoding = tmp_minfee_a_encoding;
+                            minfee_a_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (1, key_enc) => {
+                            if minfee_b.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_minfee_b, tmp_minfee_b_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("minfee_b"))?;
+                            minfee_b = Some(tmp_minfee_b);
+                            minfee_b_encoding = tmp_minfee_b_encoding;
+                            minfee_b_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        }
+                        (2, key_enc) => {
+                            if max_block_body_size.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_max_block_body_size, tmp_max_block_body_size_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max_block_body_size"))?;
+                            max_block_body_size = Some(tmp_max_block_body_size);
+                            max_block_body_size_encoding = tmp_max_block_body_size_encoding;
+                            max_block_body_size_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        }
+                        (3, key_enc) => {
+                            if max_transaction_size.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_max_transaction_size, tmp_max_transaction_size_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max_transaction_size"))?;
+                            max_transaction_size = Some(tmp_max_transaction_size);
+                            max_transaction_size_encoding = tmp_max_transaction_size_encoding;
+                            max_transaction_size_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        }
+                        (4, key_enc) => {
+                            if max_block_header_size.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_max_block_header_size, tmp_max_block_header_size_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max_block_header_size"))?;
+                            max_block_header_size = Some(tmp_max_block_header_size);
+                            max_block_header_size_encoding = tmp_max_block_header_size_encoding;
+                            max_block_header_size_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        }
+                        (5, key_enc) => {
+                            if key_deposit.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_key_deposit, tmp_key_deposit_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("key_deposit"))?;
+                            key_deposit = Some(tmp_key_deposit);
+                            key_deposit_encoding = tmp_key_deposit_encoding;
+                            key_deposit_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        }
+                        (6, key_enc) => {
+                            if pool_deposit.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let (tmp_pool_deposit, tmp_pool_deposit_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("pool_deposit"))?;
+                            pool_deposit = Some(tmp_pool_deposit);
+                            pool_deposit_encoding = tmp_pool_deposit_encoding;
+                            pool_deposit_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        }
+                        (7, key_enc) => {
+                            if maximum_epoch.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let (tmp_maximum_epoch, tmp_maximum_epoch_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("maximum_epoch"))?;
+                            maximum_epoch = Some(tmp_maximum_epoch);
+                            maximum_epoch_encoding = tmp_maximum_epoch_encoding;
+                            maximum_epoch_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        }
+                        (8, key_enc) => {
+                            if n_opt.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(8)).into());
+                            }
+                            let (tmp_n_opt, tmp_n_opt_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("n_opt"))?;
+                            n_opt = Some(tmp_n_opt);
+                            n_opt_encoding = tmp_n_opt_encoding;
+                            n_opt_key_encoding = Some(key_enc);
+                            orig_deser_order.push(8);
+                        }
+                        (9, key_enc) => {
+                            if pool_pledge_influence.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(9)).into());
+                            }
+                            let tmp_pool_pledge_influence = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Rational::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("pool_pledge_influence"))?;
+                            pool_pledge_influence = Some(tmp_pool_pledge_influence);
+                            pool_pledge_influence_key_encoding = Some(key_enc);
+                            orig_deser_order.push(9);
+                        }
+                        (10, key_enc) => {
+                            if expansion_rate.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(10)).into());
+                            }
+                            let tmp_expansion_rate = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                UnitInterval::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("expansion_rate"))?;
+                            expansion_rate = Some(tmp_expansion_rate);
+                            expansion_rate_key_encoding = Some(key_enc);
+                            orig_deser_order.push(10);
+                        }
+                        (11, key_enc) => {
+                            if treasury_growth_rate.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(11)).into());
+                            }
+                            let tmp_treasury_growth_rate = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                UnitInterval::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("treasury_growth_rate"))?;
+                            treasury_growth_rate = Some(tmp_treasury_growth_rate);
+                            treasury_growth_rate_key_encoding = Some(key_enc);
+                            orig_deser_order.push(11);
+                        }
+                        (12, key_enc) => {
+                            if decentralization_constant.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(12)).into());
+                            }
+                            let tmp_decentralization_constant =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    UnitInterval::deserialize(raw)
+                                })()
+                                .map_err(|e| e.annotate("decentralization_constant"))?;
+                            decentralization_constant = Some(tmp_decentralization_constant);
+                            decentralization_constant_key_encoding = Some(key_enc);
+                            orig_deser_order.push(12);
+                        }
+                        (13, key_enc) => {
+                            if extra_entropy.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(13)).into());
+                            }
+                            let tmp_extra_entropy = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Nonce::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("extra_entropy"))?;
+                            extra_entropy = Some(tmp_extra_entropy);
+                            extra_entropy_key_encoding = Some(key_enc);
+                            orig_deser_order.push(13);
+                        }
+                        (14, key_enc) => {
+                            if protocol_version.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(14)).into());
+                            }
+                            let tmp_protocol_version = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ProtocolVersionStruct::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("protocol_version"))?;
+                            protocol_version = Some(tmp_protocol_version);
+                            protocol_version_key_encoding = Some(key_enc);
+                            orig_deser_order.push(14);
+                        }
+                        (16, key_enc) => {
+                            if min_pool_cost.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(16)).into());
+                            }
+                            let (tmp_min_pool_cost, tmp_min_pool_cost_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("min_pool_cost"))?;
+                            min_pool_cost = Some(tmp_min_pool_cost);
+                            min_pool_cost_encoding = tmp_min_pool_cost_encoding;
+                            min_pool_cost_key_encoding = Some(key_enc);
+                            orig_deser_order.push(15);
+                        }
+                        (17, key_enc) => {
+                            if ada_per_utxo_byte.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(17)).into());
+                            }
+                            let (tmp_ada_per_utxo_byte, tmp_ada_per_utxo_byte_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("ada_per_utxo_byte"))?;
+                            ada_per_utxo_byte = Some(tmp_ada_per_utxo_byte);
+                            ada_per_utxo_byte_encoding = tmp_ada_per_utxo_byte_encoding;
+                            ada_per_utxo_byte_key_encoding = Some(key_enc);
+                            orig_deser_order.push(16);
+                        }
+                        (18, key_enc) => {
+                            if cost_models_for_script_languages.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(18)).into());
+                            }
+                            let tmp_cost_models_for_script_languages =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    AlonzoCostmdls::deserialize(raw)
+                                })()
+                                .map_err(|e| e.annotate("cost_models_for_script_languages"))?;
+                            cost_models_for_script_languages =
+                                Some(tmp_cost_models_for_script_languages);
+                            cost_models_for_script_languages_key_encoding = Some(key_enc);
+                            orig_deser_order.push(17);
+                        }
+                        (19, key_enc) => {
+                            if execution_costs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(19)).into());
+                            }
+                            let tmp_execution_costs = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ExUnitPrices::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("execution_costs"))?;
+                            execution_costs = Some(tmp_execution_costs);
+                            execution_costs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(18);
+                        }
+                        (20, key_enc) => {
+                            if max_tx_ex_units.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(20)).into());
+                            }
+                            let tmp_max_tx_ex_units = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ExUnits::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("max_tx_ex_units"))?;
+                            max_tx_ex_units = Some(tmp_max_tx_ex_units);
+                            max_tx_ex_units_key_encoding = Some(key_enc);
+                            orig_deser_order.push(19);
+                        }
+                        (21, key_enc) => {
+                            if max_block_ex_units.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(21)).into());
+                            }
+                            let tmp_max_block_ex_units = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ExUnits::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("max_block_ex_units"))?;
+                            max_block_ex_units = Some(tmp_max_block_ex_units);
+                            max_block_ex_units_key_encoding = Some(key_enc);
+                            orig_deser_order.push(20);
+                        }
+                        (22, key_enc) => {
+                            if max.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(22)).into());
+                            }
+                            let (tmp_max, tmp_max_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max"))?;
+                            max = Some(tmp_max);
+                            max_encoding = tmp_max_encoding;
+                            max_key_encoding = Some(key_enc);
+                            orig_deser_order.push(21);
+                        }
+                        (23, key_enc) => {
+                            if collateral_percentage.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(23)).into());
+                            }
+                            let (tmp_collateral_percentage, tmp_collateral_percentage_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("collateral_percentage"))?;
+                            collateral_percentage = Some(tmp_collateral_percentage);
+                            collateral_percentage_encoding = tmp_collateral_percentage_encoding;
+                            collateral_percentage_key_encoding = Some(key_enc);
+                            orig_deser_order.push(22);
+                        }
+                        (24, key_enc) => {
+                            if max_collateral_inputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(24)).into());
+                            }
+                            let (tmp_max_collateral_inputs, tmp_max_collateral_inputs_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max_collateral_inputs"))?;
+                            max_collateral_inputs = Some(tmp_max_collateral_inputs);
+                            max_collateral_inputs_encoding = tmp_max_collateral_inputs_encoding;
+                            max_collateral_inputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(23);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                minfee_a,
+                minfee_b,
+                max_block_body_size,
+                max_transaction_size,
+                max_block_header_size,
+                key_deposit,
+                pool_deposit,
+                maximum_epoch,
+                n_opt,
+                pool_pledge_influence,
+                expansion_rate,
+                treasury_growth_rate,
+                decentralization_constant,
+                extra_entropy,
+                protocol_version,
+                min_pool_cost,
+                ada_per_utxo_byte,
+                cost_models_for_script_languages,
+                execution_costs,
+                max_tx_ex_units,
+                max_block_ex_units,
+                max,
+                collateral_percentage,
+                max_collateral_inputs,
+                encodings: Some(AlonzoProtocolParamUpdateEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    minfee_a_key_encoding,
+                    minfee_a_encoding,
+                    minfee_b_key_encoding,
+                    minfee_b_encoding,
+                    max_block_body_size_key_encoding,
+                    max_block_body_size_encoding,
+                    max_transaction_size_key_encoding,
+                    max_transaction_size_encoding,
+                    max_block_header_size_key_encoding,
+                    max_block_header_size_encoding,
+                    key_deposit_key_encoding,
+                    key_deposit_encoding,
+                    pool_deposit_key_encoding,
+                    pool_deposit_encoding,
+                    maximum_epoch_key_encoding,
+                    maximum_epoch_encoding,
+                    n_opt_key_encoding,
+                    n_opt_encoding,
+                    pool_pledge_influence_key_encoding,
+                    expansion_rate_key_encoding,
+                    treasury_growth_rate_key_encoding,
+                    decentralization_constant_key_encoding,
+                    extra_entropy_key_encoding,
+                    protocol_version_key_encoding,
+                    min_pool_cost_key_encoding,
+                    min_pool_cost_encoding,
+                    ada_per_utxo_byte_key_encoding,
+                    ada_per_utxo_byte_encoding,
+                    cost_models_for_script_languages_key_encoding,
+                    execution_costs_key_encoding,
+                    max_tx_ex_units_key_encoding,
+                    max_block_ex_units_key_encoding,
+                    max_key_encoding,
+                    max_encoding,
+                    collateral_percentage_key_encoding,
+                    collateral_percentage_encoding,
+                    max_collateral_inputs_key_encoding,
+                    max_collateral_inputs_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("AlonzoProtocolParamUpdate"))
+    }
+}
+
+impl Serialize for AlonzoTransaction {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(4, force_canonical),
+        )?;
+        self.body.serialize(serializer, force_canonical)?;
+        self.witness_set.serialize(serializer, force_canonical)?;
+        serializer.write_special(cbor_event::Special::Bool(self.is_valid))?;
+        match &self.auxiliary_data {
+            Some(x) => x.serialize(serializer, force_canonical),
+            None => serializer.write_special(cbor_event::Special::Null),
+        }?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoTransaction {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(4)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let body = AlonzoTransactionBody::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("body"))?;
+            let witness_set = AlonzoTransactionWitnessSet::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("witness_set"))?;
+            let is_valid = raw
+                .bool()
+                .map_err(Into::into)
+                .map_err(|e: DeserializeError| e.annotate("is_valid"))?;
+            let auxiliary_data = (|| -> Result<_, DeserializeError> {
+                Ok(match raw.cbor_type()? != cbor_event::Type::Special {
+                    true => Some(AlonzoAuxiliaryData::deserialize(raw)?),
+                    false => {
+                        if raw.special()? != cbor_event::Special::Null {
+                            return Err(DeserializeFailure::ExpectedNull.into());
+                        }
+                        None
+                    }
+                })
+            })()
+            .map_err(|e| e.annotate("auxiliary_data"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(AlonzoTransaction {
+                body,
+                witness_set,
+                is_valid,
+                auxiliary_data,
+                encodings: Some(AlonzoTransactionEncoding { len_encoding }),
+            })
+        })()
+        .map_err(|e| e.annotate("AlonzoTransaction"))
+    }
+}
+
+impl Serialize for AlonzoTransactionBody {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    3 + match &self.ttl {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.certs {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.withdrawals {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.update {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.auxiliary_data_hash {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.validity_interval_start {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.mint {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.script_data_hash {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.collateral_inputs {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.required_signers {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.network_id {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == 3 + match &self.ttl {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.certs {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.withdrawals {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.update {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.auxiliary_data_hash {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.validity_interval_start {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.mint {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.script_data_hash {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.collateral_inputs {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.required_signers {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.network_id {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    serializer.write_unsigned_integer_sz(
+                        0u64,
+                        fit_sz(
+                            0u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.inputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.inputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.inputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.inputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.inputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                1 => {
+                    serializer.write_unsigned_integer_sz(
+                        1u64,
+                        fit_sz(
+                            1u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.outputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.outputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.outputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.outputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.outputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                2 => {
+                    serializer.write_unsigned_integer_sz(
+                        2u64,
+                        fit_sz(
+                            2u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_unsigned_integer_sz(
+                        self.fee,
+                        fit_sz(
+                            self.fee,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                }
+                3 => {
+                    if let Some(field) = &self.ttl {
+                        serializer.write_unsigned_integer_sz(
+                            3u64,
+                            fit_sz(
+                                3u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ttl_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ttl_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                4 => {
+                    if let Some(field) = &self.certs {
+                        serializer.write_unsigned_integer_sz(
+                            4u64,
+                            fit_sz(
+                                4u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.certs_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.certs_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.certs_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                5 => {
+                    if let Some(field) = &self.withdrawals {
+                        serializer.write_unsigned_integer_sz(
+                            5u64,
+                            fit_sz(
+                                5u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.withdrawals_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_map_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.withdrawals_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        let mut key_order = field
+                            .iter()
+                            .map(|(k, v)| {
+                                let mut buf = cbor_event::se::Serializer::new_vec();
+                                k.serialize(&mut buf, force_canonical)?;
+                                Ok((buf.finalize(), k, v))
+                            })
+                            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                        if force_canonical {
+                            key_order.sort_by(
+                                |(lhs_bytes, _, _), (rhs_bytes, _, _)| match lhs_bytes
+                                    .len()
+                                    .cmp(&rhs_bytes.len())
+                                {
+                                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                    diff_ord => diff_ord,
+                                },
+                            );
+                        }
+                        for (key_bytes, key, value) in key_order {
+                            serializer.write_raw_bytes(&key_bytes)?;
+                            let withdrawals_value_encoding = self
+                                .encodings
+                                .as_ref()
+                                .and_then(|encs| encs.withdrawals_value_encodings.get(key))
+                                .cloned()
+                                .unwrap_or_default();
+                            serializer.write_unsigned_integer_sz(
+                                *value,
+                                fit_sz(*value, withdrawals_value_encoding, force_canonical),
+                            )?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.withdrawals_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                6 => {
+                    if let Some(field) = &self.update {
+                        serializer.write_unsigned_integer_sz(
+                            6u64,
+                            fit_sz(
+                                6u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.update_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                7 => {
+                    if let Some(field) = &self.auxiliary_data_hash {
+                        serializer.write_unsigned_integer_sz(
+                            7u64,
+                            fit_sz(
+                                7u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.auxiliary_data_hash_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_bytes_sz(
+                            &field.to_raw_bytes(),
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.auxiliary_data_hash_encoding.clone())
+                                .unwrap_or_default()
+                                .to_str_len_sz(field.to_raw_bytes().len() as u64, force_canonical),
+                        )?;
+                    }
+                }
+                8 => {
+                    if let Some(field) = &self.validity_interval_start {
+                        serializer.write_unsigned_integer_sz(
+                            8u64,
+                            fit_sz(
+                                8u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.validity_interval_start_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.validity_interval_start_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                9 => {
+                    if let Some(field) = &self.mint {
+                        serializer.write_unsigned_integer_sz(
+                            9u64,
+                            fit_sz(
+                                9u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.mint_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_map_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.mint_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        let mut key_order = field
+                            .iter()
+                            .map(|(k, v)| {
+                                let mut buf = cbor_event::se::Serializer::new_vec();
+                                let mint_key_encoding = self
+                                    .encodings
+                                    .as_ref()
+                                    .and_then(|encs| encs.mint_key_encodings.get(k))
+                                    .cloned()
+                                    .unwrap_or_default();
+                                buf.write_bytes_sz(
+                                    &k.to_raw_bytes(),
+                                    mint_key_encoding.to_str_len_sz(
+                                        k.to_raw_bytes().len() as u64,
+                                        force_canonical,
+                                    ),
+                                )?;
+                                Ok((buf.finalize(), k, v))
+                            })
+                            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                        if force_canonical {
+                            key_order.sort_by(
+                                |(lhs_bytes, _, _), (rhs_bytes, _, _)| match lhs_bytes
+                                    .len()
+                                    .cmp(&rhs_bytes.len())
+                                {
+                                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                    diff_ord => diff_ord,
+                                },
+                            );
+                        }
+                        for (key_bytes, key, value) in key_order {
+                            serializer.write_raw_bytes(&key_bytes)?;
+                            let (mint_value_encoding, mint_value_value_encodings) = self
+                                .encodings
+                                .as_ref()
+                                .and_then(|encs| encs.mint_value_encodings.get(key))
+                                .cloned()
+                                .unwrap_or_else(|| (LenEncoding::default(), BTreeMap::new()));
+                            serializer.write_map_sz(
+                                mint_value_encoding.to_len_sz(value.len() as u64, force_canonical),
+                            )?;
+                            let mut key_order = value
+                                .iter()
+                                .map(|(k, v)| {
+                                    let mut buf = cbor_event::se::Serializer::new_vec();
+                                    k.serialize(&mut buf, force_canonical)?;
+                                    Ok((buf.finalize(), k, v))
+                                })
+                                .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                            if force_canonical {
+                                key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                                    match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                                        std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                        diff_ord => diff_ord,
+                                    }
+                                });
+                            }
+                            for (key_bytes, key, value) in key_order {
+                                serializer.write_raw_bytes(&key_bytes)?;
+                                let mint_value_value_encoding = mint_value_value_encodings
+                                    .get(key)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                if *value >= 0 {
+                                    serializer.write_unsigned_integer_sz(
+                                        *value as u64,
+                                        fit_sz(
+                                            *value as u64,
+                                            mint_value_value_encoding,
+                                            force_canonical,
+                                        ),
+                                    )?;
+                                } else {
+                                    serializer.write_negative_integer_sz(
+                                        *value as i128,
+                                        fit_sz(
+                                            (*value + 1).abs() as u64,
+                                            mint_value_value_encoding,
+                                            force_canonical,
+                                        ),
+                                    )?;
+                                }
+                            }
+                            mint_value_encoding.end(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.mint_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                10 => {
+                    if let Some(field) = &self.script_data_hash {
+                        serializer.write_unsigned_integer_sz(
+                            11u64,
+                            fit_sz(
+                                11u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.script_data_hash_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_bytes_sz(
+                            &field.to_raw_bytes(),
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.script_data_hash_encoding.clone())
+                                .unwrap_or_default()
+                                .to_str_len_sz(field.to_raw_bytes().len() as u64, force_canonical),
+                        )?;
+                    }
+                }
+                11 => {
+                    if let Some(field) = &self.collateral_inputs {
+                        serializer.write_unsigned_integer_sz(
+                            13u64,
+                            fit_sz(
+                                13u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.collateral_inputs_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.collateral_inputs_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.collateral_inputs_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                12 => {
+                    if let Some(field) = &self.required_signers {
+                        serializer.write_unsigned_integer_sz(
+                            14u64,
+                            fit_sz(
+                                14u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.required_signers_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.required_signers_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for (i, element) in field.iter().enumerate() {
+                            let required_signers_elem_encoding = self
+                                .encodings
+                                .as_ref()
+                                .and_then(|encs| encs.required_signers_elem_encodings.get(i))
+                                .cloned()
+                                .unwrap_or_default();
+                            serializer.write_bytes_sz(
+                                &element.to_raw_bytes(),
+                                required_signers_elem_encoding.to_str_len_sz(
+                                    element.to_raw_bytes().len() as u64,
+                                    force_canonical,
+                                ),
+                            )?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.required_signers_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                13 => {
+                    if let Some(field) = &self.network_id {
+                        serializer.write_unsigned_integer_sz(
+                            15u64,
+                            fit_sz(
+                                15u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.network_id_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field as u64,
+                            fit_sz(
+                                *field as u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.network_id_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoTransactionBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut inputs_encoding = LenEncoding::default();
+            let mut inputs_key_encoding = None;
+            let mut inputs = None;
+            let mut outputs_encoding = LenEncoding::default();
+            let mut outputs_key_encoding = None;
+            let mut outputs = None;
+            let mut fee_encoding = None;
+            let mut fee_key_encoding = None;
+            let mut fee = None;
+            let mut ttl_encoding = None;
+            let mut ttl_key_encoding = None;
+            let mut ttl = None;
+            let mut certs_encoding = LenEncoding::default();
+            let mut certs_key_encoding = None;
+            let mut certs = None;
+            let mut withdrawals_encoding = LenEncoding::default();
+            let mut withdrawals_value_encodings = BTreeMap::new();
+            let mut withdrawals_key_encoding = None;
+            let mut withdrawals = None;
+            let mut update_key_encoding = None;
+            let mut update = None;
+            let mut auxiliary_data_hash_encoding = StringEncoding::default();
+            let mut auxiliary_data_hash_key_encoding = None;
+            let mut auxiliary_data_hash = None;
+            let mut validity_interval_start_encoding = None;
+            let mut validity_interval_start_key_encoding = None;
+            let mut validity_interval_start = None;
+            let mut mint_encoding = LenEncoding::default();
+            let mut mint_key_encodings = BTreeMap::new();
+            let mut mint_value_encodings = BTreeMap::new();
+            let mut mint_key_encoding = None;
+            let mut mint = None;
+            let mut script_data_hash_encoding = StringEncoding::default();
+            let mut script_data_hash_key_encoding = None;
+            let mut script_data_hash = None;
+            let mut collateral_inputs_encoding = LenEncoding::default();
+            let mut collateral_inputs_key_encoding = None;
+            let mut collateral_inputs = None;
+            let mut required_signers_encoding = LenEncoding::default();
+            let mut required_signers_elem_encodings = Vec::new();
+            let mut required_signers_key_encoding = None;
+            let mut required_signers = None;
+            let mut network_id_encoding = None;
+            let mut network_id_key_encoding = None;
+            let mut network_id = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if inputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_inputs, tmp_inputs_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut inputs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let inputs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (inputs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    inputs_arr.push(TransactionInput::deserialize(raw)?);
+                                }
+                                Ok((inputs_arr, inputs_encoding))
+                            })().map_err(|e| e.annotate("inputs"))?;
+                            inputs = Some(tmp_inputs);
+                            inputs_encoding = tmp_inputs_encoding;
+                            inputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if outputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_outputs, tmp_outputs_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut outputs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let outputs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (outputs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    outputs_arr.push(AlonzoTransactionOutput::deserialize(raw)?);
+                                }
+                                Ok((outputs_arr, outputs_encoding))
+                            })().map_err(|e| e.annotate("outputs"))?;
+                            outputs = Some(tmp_outputs);
+                            outputs_encoding = tmp_outputs_encoding;
+                            outputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if fee.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into).map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            fee = Some(tmp_fee);
+                            fee_encoding = tmp_fee_encoding;
+                            fee_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if ttl.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_ttl, tmp_ttl_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                            })().map_err(|e| e.annotate("ttl"))?;
+                            ttl = Some(tmp_ttl);
+                            ttl_encoding = tmp_ttl_encoding;
+                            ttl_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (4, key_enc) =>  {
+                            if certs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_certs, tmp_certs_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut certs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let certs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (certs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    certs_arr.push(Certificate::deserialize(raw)?);
+                                }
+                                Ok((certs_arr, certs_encoding))
+                            })().map_err(|e| e.annotate("certs"))?;
+                            certs = Some(tmp_certs);
+                            certs_encoding = tmp_certs_encoding;
+                            certs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        },
+                        (5, key_enc) =>  {
+                            if withdrawals.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_withdrawals, tmp_withdrawals_encoding, tmp_withdrawals_value_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut withdrawals_table = OrderedHashMap::new();
+                                let withdrawals_len = raw.map_sz()?;
+                                let withdrawals_encoding = withdrawals_len.into();
+                                let mut withdrawals_value_encodings = BTreeMap::new();
+                                while match withdrawals_len { cbor_event::LenSz::Len(n, _) => (withdrawals_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    let withdrawals_key = RewardAccount::deserialize(raw)?;
+                                    let (withdrawals_value, withdrawals_value_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                                    if withdrawals_table.insert(withdrawals_key.clone(), withdrawals_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    withdrawals_value_encodings.insert(withdrawals_key, withdrawals_value_encoding);
+                                }
+                                Ok((withdrawals_table, withdrawals_encoding, withdrawals_value_encodings))
+                            })().map_err(|e| e.annotate("withdrawals"))?;
+                            withdrawals = Some(tmp_withdrawals);
+                            withdrawals_encoding = tmp_withdrawals_encoding;
+                            withdrawals_value_encodings = tmp_withdrawals_value_encodings;
+                            withdrawals_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        },
+                        (6, key_enc) =>  {
+                            if update.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let tmp_update = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                AlonzoUpdate::deserialize(raw)
+                            })().map_err(|e| e.annotate("update"))?;
+                            update = Some(tmp_update);
+                            update_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        },
+                        (7, key_enc) =>  {
+                            if auxiliary_data_hash.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let (tmp_auxiliary_data_hash, tmp_auxiliary_data_hash_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.bytes_sz().map_err(Into::<DeserializeError>::into).and_then(|(bytes, enc)| AuxiliaryDataHash::from_raw_bytes(&bytes).map(|bytes| (bytes, StringEncoding::from(enc))).map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into()))
+                            })().map_err(|e| e.annotate("auxiliary_data_hash"))?;
+                            auxiliary_data_hash = Some(tmp_auxiliary_data_hash);
+                            auxiliary_data_hash_encoding = tmp_auxiliary_data_hash_encoding;
+                            auxiliary_data_hash_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        },
+                        (8, key_enc) =>  {
+                            if validity_interval_start.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(8)).into());
+                            }
+                            let (tmp_validity_interval_start, tmp_validity_interval_start_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                            })().map_err(|e| e.annotate("validity_interval_start"))?;
+                            validity_interval_start = Some(tmp_validity_interval_start);
+                            validity_interval_start_encoding = tmp_validity_interval_start_encoding;
+                            validity_interval_start_key_encoding = Some(key_enc);
+                            orig_deser_order.push(8);
+                        },
+                        (9, key_enc) =>  {
+                            if mint.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(9)).into());
+                            }
+                            let (tmp_mint, tmp_mint_encoding, tmp_mint_key_encodings, tmp_mint_value_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut mint_table = OrderedHashMap::new();
+                                let mint_len = raw.map_sz()?;
+                                let mint_encoding = mint_len.into();
+                                let mut mint_key_encodings = BTreeMap::new();
+                                let mut mint_value_encodings = BTreeMap::new();
+                                while match mint_len { cbor_event::LenSz::Len(n, _) => (mint_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    let (mint_key, mint_key_encoding) = raw.bytes_sz().map_err(Into::<DeserializeError>::into).and_then(|(bytes, enc)| PolicyId::from_raw_bytes(&bytes).map(|bytes| (bytes, StringEncoding::from(enc))).map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into()))?;
+                                    let mut mint_value_table = OrderedHashMap::new();
+                                    let mint_value_len = raw.map_sz()?;
+                                    let mint_value_encoding = mint_value_len.into();
+                                    let mut mint_value_value_encodings = BTreeMap::new();
+                                    while match mint_value_len { cbor_event::LenSz::Len(n, _) => (mint_value_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        let mint_value_key = AssetName::deserialize(raw)?;
+                                        let (mint_value_value, mint_value_value_encoding) = match raw.cbor_type()? {
+                                            cbor_event::Type::UnsignedInteger => {
+                                                let (x, enc) = raw.unsigned_integer_sz()?;
+                                                (x as i64, Some(enc))
+                                            },
+                                            _ => {
+                                                let (x, enc) = raw.negative_integer_sz()?;
+                                                (x as i64, Some(enc))
+                                            },
+                                        };
+                                        if mint_value_table.insert(mint_value_key.clone(), mint_value_value).is_some() {
+                                            return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                        }
+                                        mint_value_value_encodings.insert(mint_value_key, mint_value_value_encoding);
+                                    }
+                                    let (mint_value, mint_value_encoding, mint_value_value_encodings) = (mint_value_table, mint_value_encoding, mint_value_value_encodings);
+                                    if mint_table.insert(mint_key.clone(), mint_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    mint_key_encodings.insert(mint_key.clone(), mint_key_encoding);
+                                    mint_value_encodings.insert(mint_key.clone(), (mint_value_encoding, mint_value_value_encodings));
+                                }
+                                Ok((mint_table, mint_encoding, mint_key_encodings, mint_value_encodings))
+                            })().map_err(|e| e.annotate("mint"))?;
+                            mint = Some(tmp_mint);
+                            mint_encoding = tmp_mint_encoding;
+                            mint_key_encodings = tmp_mint_key_encodings;
+                            mint_value_encodings = tmp_mint_value_encodings;
+                            mint_key_encoding = Some(key_enc);
+                            orig_deser_order.push(9);
+                        },
+                        (11, key_enc) =>  {
+                            if script_data_hash.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(11)).into());
+                            }
+                            let (tmp_script_data_hash, tmp_script_data_hash_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.bytes_sz().map_err(Into::<DeserializeError>::into).and_then(|(bytes, enc)| ScriptDataHash::from_raw_bytes(&bytes).map(|bytes| (bytes, StringEncoding::from(enc))).map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into()))
+                            })().map_err(|e| e.annotate("script_data_hash"))?;
+                            script_data_hash = Some(tmp_script_data_hash);
+                            script_data_hash_encoding = tmp_script_data_hash_encoding;
+                            script_data_hash_key_encoding = Some(key_enc);
+                            orig_deser_order.push(10);
+                        },
+                        (13, key_enc) =>  {
+                            if collateral_inputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(13)).into());
+                            }
+                            let (tmp_collateral_inputs, tmp_collateral_inputs_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut collateral_inputs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let collateral_inputs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (collateral_inputs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    collateral_inputs_arr.push(TransactionInput::deserialize(raw)?);
+                                }
+                                Ok((collateral_inputs_arr, collateral_inputs_encoding))
+                            })().map_err(|e| e.annotate("collateral_inputs"))?;
+                            collateral_inputs = Some(tmp_collateral_inputs);
+                            collateral_inputs_encoding = tmp_collateral_inputs_encoding;
+                            collateral_inputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(11);
+                        },
+                        (14, key_enc) =>  {
+                            if required_signers.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(14)).into());
+                            }
+                            let (tmp_required_signers, tmp_required_signers_encoding, tmp_required_signers_elem_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut required_signers_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let required_signers_encoding = len.into();
+                                let mut required_signers_elem_encodings = Vec::new();
+                                while match len { cbor_event::LenSz::Len(n, _) => (required_signers_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    let (required_signers_elem, required_signers_elem_encoding) = raw.bytes_sz().map_err(Into::<DeserializeError>::into).and_then(|(bytes, enc)| Ed25519KeyHash::from_raw_bytes(&bytes).map(|bytes| (bytes, StringEncoding::from(enc))).map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into()))?;
+                                    required_signers_arr.push(required_signers_elem);
+                                    required_signers_elem_encodings.push(required_signers_elem_encoding);
+                                }
+                                Ok((required_signers_arr, required_signers_encoding, required_signers_elem_encodings))
+                            })().map_err(|e| e.annotate("required_signers"))?;
+                            required_signers = Some(tmp_required_signers);
+                            required_signers_encoding = tmp_required_signers_encoding;
+                            required_signers_elem_encodings = tmp_required_signers_elem_encodings;
+                            required_signers_key_encoding = Some(key_enc);
+                            orig_deser_order.push(12);
+                        },
+                        (15, key_enc) =>  {
+                            if network_id.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(15)).into());
+                            }
+                            let (tmp_network_id, tmp_network_id_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.unsigned_integer_sz().map(|(x, enc)| (x as u32, Some(enc))).map_err(Into::<DeserializeError>::into)
+                            })().map_err(|e| e.annotate("network_id"))?;
+                            network_id = Some(tmp_network_id);
+                            network_id_encoding = tmp_network_id_encoding;
+                            network_id_key_encoding = Some(key_enc);
+                            orig_deser_order.push(13);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    cbor_event::Type::Text => return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into()),
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            let inputs = match inputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(0)).into()),
+            };
+            let outputs = match outputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(1)).into()),
+            };
+            let fee = match fee {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(2)).into()),
+            };
+            read_len.finish()?;
+            Ok(Self {
+                inputs,
+                outputs,
+                fee,
+                ttl,
+                certs,
+                withdrawals,
+                update,
+                auxiliary_data_hash,
+                validity_interval_start,
+                mint: mint.map(Into::into),
+                script_data_hash,
+                collateral_inputs,
+                required_signers,
+                network_id,
+                encodings: Some(AlonzoTransactionBodyEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    inputs_key_encoding,
+                    inputs_encoding,
+                    outputs_key_encoding,
+                    outputs_encoding,
+                    fee_key_encoding,
+                    fee_encoding,
+                    ttl_key_encoding,
+                    ttl_encoding,
+                    certs_key_encoding,
+                    certs_encoding,
+                    withdrawals_key_encoding,
+                    withdrawals_encoding,
+                    withdrawals_value_encodings,
+                    update_key_encoding,
+                    auxiliary_data_hash_key_encoding,
+                    auxiliary_data_hash_encoding,
+                    validity_interval_start_key_encoding,
+                    validity_interval_start_encoding,
+                    mint_key_encoding,
+                    mint_encoding,
+                    mint_key_encodings,
+                    mint_value_encodings,
+                    script_data_hash_key_encoding,
+                    script_data_hash_encoding,
+                    collateral_inputs_key_encoding,
+                    collateral_inputs_encoding,
+                    required_signers_key_encoding,
+                    required_signers_encoding,
+                    required_signers_elem_encodings,
+                    network_id_key_encoding,
+                    network_id_encoding,
+                }),
+            })
+        })().map_err(|e| e.annotate("AlonzoTransactionBody"))
+    }
+}
+
+impl Serialize for AlonzoTransactionOutput {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            AlonzoTransactionOutput::ShelleyTxOut(shelley_tx_out) => {
+                shelley_tx_out.serialize(serializer, force_canonical)
+            }
+            AlonzoTransactionOutput::AlonzoTxOut(alonzo_tx_out) => {
+                alonzo_tx_out.serialize(serializer, force_canonical)
+            }
+        }
+    }
+}
+
+impl Deserialize for AlonzoTransactionOutput {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            let deser_variant: Result<_, DeserializeError> = ShelleyTxOut::deserialize(raw);
+            match deser_variant {
+                Ok(shelley_tx_out) => return Ok(Self::ShelleyTxOut(shelley_tx_out)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> = AlonzoTxOut::deserialize(raw);
+            match deser_variant {
+                Ok(alonzo_tx_out) => return Ok(Self::AlonzoTxOut(alonzo_tx_out)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            Err(DeserializeError::new(
+                "AlonzoTransactionOutput",
+                DeserializeFailure::NoVariantMatched,
+            ))
+        })()
+        .map_err(|e| e.annotate("AlonzoTransactionOutput"))
+    }
+}
+
+impl Serialize for AlonzoTransactionWitnessSet {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    match &self.vkeywitnesses {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.native_scripts {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.bootstrap_witnesses {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.plutus_v1_scripts {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.plutus_datums {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.redeemers {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == match &self.vkeywitnesses {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.native_scripts {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.bootstrap_witnesses {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.plutus_v1_scripts {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.plutus_datums {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.redeemers {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2, 3, 4, 5]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    if let Some(field) = &self.vkeywitnesses {
+                        serializer.write_unsigned_integer_sz(
+                            0u64,
+                            fit_sz(
+                                0u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.vkeywitnesses_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.vkeywitnesses_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.vkeywitnesses_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                1 => {
+                    if let Some(field) = &self.native_scripts {
+                        serializer.write_unsigned_integer_sz(
+                            1u64,
+                            fit_sz(
+                                1u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.native_scripts_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.native_scripts_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.native_scripts_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                2 => {
+                    if let Some(field) = &self.bootstrap_witnesses {
+                        serializer.write_unsigned_integer_sz(
+                            2u64,
+                            fit_sz(
+                                2u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.bootstrap_witnesses_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.bootstrap_witnesses_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.bootstrap_witnesses_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                3 => {
+                    if let Some(field) = &self.plutus_v1_scripts {
+                        serializer.write_unsigned_integer_sz(
+                            3u64,
+                            fit_sz(
+                                3u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.plutus_v1_scripts_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.plutus_v1_scripts_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.plutus_v1_scripts_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                4 => {
+                    if let Some(field) = &self.plutus_datums {
+                        serializer.write_unsigned_integer_sz(
+                            4u64,
+                            fit_sz(
+                                4u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.plutus_datums_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.plutus_datums_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.plutus_datums_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                5 => {
+                    if let Some(field) = &self.redeemers {
+                        serializer.write_unsigned_integer_sz(
+                            5u64,
+                            fit_sz(
+                                5u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.redeemers_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.redeemers_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.redeemers_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoTransactionWitnessSet {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut vkeywitnesses_encoding = LenEncoding::default();
+            let mut vkeywitnesses_key_encoding = None;
+            let mut vkeywitnesses = None;
+            let mut native_scripts_encoding = LenEncoding::default();
+            let mut native_scripts_key_encoding = None;
+            let mut native_scripts = None;
+            let mut bootstrap_witnesses_encoding = LenEncoding::default();
+            let mut bootstrap_witnesses_key_encoding = None;
+            let mut bootstrap_witnesses = None;
+            let mut plutus_v1_scripts_encoding = LenEncoding::default();
+            let mut plutus_v1_scripts_key_encoding = None;
+            let mut plutus_v1_scripts = None;
+            let mut plutus_datums_encoding = LenEncoding::default();
+            let mut plutus_datums_key_encoding = None;
+            let mut plutus_datums = None;
+            let mut redeemers_encoding = LenEncoding::default();
+            let mut redeemers_key_encoding = None;
+            let mut redeemers = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if vkeywitnesses.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_vkeywitnesses, tmp_vkeywitnesses_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut vkeywitnesses_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let vkeywitnesses_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (vkeywitnesses_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        vkeywitnesses_arr.push(Vkeywitness::deserialize(raw)?);
+                                    }
+                                    Ok((vkeywitnesses_arr, vkeywitnesses_encoding))
+                                })()
+                                .map_err(|e| e.annotate("vkeywitnesses"))?;
+                            vkeywitnesses = Some(tmp_vkeywitnesses);
+                            vkeywitnesses_encoding = tmp_vkeywitnesses_encoding;
+                            vkeywitnesses_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (1, key_enc) => {
+                            if native_scripts.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_native_scripts, tmp_native_scripts_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut native_scripts_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let native_scripts_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (native_scripts_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        native_scripts_arr.push(NativeScript::deserialize(raw)?);
+                                    }
+                                    Ok((native_scripts_arr, native_scripts_encoding))
+                                })()
+                                .map_err(|e| e.annotate("native_scripts"))?;
+                            native_scripts = Some(tmp_native_scripts);
+                            native_scripts_encoding = tmp_native_scripts_encoding;
+                            native_scripts_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        }
+                        (2, key_enc) => {
+                            if bootstrap_witnesses.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_bootstrap_witnesses, tmp_bootstrap_witnesses_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut bootstrap_witnesses_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let bootstrap_witnesses_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (bootstrap_witnesses_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        bootstrap_witnesses_arr
+                                            .push(BootstrapWitness::deserialize(raw)?);
+                                    }
+                                    Ok((bootstrap_witnesses_arr, bootstrap_witnesses_encoding))
+                                })()
+                                .map_err(|e| e.annotate("bootstrap_witnesses"))?;
+                            bootstrap_witnesses = Some(tmp_bootstrap_witnesses);
+                            bootstrap_witnesses_encoding = tmp_bootstrap_witnesses_encoding;
+                            bootstrap_witnesses_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        }
+                        (3, key_enc) => {
+                            if plutus_v1_scripts.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_plutus_v1_scripts, tmp_plutus_v1_scripts_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut plutus_v1_scripts_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let plutus_v1_scripts_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (plutus_v1_scripts_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        plutus_v1_scripts_arr
+                                            .push(PlutusV1Script::deserialize(raw)?);
+                                    }
+                                    Ok((plutus_v1_scripts_arr, plutus_v1_scripts_encoding))
+                                })()
+                                .map_err(|e| e.annotate("plutus_v1_scripts"))?;
+                            plutus_v1_scripts = Some(tmp_plutus_v1_scripts);
+                            plutus_v1_scripts_encoding = tmp_plutus_v1_scripts_encoding;
+                            plutus_v1_scripts_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        }
+                        (4, key_enc) => {
+                            if plutus_datums.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_plutus_datums, tmp_plutus_datums_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut plutus_datums_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let plutus_datums_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (plutus_datums_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        plutus_datums_arr.push(PlutusData::deserialize(raw)?);
+                                    }
+                                    Ok((plutus_datums_arr, plutus_datums_encoding))
+                                })()
+                                .map_err(|e| e.annotate("plutus_datums"))?;
+                            plutus_datums = Some(tmp_plutus_datums);
+                            plutus_datums_encoding = tmp_plutus_datums_encoding;
+                            plutus_datums_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        }
+                        (5, key_enc) => {
+                            if redeemers.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_redeemers, tmp_redeemers_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut redeemers_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let redeemers_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (redeemers_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        redeemers_arr.push(Redeemer::deserialize(raw)?);
+                                    }
+                                    Ok((redeemers_arr, redeemers_encoding))
+                                })()
+                                .map_err(|e| e.annotate("redeemers"))?;
+                            redeemers = Some(tmp_redeemers);
+                            redeemers_encoding = tmp_redeemers_encoding;
+                            redeemers_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                vkeywitnesses,
+                native_scripts,
+                bootstrap_witnesses,
+                plutus_v1_scripts,
+                plutus_datums,
+                redeemers,
+                encodings: Some(AlonzoTransactionWitnessSetEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    vkeywitnesses_key_encoding,
+                    vkeywitnesses_encoding,
+                    native_scripts_key_encoding,
+                    native_scripts_encoding,
+                    bootstrap_witnesses_key_encoding,
+                    bootstrap_witnesses_encoding,
+                    plutus_v1_scripts_key_encoding,
+                    plutus_v1_scripts_encoding,
+                    plutus_datums_key_encoding,
+                    plutus_datums_encoding,
+                    redeemers_key_encoding,
+                    redeemers_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("AlonzoTransactionWitnessSet"))
+    }
+}
+
+impl Serialize for AlonzoUpdate {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.proposed_protocol_parameter_updates_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    self.proposed_protocol_parameter_updates.len() as u64,
+                    force_canonical,
+                ),
+        )?;
+        let mut key_order = self
+            .proposed_protocol_parameter_updates
+            .iter()
+            .map(|(k, v)| {
+                let mut buf = cbor_event::se::Serializer::new_vec();
+                let proposed_protocol_parameter_updates_key_encoding = self
+                    .encodings
+                    .as_ref()
+                    .and_then(|encs| {
+                        encs.proposed_protocol_parameter_updates_key_encodings
+                            .get(k)
+                    })
+                    .cloned()
+                    .unwrap_or_default();
+                buf.write_bytes_sz(
+                    &k.to_raw_bytes(),
+                    proposed_protocol_parameter_updates_key_encoding
+                        .to_str_len_sz(k.to_raw_bytes().len() as u64, force_canonical),
+                )?;
+                Ok((buf.finalize(), k, v))
+            })
+            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, _key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.proposed_protocol_parameter_updates_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(
+            self.epoch,
+            fit_sz(
+                self.epoch,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.epoch_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for AlonzoUpdate {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let (
+                proposed_protocol_parameter_updates,
+                proposed_protocol_parameter_updates_encoding,
+                proposed_protocol_parameter_updates_key_encodings,
+            ) = (|| -> Result<_, DeserializeError> {
+                let mut proposed_protocol_parameter_updates_table = OrderedHashMap::new();
+                let proposed_protocol_parameter_updates_len = raw.map_sz()?;
+                let proposed_protocol_parameter_updates_encoding =
+                    proposed_protocol_parameter_updates_len.into();
+                let mut proposed_protocol_parameter_updates_key_encodings = BTreeMap::new();
+                while match proposed_protocol_parameter_updates_len {
+                    cbor_event::LenSz::Len(n, _) => {
+                        (proposed_protocol_parameter_updates_table.len() as u64) < n
+                    }
+                    cbor_event::LenSz::Indefinite => true,
+                } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let (
+                        proposed_protocol_parameter_updates_key,
+                        proposed_protocol_parameter_updates_key_encoding,
+                    ) = raw
+                        .bytes_sz()
+                        .map_err(Into::<DeserializeError>::into)
+                        .and_then(|(bytes, enc)| {
+                            GenesisHash::from_raw_bytes(&bytes)
+                                .map(|bytes| (bytes, StringEncoding::from(enc)))
+                                .map_err(|e| {
+                                    DeserializeFailure::InvalidStructure(Box::new(e)).into()
+                                })
+                        })?;
+                    let proposed_protocol_parameter_updates_value =
+                        AlonzoProtocolParamUpdate::deserialize(raw)?;
+                    if proposed_protocol_parameter_updates_table
+                        .insert(
+                            proposed_protocol_parameter_updates_key.clone(),
+                            proposed_protocol_parameter_updates_value,
+                        )
+                        .is_some()
+                    {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from(
+                            "some complicated/unsupported type",
+                        )))
+                        .into());
+                    }
+                    proposed_protocol_parameter_updates_key_encodings.insert(
+                        proposed_protocol_parameter_updates_key.clone(),
+                        proposed_protocol_parameter_updates_key_encoding,
+                    );
+                }
+                Ok((
+                    proposed_protocol_parameter_updates_table,
+                    proposed_protocol_parameter_updates_encoding,
+                    proposed_protocol_parameter_updates_key_encodings,
+                ))
+            })()
+            .map_err(|e| e.annotate("proposed_protocol_parameter_updates"))?;
+            let (epoch, epoch_encoding) = raw
+                .unsigned_integer_sz()
+                .map(|(x, enc)| (x, Some(enc)))
+                .map_err(Into::<DeserializeError>::into)
+                .map_err(|e: DeserializeError| e.annotate("epoch"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(AlonzoUpdate {
+                proposed_protocol_parameter_updates,
+                epoch,
+                encodings: Some(AlonzoUpdateEncoding {
+                    len_encoding,
+                    proposed_protocol_parameter_updates_encoding,
+                    proposed_protocol_parameter_updates_key_encodings,
+                    epoch_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("AlonzoUpdate"))
+    }
+}

--- a/multi-era/rust/src/lib.rs
+++ b/multi-era/rust/src/lib.rs
@@ -1,0 +1,55 @@
+#![allow(clippy::too_many_arguments)]
+
+extern crate derivative;
+pub mod allegra;
+pub mod alonzo;
+pub mod mary;
+pub mod shelley;
+pub mod serialization;
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_chain::address::RewardAccount;
+use cml_chain::crypto::GenesisHash;
+use crate::{
+    shelley::ShelleyBlock,
+    allegra::AllegraBlock,
+    mary::MaryBlock,
+    alonzo::AlonzoBlock,
+};
+use cml_chain::block::Block;
+
+pub type GenesisHashList = Vec<GenesisHash>;
+
+pub type RewardAccountList = Vec<RewardAccount>;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum MultiEraBlock {
+    Shelley(ShelleyBlock),
+    Allegra(AllegraBlock),
+    Mary(MaryBlock),
+    Alonzo(AlonzoBlock),
+    Babbage(Block),
+}
+
+impl MultiEraBlock {
+    pub fn new_shelley(shelley: ShelleyBlock) -> Self {
+        Self::Shelley(shelley)
+    }
+
+    pub fn new_allegra(allegra: AllegraBlock) -> Self {
+        Self::Allegra(allegra)
+    }
+
+    pub fn new_mary(mary: MaryBlock) -> Self {
+        Self::Mary(mary)
+    }
+
+    pub fn new_alonzo(alonzo: AlonzoBlock) -> Self {
+        Self::Alonzo(alonzo)
+    }
+
+    pub fn new_babbage(babbage: Block) -> Self {
+        Self::Babbage(babbage)
+    }
+}

--- a/multi-era/rust/src/mary/cbor_encodings.rs
+++ b/multi-era/rust/src/mary/cbor_encodings.rs
@@ -1,0 +1,53 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_core::serialization::{LenEncoding, StringEncoding};
+use std::collections::BTreeMap;
+use cml_chain::{
+    AssetName,
+    PolicyId,
+    address::RewardAccount,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct MaryBlockEncoding {
+    pub len_encoding: LenEncoding,
+    pub transaction_bodies_encoding: LenEncoding,
+    pub transaction_witness_sets_encoding: LenEncoding,
+    pub auxiliary_data_set_encoding: LenEncoding,
+    pub auxiliary_data_set_key_encodings: BTreeMap<u16, Option<cbor_event::Sz>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MaryTransactionBodyEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub inputs_encoding: LenEncoding,
+    pub inputs_key_encoding: Option<cbor_event::Sz>,
+    pub outputs_encoding: LenEncoding,
+    pub outputs_key_encoding: Option<cbor_event::Sz>,
+    pub fee_encoding: Option<cbor_event::Sz>,
+    pub fee_key_encoding: Option<cbor_event::Sz>,
+    pub ttl_encoding: Option<cbor_event::Sz>,
+    pub ttl_key_encoding: Option<cbor_event::Sz>,
+    pub certs_encoding: LenEncoding,
+    pub certs_key_encoding: Option<cbor_event::Sz>,
+    pub withdrawals_encoding: LenEncoding,
+    pub withdrawals_value_encodings: BTreeMap<RewardAccount, Option<cbor_event::Sz>>,
+    pub withdrawals_key_encoding: Option<cbor_event::Sz>,
+    pub update_key_encoding: Option<cbor_event::Sz>,
+    pub auxiliary_data_hash_encoding: StringEncoding,
+    pub auxiliary_data_hash_key_encoding: Option<cbor_event::Sz>,
+    pub validity_interval_start_encoding: Option<cbor_event::Sz>,
+    pub validity_interval_start_key_encoding: Option<cbor_event::Sz>,
+    pub mint_encoding: LenEncoding,
+    pub mint_key_encodings: BTreeMap<PolicyId, StringEncoding>,
+    pub mint_value_encodings:
+        BTreeMap<PolicyId, (LenEncoding, BTreeMap<AssetName, Option<cbor_event::Sz>>)>,
+    pub mint_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MaryTransactionEncoding {
+    pub len_encoding: LenEncoding,
+}

--- a/multi-era/rust/src/mary/mod.rs
+++ b/multi-era/rust/src/mary/mod.rs
@@ -1,0 +1,102 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+pub mod cbor_encodings;
+pub mod serialization;
+
+use crate::allegra::{AllegraAuxiliaryData, AllegraTransactionWitnessSet};
+use cml_chain::TransactionIndex;
+use cml_chain::assets::{Coin, Mint};
+use cml_chain::certs::Certificate;
+use cml_chain::crypto::AuxiliaryDataHash;
+use cml_chain::transaction::{ShelleyTxOut, TransactionInput};
+use cml_chain::Withdrawals;
+use crate::shelley::{ShelleyHeader, ShelleyUpdate};
+use cbor_encodings::{MaryBlockEncoding, MaryTransactionBodyEncoding, MaryTransactionEncoding};
+use cml_core::ordered_hash_map::OrderedHashMap;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MaryBlock {
+    pub header: ShelleyHeader,
+    pub transaction_bodies: Vec<MaryTransactionBody>,
+    pub transaction_witness_sets: Vec<AllegraTransactionWitnessSet>,
+    pub auxiliary_data_set: OrderedHashMap<TransactionIndex, AllegraAuxiliaryData>,
+    #[serde(skip)]
+    pub encodings: Option<MaryBlockEncoding>,
+}
+
+impl MaryBlock {
+    pub fn new(
+        header: ShelleyHeader,
+        transaction_bodies: Vec<MaryTransactionBody>,
+        transaction_witness_sets: Vec<AllegraTransactionWitnessSet>,
+        auxiliary_data_set: OrderedHashMap<TransactionIndex, AllegraAuxiliaryData>,
+    ) -> Self {
+        Self {
+            header,
+            transaction_bodies,
+            transaction_witness_sets,
+            auxiliary_data_set,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MaryTransaction {
+    pub body: MaryTransactionBody,
+    pub witness_set: AllegraTransactionWitnessSet,
+    pub auxiliary_data: Option<AllegraAuxiliaryData>,
+    #[serde(skip)]
+    pub encodings: Option<MaryTransactionEncoding>,
+}
+
+impl MaryTransaction {
+    pub fn new(
+        body: MaryTransactionBody,
+        witness_set: AllegraTransactionWitnessSet,
+        auxiliary_data: Option<AllegraAuxiliaryData>,
+    ) -> Self {
+        Self {
+            body,
+            witness_set,
+            auxiliary_data,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MaryTransactionBody {
+    pub inputs: Vec<TransactionInput>,
+    pub outputs: Vec<ShelleyTxOut>,
+    pub fee: Coin,
+    pub ttl: Option<u64>,
+    pub certs: Option<Vec<Certificate>>,
+    pub withdrawals: Option<Withdrawals>,
+    pub update: Option<ShelleyUpdate>,
+    pub auxiliary_data_hash: Option<AuxiliaryDataHash>,
+    pub validity_interval_start: Option<u64>,
+    pub mint: Option<Mint>,
+    #[serde(skip)]
+    pub encodings: Option<MaryTransactionBodyEncoding>,
+}
+
+impl MaryTransactionBody {
+    pub fn new(inputs: Vec<TransactionInput>, outputs: Vec<ShelleyTxOut>, fee: Coin) -> Self {
+        Self {
+            inputs,
+            outputs,
+            fee,
+            ttl: None,
+            certs: None,
+            withdrawals: None,
+            update: None,
+            auxiliary_data_hash: None,
+            validity_interval_start: None,
+            mint: None,
+            encodings: None,
+        }
+    }
+}

--- a/multi-era/rust/src/mary/serialization.rs
+++ b/multi-era/rust/src/mary/serialization.rs
@@ -1,0 +1,1039 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use super::cbor_encodings::*;
+use super::*;
+use cbor_event;
+use cbor_event::de::Deserializer;
+use cbor_event::se::Serializer;
+use cml_chain::AssetName;
+use cml_chain::PolicyId;
+use cml_chain::address::RewardAccount;
+use cml_core::error::*;
+use cml_core::serialization::*;
+use cml_crypto::RawBytesEncoding;
+use std::io::{BufRead, Seek, Write};
+
+impl Serialize for MaryBlock {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(4, force_canonical),
+        )?;
+        self.header.serialize(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_bodies_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_bodies.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_bodies.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_bodies_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_witness_sets_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_witness_sets.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_witness_sets.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_witness_sets_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.auxiliary_data_set_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.auxiliary_data_set.len() as u64, force_canonical),
+        )?;
+        let mut key_order = self
+            .auxiliary_data_set
+            .iter()
+            .map(|(k, v)| {
+                let mut buf = cbor_event::se::Serializer::new_vec();
+                let auxiliary_data_set_key_encoding = self
+                    .encodings
+                    .as_ref()
+                    .and_then(|encs| encs.auxiliary_data_set_key_encodings.get(k))
+                    .cloned()
+                    .unwrap_or_default();
+                buf.write_unsigned_integer_sz(
+                    *k as u64,
+                    fit_sz(*k as u64, auxiliary_data_set_key_encoding, force_canonical),
+                )?;
+                Ok((buf.finalize(), k, v))
+            })
+            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, _key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.auxiliary_data_set_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MaryBlock {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(4)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let header = ShelleyHeader::deserialize(raw).map_err(|e: DeserializeError| e.annotate("header"))?;
+            let (transaction_bodies, transaction_bodies_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_bodies_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_bodies_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => (transaction_bodies_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    transaction_bodies_arr.push(MaryTransactionBody::deserialize(raw)?);
+                }
+                Ok((transaction_bodies_arr, transaction_bodies_encoding))
+            })().map_err(|e| e.annotate("transaction_bodies"))?;
+            let (transaction_witness_sets, transaction_witness_sets_encoding) = (|| -> Result<_, DeserializeError> {
+                let mut transaction_witness_sets_arr = Vec::new();
+                let len = raw.array_sz()?;
+                let transaction_witness_sets_encoding = len.into();
+                while match len { cbor_event::LenSz::Len(n, _) => (transaction_witness_sets_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    transaction_witness_sets_arr.push(AllegraTransactionWitnessSet::deserialize(raw)?);
+                }
+                Ok((transaction_witness_sets_arr, transaction_witness_sets_encoding))
+            })().map_err(|e| e.annotate("transaction_witness_sets"))?;
+            let (auxiliary_data_set, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings) = (|| -> Result<_, DeserializeError> {
+                let mut auxiliary_data_set_table = OrderedHashMap::new();
+                let auxiliary_data_set_len = raw.map_sz()?;
+                let auxiliary_data_set_encoding = auxiliary_data_set_len.into();
+                let mut auxiliary_data_set_key_encodings = BTreeMap::new();
+                while match auxiliary_data_set_len { cbor_event::LenSz::Len(n, _) => (auxiliary_data_set_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let (auxiliary_data_set_key, auxiliary_data_set_key_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x as u16, Some(enc)))?;
+                    let auxiliary_data_set_value = AllegraAuxiliaryData::deserialize(raw)?;
+                    if auxiliary_data_set_table.insert(auxiliary_data_set_key, auxiliary_data_set_value).is_some() {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                    }
+                    auxiliary_data_set_key_encodings.insert(auxiliary_data_set_key, auxiliary_data_set_key_encoding);
+                }
+                Ok((auxiliary_data_set_table, auxiliary_data_set_encoding, auxiliary_data_set_key_encodings))
+            })().map_err(|e| e.annotate("auxiliary_data_set"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(MaryBlock {
+                header,
+                transaction_bodies,
+                transaction_witness_sets,
+                auxiliary_data_set,
+                encodings: Some(MaryBlockEncoding {
+                    len_encoding,
+                    transaction_bodies_encoding,
+                    transaction_witness_sets_encoding,
+                    auxiliary_data_set_encoding,
+                    auxiliary_data_set_key_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("MaryBlock"))
+    }
+}
+
+impl Serialize for MaryTransaction {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(3, force_canonical),
+        )?;
+        self.body.serialize(serializer, force_canonical)?;
+        self.witness_set.serialize(serializer, force_canonical)?;
+        match &self.auxiliary_data {
+            Some(x) => x.serialize(serializer, force_canonical),
+            None => serializer.write_special(cbor_event::Special::Null),
+        }?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MaryTransaction {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let body = MaryTransactionBody::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("body"))?;
+            let witness_set = AllegraTransactionWitnessSet::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("witness_set"))?;
+            let auxiliary_data = (|| -> Result<_, DeserializeError> {
+                Ok(match raw.cbor_type()? != cbor_event::Type::Special {
+                    true => Some(AllegraAuxiliaryData::deserialize(raw)?),
+                    false => {
+                        if raw.special()? != cbor_event::Special::Null {
+                            return Err(DeserializeFailure::ExpectedNull.into());
+                        }
+                        None
+                    }
+                })
+            })()
+            .map_err(|e| e.annotate("auxiliary_data"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(MaryTransaction {
+                body,
+                witness_set,
+                auxiliary_data,
+                encodings: Some(MaryTransactionEncoding { len_encoding }),
+            })
+        })()
+        .map_err(|e| e.annotate("MaryTransaction"))
+    }
+}
+
+impl Serialize for MaryTransactionBody {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    3 + match &self.ttl {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.certs {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.withdrawals {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.update {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.auxiliary_data_hash {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.validity_interval_start {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.mint {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == 3 + match &self.ttl {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.certs {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.withdrawals {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.update {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.auxiliary_data_hash {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.validity_interval_start {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.mint {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    serializer.write_unsigned_integer_sz(
+                        0u64,
+                        fit_sz(
+                            0u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.inputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.inputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.inputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.inputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.inputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                1 => {
+                    serializer.write_unsigned_integer_sz(
+                        1u64,
+                        fit_sz(
+                            1u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.outputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.outputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.outputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.outputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.outputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                2 => {
+                    serializer.write_unsigned_integer_sz(
+                        2u64,
+                        fit_sz(
+                            2u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_unsigned_integer_sz(
+                        self.fee,
+                        fit_sz(
+                            self.fee,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                }
+                3 => {
+                    if let Some(field) = &self.ttl {
+                        serializer.write_unsigned_integer_sz(
+                            3u64,
+                            fit_sz(
+                                3u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ttl_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.ttl_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                4 => {
+                    if let Some(field) = &self.certs {
+                        serializer.write_unsigned_integer_sz(
+                            4u64,
+                            fit_sz(
+                                4u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.certs_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.certs_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.certs_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                5 => {
+                    if let Some(field) = &self.withdrawals {
+                        serializer.write_unsigned_integer_sz(
+                            5u64,
+                            fit_sz(
+                                5u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.withdrawals_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_map_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.withdrawals_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        let mut key_order = field
+                            .iter()
+                            .map(|(k, v)| {
+                                let mut buf = cbor_event::se::Serializer::new_vec();
+                                k.serialize(&mut buf, force_canonical)?;
+                                Ok((buf.finalize(), k, v))
+                            })
+                            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                        if force_canonical {
+                            key_order.sort_by(
+                                |(lhs_bytes, _, _), (rhs_bytes, _, _)| match lhs_bytes
+                                    .len()
+                                    .cmp(&rhs_bytes.len())
+                                {
+                                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                    diff_ord => diff_ord,
+                                },
+                            );
+                        }
+                        for (key_bytes, key, value) in key_order {
+                            serializer.write_raw_bytes(&key_bytes)?;
+                            let withdrawals_value_encoding = self
+                                .encodings
+                                .as_ref()
+                                .and_then(|encs| encs.withdrawals_value_encodings.get(key))
+                                .cloned()
+                                .unwrap_or_default();
+                            serializer.write_unsigned_integer_sz(
+                                *value,
+                                fit_sz(*value, withdrawals_value_encoding, force_canonical),
+                            )?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.withdrawals_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                6 => {
+                    if let Some(field) = &self.update {
+                        serializer.write_unsigned_integer_sz(
+                            6u64,
+                            fit_sz(
+                                6u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.update_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                7 => {
+                    if let Some(field) = &self.auxiliary_data_hash {
+                        serializer.write_unsigned_integer_sz(
+                            7u64,
+                            fit_sz(
+                                7u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.auxiliary_data_hash_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_bytes_sz(
+                            &field.to_raw_bytes(),
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.auxiliary_data_hash_encoding.clone())
+                                .unwrap_or_default()
+                                .to_str_len_sz(field.to_raw_bytes().len() as u64, force_canonical),
+                        )?;
+                    }
+                }
+                8 => {
+                    if let Some(field) = &self.validity_interval_start {
+                        serializer.write_unsigned_integer_sz(
+                            8u64,
+                            fit_sz(
+                                8u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.validity_interval_start_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.validity_interval_start_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                9 => {
+                    if let Some(field) = &self.mint {
+                        serializer.write_unsigned_integer_sz(
+                            9u64,
+                            fit_sz(
+                                9u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.mint_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_map_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.mint_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        let mut key_order = field
+                            .iter()
+                            .map(|(k, v)| {
+                                let mut buf = cbor_event::se::Serializer::new_vec();
+                                let mint_key_encoding = self
+                                    .encodings
+                                    .as_ref()
+                                    .and_then(|encs| encs.mint_key_encodings.get(k))
+                                    .cloned()
+                                    .unwrap_or_default();
+                                buf.write_bytes_sz(
+                                    &k.to_raw_bytes(),
+                                    mint_key_encoding.to_str_len_sz(
+                                        k.to_raw_bytes().len() as u64,
+                                        force_canonical,
+                                    ),
+                                )?;
+                                Ok((buf.finalize(), k, v))
+                            })
+                            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                        if force_canonical {
+                            key_order.sort_by(
+                                |(lhs_bytes, _, _), (rhs_bytes, _, _)| match lhs_bytes
+                                    .len()
+                                    .cmp(&rhs_bytes.len())
+                                {
+                                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                    diff_ord => diff_ord,
+                                },
+                            );
+                        }
+                        for (key_bytes, key, value) in key_order {
+                            serializer.write_raw_bytes(&key_bytes)?;
+                            let (mint_value_encoding, mint_value_value_encodings) = self
+                                .encodings
+                                .as_ref()
+                                .and_then(|encs| encs.mint_value_encodings.get(key))
+                                .cloned()
+                                .unwrap_or_else(|| (LenEncoding::default(), BTreeMap::new()));
+                            serializer.write_map_sz(
+                                mint_value_encoding.to_len_sz(value.len() as u64, force_canonical),
+                            )?;
+                            let mut key_order = value
+                                .iter()
+                                .map(|(k, v)| {
+                                    let mut buf = cbor_event::se::Serializer::new_vec();
+                                    k.serialize(&mut buf, force_canonical)?;
+                                    Ok((buf.finalize(), k, v))
+                                })
+                                .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                            if force_canonical {
+                                key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                                    match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                                        std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                        diff_ord => diff_ord,
+                                    }
+                                });
+                            }
+                            for (key_bytes, key, value) in key_order {
+                                serializer.write_raw_bytes(&key_bytes)?;
+                                let mint_value_value_encoding = mint_value_value_encodings
+                                    .get(key)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                if *value >= 0 {
+                                    serializer.write_unsigned_integer_sz(
+                                        *value as u64,
+                                        fit_sz(
+                                            *value as u64,
+                                            mint_value_value_encoding,
+                                            force_canonical,
+                                        ),
+                                    )?;
+                                } else {
+                                    serializer.write_negative_integer_sz(
+                                        *value as i128,
+                                        fit_sz(
+                                            (*value + 1).abs() as u64,
+                                            mint_value_value_encoding,
+                                            force_canonical,
+                                        ),
+                                    )?;
+                                }
+                            }
+                            mint_value_encoding.end(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.mint_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MaryTransactionBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut inputs_encoding = LenEncoding::default();
+            let mut inputs_key_encoding = None;
+            let mut inputs = None;
+            let mut outputs_encoding = LenEncoding::default();
+            let mut outputs_key_encoding = None;
+            let mut outputs = None;
+            let mut fee_encoding = None;
+            let mut fee_key_encoding = None;
+            let mut fee = None;
+            let mut ttl_encoding = None;
+            let mut ttl_key_encoding = None;
+            let mut ttl = None;
+            let mut certs_encoding = LenEncoding::default();
+            let mut certs_key_encoding = None;
+            let mut certs = None;
+            let mut withdrawals_encoding = LenEncoding::default();
+            let mut withdrawals_value_encodings = BTreeMap::new();
+            let mut withdrawals_key_encoding = None;
+            let mut withdrawals = None;
+            let mut update_key_encoding = None;
+            let mut update = None;
+            let mut auxiliary_data_hash_encoding = StringEncoding::default();
+            let mut auxiliary_data_hash_key_encoding = None;
+            let mut auxiliary_data_hash = None;
+            let mut validity_interval_start_encoding = None;
+            let mut validity_interval_start_key_encoding = None;
+            let mut validity_interval_start = None;
+            let mut mint_encoding = LenEncoding::default();
+            let mut mint_key_encodings = BTreeMap::new();
+            let mut mint_value_encodings = BTreeMap::new();
+            let mut mint_key_encoding = None;
+            let mut mint = None;
+            let mut read = 0;
+            while match len { cbor_event::LenSz::Len(n, _) => read < n, cbor_event::LenSz::Indefinite => true, } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) =>  {
+                            if inputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_inputs, tmp_inputs_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut inputs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let inputs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (inputs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    inputs_arr.push(TransactionInput::deserialize(raw)?);
+                                }
+                                Ok((inputs_arr, inputs_encoding))
+                            })().map_err(|e| e.annotate("inputs"))?;
+                            inputs = Some(tmp_inputs);
+                            inputs_encoding = tmp_inputs_encoding;
+                            inputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        },
+                        (1, key_enc) =>  {
+                            if outputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_outputs, tmp_outputs_encoding) = (|| -> Result<_, DeserializeError> {
+                                let mut outputs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let outputs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (outputs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    outputs_arr.push(ShelleyTxOut::deserialize(raw)?);
+                                }
+                                Ok((outputs_arr, outputs_encoding))
+                            })().map_err(|e| e.annotate("outputs"))?;
+                            outputs = Some(tmp_outputs);
+                            outputs_encoding = tmp_outputs_encoding;
+                            outputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        },
+                        (2, key_enc) =>  {
+                            if fee.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into).map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            fee = Some(tmp_fee);
+                            fee_encoding = tmp_fee_encoding;
+                            fee_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        },
+                        (3, key_enc) =>  {
+                            if ttl.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_ttl, tmp_ttl_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                            })().map_err(|e| e.annotate("ttl"))?;
+                            ttl = Some(tmp_ttl);
+                            ttl_encoding = tmp_ttl_encoding;
+                            ttl_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        },
+                        (4, key_enc) =>  {
+                            if certs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_certs, tmp_certs_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut certs_arr = Vec::new();
+                                let len = raw.array_sz()?;
+                                let certs_encoding = len.into();
+                                while match len { cbor_event::LenSz::Len(n, _) => (certs_arr.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    certs_arr.push(Certificate::deserialize(raw)?);
+                                }
+                                Ok((certs_arr, certs_encoding))
+                            })().map_err(|e| e.annotate("certs"))?;
+                            certs = Some(tmp_certs);
+                            certs_encoding = tmp_certs_encoding;
+                            certs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        },
+                        (5, key_enc) =>  {
+                            if withdrawals.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_withdrawals, tmp_withdrawals_encoding, tmp_withdrawals_value_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut withdrawals_table = OrderedHashMap::new();
+                                let withdrawals_len = raw.map_sz()?;
+                                let withdrawals_encoding = withdrawals_len.into();
+                                let mut withdrawals_value_encodings = BTreeMap::new();
+                                while match withdrawals_len { cbor_event::LenSz::Len(n, _) => (withdrawals_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    let withdrawals_key = RewardAccount::deserialize(raw)?;
+                                    let (withdrawals_value, withdrawals_value_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                                    if withdrawals_table.insert(withdrawals_key.clone(), withdrawals_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    withdrawals_value_encodings.insert(withdrawals_key, withdrawals_value_encoding);
+                                }
+                                Ok((withdrawals_table, withdrawals_encoding, withdrawals_value_encodings))
+                            })().map_err(|e| e.annotate("withdrawals"))?;
+                            withdrawals = Some(tmp_withdrawals);
+                            withdrawals_encoding = tmp_withdrawals_encoding;
+                            withdrawals_value_encodings = tmp_withdrawals_value_encodings;
+                            withdrawals_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        },
+                        (6, key_enc) =>  {
+                            if update.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let tmp_update = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ShelleyUpdate::deserialize(raw)
+                            })().map_err(|e| e.annotate("update"))?;
+                            update = Some(tmp_update);
+                            update_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        },
+                        (7, key_enc) =>  {
+                            if auxiliary_data_hash.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let (tmp_auxiliary_data_hash, tmp_auxiliary_data_hash_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.bytes_sz().map_err(Into::<DeserializeError>::into).and_then(|(bytes, enc)| AuxiliaryDataHash::from_raw_bytes(&bytes).map(|bytes| (bytes, StringEncoding::from(enc))).map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into()))
+                            })().map_err(|e| e.annotate("auxiliary_data_hash"))?;
+                            auxiliary_data_hash = Some(tmp_auxiliary_data_hash);
+                            auxiliary_data_hash_encoding = tmp_auxiliary_data_hash_encoding;
+                            auxiliary_data_hash_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        },
+                        (8, key_enc) =>  {
+                            if validity_interval_start.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(8)).into());
+                            }
+                            let (tmp_validity_interval_start, tmp_validity_interval_start_encoding) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                            })().map_err(|e| e.annotate("validity_interval_start"))?;
+                            validity_interval_start = Some(tmp_validity_interval_start);
+                            validity_interval_start_encoding = tmp_validity_interval_start_encoding;
+                            validity_interval_start_key_encoding = Some(key_enc);
+                            orig_deser_order.push(8);
+                        },
+                        (9, key_enc) =>  {
+                            if mint.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(9)).into());
+                            }
+                            let (tmp_mint, tmp_mint_encoding, tmp_mint_key_encodings, tmp_mint_value_encodings) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut mint_table = OrderedHashMap::new();
+                                let mint_len = raw.map_sz()?;
+                                let mint_encoding = mint_len.into();
+                                let mut mint_key_encodings = BTreeMap::new();
+                                let mut mint_value_encodings = BTreeMap::new();
+                                while match mint_len { cbor_event::LenSz::Len(n, _) => (mint_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    let (mint_key, mint_key_encoding) = raw.bytes_sz().map_err(Into::<DeserializeError>::into).and_then(|(bytes, enc)| PolicyId::from_raw_bytes(&bytes).map(|bytes| (bytes, StringEncoding::from(enc))).map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into()))?;
+                                    let mut mint_value_table = OrderedHashMap::new();
+                                    let mint_value_len = raw.map_sz()?;
+                                    let mint_value_encoding = mint_value_len.into();
+                                    let mut mint_value_value_encodings = BTreeMap::new();
+                                    while match mint_value_len { cbor_event::LenSz::Len(n, _) => (mint_value_table.len() as u64) < n, cbor_event::LenSz::Indefinite => true, } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        let mint_value_key = AssetName::deserialize(raw)?;
+                                        let (mint_value_value, mint_value_value_encoding) = match raw.cbor_type()? {
+                                            cbor_event::Type::UnsignedInteger => {
+                                                let (x, enc) = raw.unsigned_integer_sz()?;
+                                                (x as i64, Some(enc))
+                                            },
+                                            _ => {
+                                                let (x, enc) = raw.negative_integer_sz()?;
+                                                (x as i64, Some(enc))
+                                            },
+                                        };
+                                        if mint_value_table.insert(mint_value_key.clone(), mint_value_value).is_some() {
+                                            return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                        }
+                                        mint_value_value_encodings.insert(mint_value_key, mint_value_value_encoding);
+                                    }
+                                    let (mint_value, mint_value_encoding, mint_value_value_encodings) = (mint_value_table, mint_value_encoding, mint_value_value_encodings);
+                                    if mint_table.insert(mint_key.clone(), mint_value).is_some() {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                                    }
+                                    mint_key_encodings.insert(mint_key.clone(), mint_key_encoding);
+                                    mint_value_encodings.insert(mint_key.clone(), (mint_value_encoding, mint_value_value_encodings));
+                                }
+                                Ok((mint_table, mint_encoding, mint_key_encodings, mint_value_encodings))
+                            })().map_err(|e| e.annotate("mint"))?;
+                            mint = Some(tmp_mint);
+                            mint_encoding = tmp_mint_encoding;
+                            mint_key_encodings = tmp_mint_key_encodings;
+                            mint_value_encodings = tmp_mint_value_encodings;
+                            mint_key_encoding = Some(key_enc);
+                            orig_deser_order.push(9);
+                        },
+                        (unknown_key, _enc) => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
+                    },
+                    cbor_event::Type::Text => return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into()),
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => return Err(DeserializeFailure::BreakInDefiniteLen.into()),
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => return Err(DeserializeFailure::UnexpectedKeyType(other_type).into()),
+                }
+                read += 1;
+            }
+            let inputs = match inputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(0)).into()),
+            };
+            let outputs = match outputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(1)).into()),
+            };
+            let fee = match fee {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(2)).into()),
+            };
+            read_len.finish()?;
+            Ok(Self {
+                inputs,
+                outputs,
+                fee,
+                ttl,
+                certs,
+                withdrawals,
+                update,
+                auxiliary_data_hash,
+                validity_interval_start,
+                mint: mint.map(Into::into),
+                encodings: Some(MaryTransactionBodyEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    inputs_key_encoding,
+                    inputs_encoding,
+                    outputs_key_encoding,
+                    outputs_encoding,
+                    fee_key_encoding,
+                    fee_encoding,
+                    ttl_key_encoding,
+                    ttl_encoding,
+                    certs_key_encoding,
+                    certs_encoding,
+                    withdrawals_key_encoding,
+                    withdrawals_encoding,
+                    withdrawals_value_encodings,
+                    update_key_encoding,
+                    auxiliary_data_hash_key_encoding,
+                    auxiliary_data_hash_encoding,
+                    validity_interval_start_key_encoding,
+                    validity_interval_start_encoding,
+                    mint_key_encoding,
+                    mint_encoding,
+                    mint_key_encodings,
+                    mint_value_encodings,
+                }),
+            })
+        })().map_err(|e| e.annotate("MaryTransactionBody"))
+    }
+}

--- a/multi-era/rust/src/serialization.rs
+++ b/multi-era/rust/src/serialization.rs
@@ -1,0 +1,85 @@
+use super::*;
+use cbor_event::de::Deserializer;
+use cbor_event::se::Serializer;
+use cml_core::error::*;
+use cml_core::serialization::*;
+use std::io::{BufRead, Seek, SeekFrom, Write};
+
+impl Serialize for MultiEraBlock {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            MultiEraBlock::Shelley(shelley) => shelley.serialize(serializer, force_canonical),
+            MultiEraBlock::Allegra(allegra) => allegra.serialize(serializer, force_canonical),
+            MultiEraBlock::Mary(mary) => mary.serialize(serializer, force_canonical),
+            MultiEraBlock::Alonzo(alonzo) => alonzo.serialize(serializer, force_canonical),
+            MultiEraBlock::Babbage(babbage) => babbage.serialize(serializer, force_canonical),
+        }
+    }
+}
+
+impl Deserialize for MultiEraBlock {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            let deser_variant: Result<_, DeserializeError> = ShelleyBlock::deserialize(raw);
+            match deser_variant {
+                Ok(shelley) => return Ok(Self::Shelley(shelley)),
+                Err(_e) => {
+                    raw
+                        .as_mut_ref()
+                        .seek(SeekFrom::Start(initial_position))
+                        .unwrap()
+                },
+            };
+            let deser_variant: Result<_, DeserializeError> = AllegraBlock::deserialize(raw);
+            match deser_variant {
+                Ok(allegra) => return Ok(Self::Allegra(allegra)),
+                Err(_e) => {
+                    raw
+                        .as_mut_ref()
+                        .seek(SeekFrom::Start(initial_position))
+                        .unwrap()
+                },
+            };
+            let deser_variant: Result<_, DeserializeError> = MaryBlock::deserialize(raw);
+            match deser_variant {
+                Ok(mary) => return Ok(Self::Mary(mary)),
+                Err(_e) => {
+                    raw
+                        .as_mut_ref()
+                        .seek(SeekFrom::Start(initial_position))
+                        .unwrap()
+                },
+            };
+            let deser_variant: Result<_, DeserializeError> = AlonzoBlock::deserialize(raw);
+            match deser_variant {
+                Ok(alonzo) => return Ok(Self::Alonzo(alonzo)),
+                Err(_e) => {
+                    raw
+                        .as_mut_ref()
+                        .seek(SeekFrom::Start(initial_position))
+                        .unwrap()
+                },
+            };
+            let deser_variant: Result<_, DeserializeError> = Block::deserialize(raw);
+            match deser_variant {
+                Ok(babbage) => return Ok(Self::Babbage(babbage)),
+                Err(_e) => {
+                    raw
+                        .as_mut_ref()
+                        .seek(SeekFrom::Start(initial_position))
+                        .unwrap()
+                },
+            };
+            Err(DeserializeError::new(
+                "MultiEraBlock",
+                DeserializeFailure::NoVariantMatched,
+            ))
+        })()
+        .map_err(|e| e.annotate("MultiEraBlock"))
+    }
+}

--- a/multi-era/rust/src/shelley/cbor_encodings.rs
+++ b/multi-era/rust/src/shelley/cbor_encodings.rs
@@ -1,0 +1,157 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_core::serialization::{LenEncoding, StringEncoding};
+use std::collections::BTreeMap;
+use cml_chain::{
+    address::RewardAccount,
+    certs::StakeCredential,
+    crypto::GenesisHash,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct MoveInstantaneousRewardEncoding {
+    pub len_encoding: LenEncoding,
+    pub pot_encoding: Option<cbor_event::Sz>,
+    pub to_stake_credentials_encoding: LenEncoding,
+    pub to_stake_credentials_value_encodings: BTreeMap<StakeCredential, Option<cbor_event::Sz>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MultisigAllEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<cbor_event::Sz>,
+    pub multisig_scripts_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MultisigAnyEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<cbor_event::Sz>,
+    pub multisig_scripts_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MultisigNOfKEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<cbor_event::Sz>,
+    pub n_encoding: Option<cbor_event::Sz>,
+    pub multisig_scripts_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MultisigPubkeyEncoding {
+    pub len_encoding: LenEncoding,
+    pub tag_encoding: Option<cbor_event::Sz>,
+    pub ed25519_key_hash_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyBlockEncoding {
+    pub len_encoding: LenEncoding,
+    pub transaction_bodies_encoding: LenEncoding,
+    pub transaction_witness_sets_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyHeaderBodyEncoding {
+    pub len_encoding: LenEncoding,
+    pub block_number_encoding: Option<cbor_event::Sz>,
+    pub slot_encoding: Option<cbor_event::Sz>,
+    pub prev_hash_encoding: StringEncoding,
+    pub issuer_vkey_encoding: StringEncoding,
+    pub v_r_f_vkey_encoding: StringEncoding,
+    pub block_body_size_encoding: Option<cbor_event::Sz>,
+    pub block_body_hash_encoding: StringEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyHeaderEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyProtocolParamUpdateEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub minfee_a_encoding: Option<cbor_event::Sz>,
+    pub minfee_a_key_encoding: Option<cbor_event::Sz>,
+    pub minfee_b_encoding: Option<cbor_event::Sz>,
+    pub minfee_b_key_encoding: Option<cbor_event::Sz>,
+    pub max_block_body_size_encoding: Option<cbor_event::Sz>,
+    pub max_block_body_size_key_encoding: Option<cbor_event::Sz>,
+    pub max_transaction_size_encoding: Option<cbor_event::Sz>,
+    pub max_transaction_size_key_encoding: Option<cbor_event::Sz>,
+    pub max_block_header_size_encoding: Option<cbor_event::Sz>,
+    pub max_block_header_size_key_encoding: Option<cbor_event::Sz>,
+    pub key_deposit_encoding: Option<cbor_event::Sz>,
+    pub key_deposit_key_encoding: Option<cbor_event::Sz>,
+    pub pool_deposit_encoding: Option<cbor_event::Sz>,
+    pub pool_deposit_key_encoding: Option<cbor_event::Sz>,
+    pub maximum_epoch_encoding: Option<cbor_event::Sz>,
+    pub maximum_epoch_key_encoding: Option<cbor_event::Sz>,
+    pub n_opt_encoding: Option<cbor_event::Sz>,
+    pub n_opt_key_encoding: Option<cbor_event::Sz>,
+    pub pool_pledge_influence_key_encoding: Option<cbor_event::Sz>,
+    pub expansion_rate_key_encoding: Option<cbor_event::Sz>,
+    pub treasury_growth_rate_key_encoding: Option<cbor_event::Sz>,
+    pub decentralization_constant_key_encoding: Option<cbor_event::Sz>,
+    pub extra_entropy_key_encoding: Option<cbor_event::Sz>,
+    pub protocol_version_key_encoding: Option<cbor_event::Sz>,
+    pub min_utxo_value_encoding: Option<cbor_event::Sz>,
+    pub min_utxo_value_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyTransactionBodyEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub inputs_encoding: LenEncoding,
+    pub inputs_key_encoding: Option<cbor_event::Sz>,
+    pub outputs_encoding: LenEncoding,
+    pub outputs_key_encoding: Option<cbor_event::Sz>,
+    pub fee_encoding: Option<cbor_event::Sz>,
+    pub fee_key_encoding: Option<cbor_event::Sz>,
+    pub ttl_encoding: Option<cbor_event::Sz>,
+    pub ttl_key_encoding: Option<cbor_event::Sz>,
+    pub certs_encoding: LenEncoding,
+    pub certs_key_encoding: Option<cbor_event::Sz>,
+    pub withdrawals_encoding: LenEncoding,
+    pub withdrawals_value_encodings: BTreeMap<RewardAccount, Option<cbor_event::Sz>>,
+    pub withdrawals_key_encoding: Option<cbor_event::Sz>,
+    pub update_key_encoding: Option<cbor_event::Sz>,
+    pub auxiliary_data_hash_encoding: StringEncoding,
+    pub auxiliary_data_hash_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyTransactionEncoding {
+    pub len_encoding: LenEncoding,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyTransactionOutputEncoding {
+    pub len_encoding: LenEncoding,
+    pub amount_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyTransactionWitnessSetEncoding {
+    pub len_encoding: LenEncoding,
+    pub orig_deser_order: Vec<usize>,
+    pub vkeywitnesses_encoding: LenEncoding,
+    pub vkeywitnesses_key_encoding: Option<cbor_event::Sz>,
+    pub native_scripts_encoding: LenEncoding,
+    pub native_scripts_key_encoding: Option<cbor_event::Sz>,
+    pub bootstrap_witnesses_encoding: LenEncoding,
+    pub bootstrap_witnesses_key_encoding: Option<cbor_event::Sz>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ShelleyUpdateEncoding {
+    pub len_encoding: LenEncoding,
+    pub shelley_proposed_protocol_parameter_updates_encoding: LenEncoding,
+    pub shelley_proposed_protocol_parameter_updates_key_encodings:
+        BTreeMap<GenesisHash, StringEncoding>,
+    pub epoch_encoding: Option<cbor_event::Sz>,
+}

--- a/multi-era/rust/src/shelley/mod.rs
+++ b/multi-era/rust/src/shelley/mod.rs
@@ -1,0 +1,411 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+pub mod cbor_encodings;
+pub mod serialization;
+
+use cml_chain::ProtocolVersionStruct;
+use cml_chain::address::Address;
+use cml_chain::assets::Coin;
+use cml_chain::auxdata::Metadata;
+use cml_chain::block::{OperationalCert, ProtocolVersion};
+use cml_chain::certs::{Certificate, MIRPot, StakeCredential};
+use cml_chain::crypto::{
+    AuxiliaryDataHash, BlockBodyHash, BlockHeaderHash, BootstrapWitness, Ed25519KeyHash,
+    GenesisHash, KESSignature, Nonce, VRFCert, VRFVkey, Vkey, Vkeywitness,
+};
+use cml_chain::transaction::TransactionInput;
+use cml_chain::{Epoch, Rational, UnitInterval, Withdrawals};
+use cbor_encodings::{
+    MoveInstantaneousRewardEncoding, MultisigAllEncoding, MultisigAnyEncoding,
+    MultisigNOfKEncoding, MultisigPubkeyEncoding, ShelleyBlockEncoding, ShelleyHeaderBodyEncoding,
+    ShelleyHeaderEncoding, ShelleyProtocolParamUpdateEncoding, ShelleyTransactionBodyEncoding,
+    ShelleyTransactionEncoding, ShelleyTransactionOutputEncoding,
+    ShelleyTransactionWitnessSetEncoding, ShelleyUpdateEncoding,
+};
+use cml_core::ordered_hash_map::OrderedHashMap;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MoveInstantaneousReward {
+    pub pot: MIRPot,
+    pub to_stake_credentials: OrderedHashMap<StakeCredential, Coin>,
+    #[serde(skip)]
+    pub encodings: Option<MoveInstantaneousRewardEncoding>,
+}
+
+impl MoveInstantaneousReward {
+    pub fn new(pot: MIRPot, to_stake_credentials: OrderedHashMap<StakeCredential, Coin>) -> Self {
+        Self {
+            pot,
+            to_stake_credentials,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MultisigAll {
+    pub multisig_scripts: Vec<MultisigScript>,
+    #[serde(skip)]
+    pub encodings: Option<MultisigAllEncoding>,
+}
+
+impl MultisigAll {
+    pub fn new(multisig_scripts: Vec<MultisigScript>) -> Self {
+        Self {
+            multisig_scripts,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MultisigAny {
+    pub multisig_scripts: Vec<MultisigScript>,
+    #[serde(skip)]
+    pub encodings: Option<MultisigAnyEncoding>,
+}
+
+impl MultisigAny {
+    pub fn new(multisig_scripts: Vec<MultisigScript>) -> Self {
+        Self {
+            multisig_scripts,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MultisigNOfK {
+    pub n: u64,
+    pub multisig_scripts: Vec<MultisigScript>,
+    #[serde(skip)]
+    pub encodings: Option<MultisigNOfKEncoding>,
+}
+
+impl MultisigNOfK {
+    pub fn new(n: u64, multisig_scripts: Vec<MultisigScript>) -> Self {
+        Self {
+            n,
+            multisig_scripts,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct MultisigPubkey {
+    pub ed25519_key_hash: Ed25519KeyHash,
+    #[serde(skip)]
+    pub encodings: Option<MultisigPubkeyEncoding>,
+}
+
+impl MultisigPubkey {
+    pub fn new(ed25519_key_hash: Ed25519KeyHash) -> Self {
+        Self {
+            ed25519_key_hash,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub enum MultisigScript {
+    MultisigPubkey(MultisigPubkey),
+    MultisigAll(MultisigAll),
+    MultisigAny(MultisigAny),
+    MultisigNOfK(MultisigNOfK),
+}
+
+impl MultisigScript {
+    pub fn new_multisig_pubkey(ed25519_key_hash: Ed25519KeyHash) -> Self {
+        Self::MultisigPubkey(MultisigPubkey::new(ed25519_key_hash))
+    }
+
+    pub fn new_multisig_all(multisig_scripts: Vec<MultisigScript>) -> Self {
+        Self::MultisigAll(MultisigAll::new(multisig_scripts))
+    }
+
+    pub fn new_multisig_any(multisig_scripts: Vec<MultisigScript>) -> Self {
+        Self::MultisigAny(MultisigAny::new(multisig_scripts))
+    }
+
+    pub fn new_multisig_n_of_k(n: u64, multisig_scripts: Vec<MultisigScript>) -> Self {
+        Self::MultisigNOfK(MultisigNOfK::new(n, multisig_scripts))
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyBlock {
+    pub header: ShelleyHeader,
+    pub transaction_bodies: Vec<ShelleyTransactionBody>,
+    pub transaction_witness_sets: Vec<ShelleyTransactionWitnessSet>,
+    pub transaction_metadata_set: Metadata,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyBlockEncoding>,
+}
+
+impl ShelleyBlock {
+    pub fn new(
+        header: ShelleyHeader,
+        transaction_bodies: Vec<ShelleyTransactionBody>,
+        transaction_witness_sets: Vec<ShelleyTransactionWitnessSet>,
+        transaction_metadata_set: Metadata,
+    ) -> Self {
+        Self {
+            header,
+            transaction_bodies,
+            transaction_witness_sets,
+            transaction_metadata_set,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyHeader {
+    pub body: ShelleyHeaderBody,
+    pub signature: KESSignature,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyHeaderEncoding>,
+}
+
+impl ShelleyHeader {
+    pub fn new(body: ShelleyHeaderBody, signature: KESSignature) -> Self {
+        Self {
+            body,
+            signature,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyHeaderBody {
+    pub block_number: u64,
+    pub slot: u64,
+    pub prev_hash: Option<BlockHeaderHash>,
+    pub issuer_vkey: Vkey,
+    pub v_r_f_vkey: VRFVkey,
+    pub nonce_vrf: VRFCert,
+    pub leader_vrf: VRFCert,
+    pub block_body_size: u64,
+    pub block_body_hash: BlockBodyHash,
+    pub operational_cert: OperationalCert,
+    pub protocol_version: ProtocolVersion,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyHeaderBodyEncoding>,
+}
+
+impl ShelleyHeaderBody {
+    pub fn new(
+        block_number: u64,
+        slot: u64,
+        prev_hash: Option<BlockHeaderHash>,
+        issuer_vkey: Vkey,
+        v_r_f_vkey: VRFVkey,
+        nonce_vrf: VRFCert,
+        leader_vrf: VRFCert,
+        block_body_size: u64,
+        block_body_hash: BlockBodyHash,
+        operational_cert: OperationalCert,
+        protocol_version: ProtocolVersion,
+    ) -> Self {
+        Self {
+            block_number,
+            slot,
+            prev_hash,
+            issuer_vkey,
+            v_r_f_vkey,
+            nonce_vrf,
+            leader_vrf,
+            block_body_size,
+            block_body_hash,
+            operational_cert,
+            protocol_version,
+            encodings: None,
+        }
+    }
+}
+
+pub type ShelleyProposedProtocolParameterUpdates =
+    OrderedHashMap<GenesisHash, ShelleyProtocolParamUpdate>;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyProtocolParamUpdate {
+    pub minfee_a: Option<u64>,
+    pub minfee_b: Option<u64>,
+    pub max_block_body_size: Option<u64>,
+    pub max_transaction_size: Option<u64>,
+    pub max_block_header_size: Option<u64>,
+    pub key_deposit: Option<Coin>,
+    pub pool_deposit: Option<Coin>,
+    pub maximum_epoch: Option<Epoch>,
+    pub n_opt: Option<u64>,
+    pub pool_pledge_influence: Option<Rational>,
+    pub expansion_rate: Option<UnitInterval>,
+    pub treasury_growth_rate: Option<UnitInterval>,
+    pub decentralization_constant: Option<UnitInterval>,
+    pub extra_entropy: Option<Nonce>,
+    pub protocol_version: Option<ProtocolVersionStruct>,
+    pub min_utxo_value: Option<Coin>,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyProtocolParamUpdateEncoding>,
+}
+
+impl ShelleyProtocolParamUpdate {
+    pub fn new() -> Self {
+        Self {
+            minfee_a: None,
+            minfee_b: None,
+            max_block_body_size: None,
+            max_transaction_size: None,
+            max_block_header_size: None,
+            key_deposit: None,
+            pool_deposit: None,
+            maximum_epoch: None,
+            n_opt: None,
+            pool_pledge_influence: None,
+            expansion_rate: None,
+            treasury_growth_rate: None,
+            decentralization_constant: None,
+            extra_entropy: None,
+            protocol_version: None,
+            min_utxo_value: None,
+            encodings: None,
+        }
+    }
+}
+
+impl Default for ShelleyProtocolParamUpdate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyTransaction {
+    pub body: ShelleyTransactionBody,
+    pub witness_set: ShelleyTransactionWitnessSet,
+    pub metadata: Option<Metadata>,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyTransactionEncoding>,
+}
+
+impl ShelleyTransaction {
+    pub fn new(
+        body: ShelleyTransactionBody,
+        witness_set: ShelleyTransactionWitnessSet,
+        metadata: Option<Metadata>,
+    ) -> Self {
+        Self {
+            body,
+            witness_set,
+            metadata,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyTransactionBody {
+    pub inputs: Vec<TransactionInput>,
+    pub outputs: Vec<ShelleyTransactionOutput>,
+    pub fee: Coin,
+    pub ttl: u64,
+    pub certs: Option<Vec<Certificate>>,
+    pub withdrawals: Option<Withdrawals>,
+    pub update: Option<ShelleyUpdate>,
+    pub auxiliary_data_hash: Option<AuxiliaryDataHash>,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyTransactionBodyEncoding>,
+}
+
+impl ShelleyTransactionBody {
+    pub fn new(
+        inputs: Vec<TransactionInput>,
+        outputs: Vec<ShelleyTransactionOutput>,
+        fee: Coin,
+        ttl: u64,
+    ) -> Self {
+        Self {
+            inputs,
+            outputs,
+            fee,
+            ttl,
+            certs: None,
+            withdrawals: None,
+            update: None,
+            auxiliary_data_hash: None,
+            encodings: None,
+        }
+    }
+}
+
+pub type ShelleyTransactionIndex = u16;
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyTransactionOutput {
+    pub address: Address,
+    pub amount: Coin,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyTransactionOutputEncoding>,
+}
+
+impl ShelleyTransactionOutput {
+    pub fn new(address: Address, amount: Coin) -> Self {
+        Self {
+            address,
+            amount,
+            encodings: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyTransactionWitnessSet {
+    pub vkeywitnesses: Option<Vec<Vkeywitness>>,
+    pub native_scripts: Option<Vec<MultisigScript>>,
+    pub bootstrap_witnesses: Option<Vec<BootstrapWitness>>,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyTransactionWitnessSetEncoding>,
+}
+
+impl ShelleyTransactionWitnessSet {
+    pub fn new() -> Self {
+        Self {
+            vkeywitnesses: None,
+            native_scripts: None,
+            bootstrap_witnesses: None,
+            encodings: None,
+        }
+    }
+}
+
+impl Default for ShelleyTransactionWitnessSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+pub struct ShelleyUpdate {
+    pub shelley_proposed_protocol_parameter_updates: ShelleyProposedProtocolParameterUpdates,
+    pub epoch: Epoch,
+    #[serde(skip)]
+    pub encodings: Option<ShelleyUpdateEncoding>,
+}
+
+impl ShelleyUpdate {
+    pub fn new(
+        shelley_proposed_protocol_parameter_updates: ShelleyProposedProtocolParameterUpdates,
+        epoch: Epoch,
+    ) -> Self {
+        Self {
+            shelley_proposed_protocol_parameter_updates,
+            epoch,
+            encodings: None,
+        }
+    }
+}

--- a/multi-era/rust/src/shelley/serialization.rs
+++ b/multi-era/rust/src/shelley/serialization.rs
@@ -1,0 +1,3317 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use super::cbor_encodings::*;
+use super::*;
+use cbor_event;
+use cbor_event::de::Deserializer;
+use cbor_event::se::Serializer;
+use cml_chain::address::RewardAccount;
+use cml_core::error::*;
+use cml_core::serialization::*;
+use cml_crypto::RawBytesEncoding;
+use std::io::{BufRead, Seek, SeekFrom, Write};
+
+impl Serialize for MoveInstantaneousReward {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        match &self.pot {
+            MIRPot::Reserve => serializer.write_unsigned_integer_sz(
+                0u64,
+                fit_sz(
+                    0u64,
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.pot_encoding)
+                        .unwrap_or_default(),
+                    force_canonical,
+                ),
+            ),
+            MIRPot::Treasury => serializer.write_unsigned_integer_sz(
+                1u64,
+                fit_sz(
+                    1u64,
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.pot_encoding)
+                        .unwrap_or_default(),
+                    force_canonical,
+                ),
+            ),
+        }?;
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.to_stake_credentials_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.to_stake_credentials.len() as u64, force_canonical),
+        )?;
+        let mut key_order = self
+            .to_stake_credentials
+            .iter()
+            .map(|(k, v)| {
+                let mut buf = cbor_event::se::Serializer::new_vec();
+                k.serialize(&mut buf, force_canonical)?;
+                Ok((buf.finalize(), k, v))
+            })
+            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            let to_stake_credentials_value_encoding = self
+                .encodings
+                .as_ref()
+                .and_then(|encs| encs.to_stake_credentials_value_encodings.get(key))
+                .cloned()
+                .unwrap_or_default();
+            serializer.write_unsigned_integer_sz(
+                *value,
+                fit_sz(*value, to_stake_credentials_value_encoding, force_canonical),
+            )?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.to_stake_credentials_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MoveInstantaneousReward {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let (pot, pot_encoding) = (|| -> Result<_, DeserializeError> {
+                let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                    let (reserve_value, reserve_encoding) = raw.unsigned_integer_sz()?;
+                    if reserve_value != 0 {
+                        return Err(DeserializeFailure::FixedValueMismatch {
+                            found: Key::Uint(reserve_value),
+                            expected: Key::Uint(0),
+                        }
+                        .into());
+                    }
+                    Ok(Some(reserve_encoding))
+                })(raw)
+                {
+                    Ok((pot_encoding)) => return Ok((MIRPot::Reserve, pot_encoding)),
+                    Err(_) => raw
+                        .as_mut_ref()
+                        .seek(SeekFrom::Start(initial_position))
+                        .unwrap(),
+                };
+                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                    let (treasury_value, treasury_encoding) = raw.unsigned_integer_sz()?;
+                    if treasury_value != 1 {
+                        return Err(DeserializeFailure::FixedValueMismatch {
+                            found: Key::Uint(treasury_value),
+                            expected: Key::Uint(1),
+                        }
+                        .into());
+                    }
+                    Ok(Some(treasury_encoding))
+                })(raw)
+                {
+                    Ok((pot_encoding)) => return Ok((MIRPot::Treasury, pot_encoding)),
+                    Err(_) => raw
+                        .as_mut_ref()
+                        .seek(SeekFrom::Start(initial_position))
+                        .unwrap(),
+                };
+                Err(DeserializeError::new(
+                    "MIRPot",
+                    DeserializeFailure::NoVariantMatched,
+                ))
+            })()
+            .map_err(|e| e.annotate("pot"))?;
+            let (
+                to_stake_credentials,
+                to_stake_credentials_encoding,
+                to_stake_credentials_value_encodings,
+            ) = (|| -> Result<_, DeserializeError> {
+                let mut to_stake_credentials_table = OrderedHashMap::new();
+                let to_stake_credentials_len = raw.map_sz()?;
+                let to_stake_credentials_encoding = to_stake_credentials_len.into();
+                let mut to_stake_credentials_value_encodings = BTreeMap::new();
+                while match to_stake_credentials_len {
+                    cbor_event::LenSz::Len(n, _) => (to_stake_credentials_table.len() as u64) < n,
+                    cbor_event::LenSz::Indefinite => true,
+                } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let to_stake_credentials_key = StakeCredential::deserialize(raw)?;
+                    let (to_stake_credentials_value, to_stake_credentials_value_encoding) =
+                        raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                    if to_stake_credentials_table
+                        .insert(to_stake_credentials_key.clone(), to_stake_credentials_value)
+                        .is_some()
+                    {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from(
+                            "some complicated/unsupported type",
+                        )))
+                        .into());
+                    }
+                    to_stake_credentials_value_encodings.insert(
+                        to_stake_credentials_key,
+                        to_stake_credentials_value_encoding,
+                    );
+                }
+                Ok((
+                    to_stake_credentials_table,
+                    to_stake_credentials_encoding,
+                    to_stake_credentials_value_encodings,
+                ))
+            })()
+            .map_err(|e| e.annotate("to_stake_credentials"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(MoveInstantaneousReward {
+                pot,
+                to_stake_credentials,
+                encodings: Some(MoveInstantaneousRewardEncoding {
+                    len_encoding,
+                    pot_encoding,
+                    to_stake_credentials_encoding,
+                    to_stake_credentials_value_encodings,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("MoveInstantaneousReward"))
+    }
+}
+
+impl Serialize for MultisigAll {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for MultisigAll {
+    fn serialize_as_embedded_group<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(
+            1u64,
+            fit_sz(
+                1u64,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.tag_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.multisig_scripts_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.multisig_scripts.len() as u64, force_canonical),
+        )?;
+        for element in self.multisig_scripts.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.multisig_scripts_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MultisigAll {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+        match len {
+            cbor_event::LenSz::Len(_, _) => (),
+            cbor_event::LenSz::Indefinite => match raw.special()? {
+                cbor_event::Special::Break => (),
+                _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+            },
+        }
+        ret
+    }
+}
+
+impl DeserializeEmbeddedGroup for MultisigAll {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+        _read_len: &mut CBORReadLen,
+        len: cbor_event::LenSz,
+    ) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        (|| -> Result<_, DeserializeError> {
+            let tag_encoding = (|| -> Result<_, DeserializeError> {
+                let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
+                if tag_value != 1 {
+                    return Err(DeserializeFailure::FixedValueMismatch {
+                        found: Key::Uint(tag_value),
+                        expected: Key::Uint(1),
+                    }
+                    .into());
+                }
+                Ok(Some(tag_encoding))
+            })()
+            .map_err(|e| e.annotate("tag"))?;
+            let (multisig_scripts, multisig_scripts_encoding) =
+                (|| -> Result<_, DeserializeError> {
+                    let mut multisig_scripts_arr = Vec::new();
+                    let len = raw.array_sz()?;
+                    let multisig_scripts_encoding = len.into();
+                    while match len {
+                        cbor_event::LenSz::Len(n, _) => (multisig_scripts_arr.len() as u64) < n,
+                        cbor_event::LenSz::Indefinite => true,
+                    } {
+                        if raw.cbor_type()? == cbor_event::Type::Special {
+                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                            break;
+                        }
+                        multisig_scripts_arr.push(MultisigScript::deserialize(raw)?);
+                    }
+                    Ok((multisig_scripts_arr, multisig_scripts_encoding))
+                })()
+                .map_err(|e| e.annotate("multisig_scripts"))?;
+            Ok(MultisigAll {
+                multisig_scripts,
+                encodings: Some(MultisigAllEncoding {
+                    len_encoding,
+                    tag_encoding,
+                    multisig_scripts_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("MultisigAll"))
+    }
+}
+
+impl Serialize for MultisigAny {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for MultisigAny {
+    fn serialize_as_embedded_group<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(
+            2u64,
+            fit_sz(
+                2u64,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.tag_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.multisig_scripts_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.multisig_scripts.len() as u64, force_canonical),
+        )?;
+        for element in self.multisig_scripts.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.multisig_scripts_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MultisigAny {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+        match len {
+            cbor_event::LenSz::Len(_, _) => (),
+            cbor_event::LenSz::Indefinite => match raw.special()? {
+                cbor_event::Special::Break => (),
+                _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+            },
+        }
+        ret
+    }
+}
+
+impl DeserializeEmbeddedGroup for MultisigAny {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+        _read_len: &mut CBORReadLen,
+        len: cbor_event::LenSz,
+    ) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        (|| -> Result<_, DeserializeError> {
+            let tag_encoding = (|| -> Result<_, DeserializeError> {
+                let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
+                if tag_value != 2 {
+                    return Err(DeserializeFailure::FixedValueMismatch {
+                        found: Key::Uint(tag_value),
+                        expected: Key::Uint(2),
+                    }
+                    .into());
+                }
+                Ok(Some(tag_encoding))
+            })()
+            .map_err(|e| e.annotate("tag"))?;
+            let (multisig_scripts, multisig_scripts_encoding) =
+                (|| -> Result<_, DeserializeError> {
+                    let mut multisig_scripts_arr = Vec::new();
+                    let len = raw.array_sz()?;
+                    let multisig_scripts_encoding = len.into();
+                    while match len {
+                        cbor_event::LenSz::Len(n, _) => (multisig_scripts_arr.len() as u64) < n,
+                        cbor_event::LenSz::Indefinite => true,
+                    } {
+                        if raw.cbor_type()? == cbor_event::Type::Special {
+                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                            break;
+                        }
+                        multisig_scripts_arr.push(MultisigScript::deserialize(raw)?);
+                    }
+                    Ok((multisig_scripts_arr, multisig_scripts_encoding))
+                })()
+                .map_err(|e| e.annotate("multisig_scripts"))?;
+            Ok(MultisigAny {
+                multisig_scripts,
+                encodings: Some(MultisigAnyEncoding {
+                    len_encoding,
+                    tag_encoding,
+                    multisig_scripts_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("MultisigAny"))
+    }
+}
+
+impl Serialize for MultisigNOfK {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(3, force_canonical),
+        )?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for MultisigNOfK {
+    fn serialize_as_embedded_group<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(
+            3u64,
+            fit_sz(
+                3u64,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.tag_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_unsigned_integer_sz(
+            self.n,
+            fit_sz(
+                self.n,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.n_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.multisig_scripts_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.multisig_scripts.len() as u64, force_canonical),
+        )?;
+        for element in self.multisig_scripts.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.multisig_scripts_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MultisigNOfK {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        read_len.finish()?;
+        let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+        match len {
+            cbor_event::LenSz::Len(_, _) => (),
+            cbor_event::LenSz::Indefinite => match raw.special()? {
+                cbor_event::Special::Break => (),
+                _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+            },
+        }
+        ret
+    }
+}
+
+impl DeserializeEmbeddedGroup for MultisigNOfK {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+        _read_len: &mut CBORReadLen,
+        len: cbor_event::LenSz,
+    ) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        (|| -> Result<_, DeserializeError> {
+            let tag_encoding = (|| -> Result<_, DeserializeError> {
+                let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
+                if tag_value != 3 {
+                    return Err(DeserializeFailure::FixedValueMismatch {
+                        found: Key::Uint(tag_value),
+                        expected: Key::Uint(3),
+                    }
+                    .into());
+                }
+                Ok(Some(tag_encoding))
+            })()
+            .map_err(|e| e.annotate("tag"))?;
+            let (n, n_encoding) = raw
+                .unsigned_integer_sz()
+                .map(|(x, enc)| (x, Some(enc)))
+                .map_err(Into::<DeserializeError>::into)
+                .map_err(|e: DeserializeError| e.annotate("n"))?;
+            let (multisig_scripts, multisig_scripts_encoding) =
+                (|| -> Result<_, DeserializeError> {
+                    let mut multisig_scripts_arr = Vec::new();
+                    let len = raw.array_sz()?;
+                    let multisig_scripts_encoding = len.into();
+                    while match len {
+                        cbor_event::LenSz::Len(n, _) => (multisig_scripts_arr.len() as u64) < n,
+                        cbor_event::LenSz::Indefinite => true,
+                    } {
+                        if raw.cbor_type()? == cbor_event::Type::Special {
+                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                            break;
+                        }
+                        multisig_scripts_arr.push(MultisigScript::deserialize(raw)?);
+                    }
+                    Ok((multisig_scripts_arr, multisig_scripts_encoding))
+                })()
+                .map_err(|e| e.annotate("multisig_scripts"))?;
+            Ok(MultisigNOfK {
+                n,
+                multisig_scripts,
+                encodings: Some(MultisigNOfKEncoding {
+                    len_encoding,
+                    tag_encoding,
+                    n_encoding,
+                    multisig_scripts_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("MultisigNOfK"))
+    }
+}
+
+impl Serialize for MultisigPubkey {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        self.serialize_as_embedded_group(serializer, force_canonical)
+    }
+}
+
+impl SerializeEmbeddedGroup for MultisigPubkey {
+    fn serialize_as_embedded_group<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer_sz(
+            0u64,
+            fit_sz(
+                0u64,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.tag_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_bytes_sz(
+            &self.ed25519_key_hash.to_raw_bytes(),
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.ed25519_key_hash_encoding.clone())
+                .unwrap_or_default()
+                .to_str_len_sz(
+                    self.ed25519_key_hash.to_raw_bytes().len() as u64,
+                    force_canonical,
+                ),
+        )?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for MultisigPubkey {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        let ret = Self::deserialize_as_embedded_group(raw, &mut read_len, len);
+        match len {
+            cbor_event::LenSz::Len(_, _) => (),
+            cbor_event::LenSz::Indefinite => match raw.special()? {
+                cbor_event::Special::Break => (),
+                _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+            },
+        }
+        ret
+    }
+}
+
+impl DeserializeEmbeddedGroup for MultisigPubkey {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+        _read_len: &mut CBORReadLen,
+        len: cbor_event::LenSz,
+    ) -> Result<Self, DeserializeError> {
+        let len_encoding = len.into();
+        (|| -> Result<_, DeserializeError> {
+            let tag_encoding = (|| -> Result<_, DeserializeError> {
+                let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
+                if tag_value != 0 {
+                    return Err(DeserializeFailure::FixedValueMismatch {
+                        found: Key::Uint(tag_value),
+                        expected: Key::Uint(0),
+                    }
+                    .into());
+                }
+                Ok(Some(tag_encoding))
+            })()
+            .map_err(|e| e.annotate("tag"))?;
+            let (ed25519_key_hash, ed25519_key_hash_encoding) = raw
+                .bytes_sz()
+                .map_err(Into::<DeserializeError>::into)
+                .and_then(|(bytes, enc)| {
+                    Ed25519KeyHash::from_raw_bytes(&bytes)
+                        .map(|bytes| (bytes, StringEncoding::from(enc)))
+                        .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into())
+                })
+                .map_err(|e: DeserializeError| e.annotate("ed25519_key_hash"))?;
+            Ok(MultisigPubkey {
+                ed25519_key_hash,
+                encodings: Some(MultisigPubkeyEncoding {
+                    len_encoding,
+                    tag_encoding,
+                    ed25519_key_hash_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("MultisigPubkey"))
+    }
+}
+
+impl Serialize for MultisigScript {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            MultisigScript::MultisigPubkey(multisig_pubkey) => {
+                multisig_pubkey.serialize(serializer, force_canonical)
+            }
+            MultisigScript::MultisigAll(multisig_all) => {
+                multisig_all.serialize(serializer, force_canonical)
+            }
+            MultisigScript::MultisigAny(multisig_any) => {
+                multisig_any.serialize(serializer, force_canonical)
+            }
+            MultisigScript::MultisigNOfK(multisig_n_of_k) => {
+                multisig_n_of_k.serialize(serializer, force_canonical)
+            }
+        }
+    }
+}
+
+impl Deserialize for MultisigScript {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array_sz()?;
+            let mut read_len = CBORReadLen::new(len);
+            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+            let deser_variant: Result<_, DeserializeError> =
+                MultisigPubkey::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match deser_variant {
+                Ok(multisig_pubkey) => return Ok(Self::MultisigPubkey(multisig_pubkey)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> =
+                MultisigAll::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match deser_variant {
+                Ok(multisig_all) => return Ok(Self::MultisigAll(multisig_all)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> =
+                MultisigAny::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match deser_variant {
+                Ok(multisig_any) => return Ok(Self::MultisigAny(multisig_any)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            let deser_variant: Result<_, DeserializeError> =
+                MultisigNOfK::deserialize_as_embedded_group(raw, &mut read_len, len);
+            match deser_variant {
+                Ok(multisig_n_of_k) => return Ok(Self::MultisigNOfK(multisig_n_of_k)),
+                Err(_) => raw
+                    .as_mut_ref()
+                    .seek(SeekFrom::Start(initial_position))
+                    .unwrap(),
+            };
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Err(DeserializeError::new(
+                "MultisigScript",
+                DeserializeFailure::NoVariantMatched,
+            ))
+        })()
+        .map_err(|e| e.annotate("MultisigScript"))
+    }
+}
+
+impl Serialize for ShelleyBlock {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(4, force_canonical),
+        )?;
+        self.header.serialize(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_bodies_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_bodies.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_bodies.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_bodies_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.transaction_witness_sets_encoding)
+                .unwrap_or_default()
+                .to_len_sz(self.transaction_witness_sets.len() as u64, force_canonical),
+        )?;
+        for element in self.transaction_witness_sets.iter() {
+            element.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.transaction_witness_sets_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        self.transaction_metadata_set
+            .serialize(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyBlock {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(4)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let header = ShelleyHeader::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("header"))?;
+            let (transaction_bodies, transaction_bodies_encoding) =
+                (|| -> Result<_, DeserializeError> {
+                    let mut transaction_bodies_arr = Vec::new();
+                    let len = raw.array_sz()?;
+                    let transaction_bodies_encoding = len.into();
+                    while match len {
+                        cbor_event::LenSz::Len(n, _) => (transaction_bodies_arr.len() as u64) < n,
+                        cbor_event::LenSz::Indefinite => true,
+                    } {
+                        if raw.cbor_type()? == cbor_event::Type::Special {
+                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                            break;
+                        }
+                        transaction_bodies_arr.push(ShelleyTransactionBody::deserialize(raw)?);
+                    }
+                    Ok((transaction_bodies_arr, transaction_bodies_encoding))
+                })()
+                .map_err(|e| e.annotate("transaction_bodies"))?;
+            let (transaction_witness_sets, transaction_witness_sets_encoding) =
+                (|| -> Result<_, DeserializeError> {
+                    let mut transaction_witness_sets_arr = Vec::new();
+                    let len = raw.array_sz()?;
+                    let transaction_witness_sets_encoding = len.into();
+                    while match len {
+                        cbor_event::LenSz::Len(n, _) => {
+                            (transaction_witness_sets_arr.len() as u64) < n
+                        }
+                        cbor_event::LenSz::Indefinite => true,
+                    } {
+                        if raw.cbor_type()? == cbor_event::Type::Special {
+                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                            break;
+                        }
+                        transaction_witness_sets_arr
+                            .push(ShelleyTransactionWitnessSet::deserialize(raw)?);
+                    }
+                    Ok((
+                        transaction_witness_sets_arr,
+                        transaction_witness_sets_encoding,
+                    ))
+                })()
+                .map_err(|e| e.annotate("transaction_witness_sets"))?;
+            let transaction_metadata_set = Metadata::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("transaction_metadata_set"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyBlock {
+                header,
+                transaction_bodies,
+                transaction_witness_sets,
+                transaction_metadata_set,
+                encodings: Some(ShelleyBlockEncoding {
+                    len_encoding,
+                    transaction_bodies_encoding,
+                    transaction_witness_sets_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyBlock"))
+    }
+}
+
+impl Serialize for ShelleyHeader {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        self.body.serialize(serializer, force_canonical)?;
+        self.signature.serialize(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyHeader {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let body = ShelleyHeaderBody::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("body"))?;
+            let signature = KESSignature::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("signature"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyHeader {
+                body,
+                signature,
+                encodings: Some(ShelleyHeaderEncoding { len_encoding }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyHeader"))
+    }
+}
+
+impl Serialize for ShelleyHeaderBody {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(15, force_canonical),
+        )?;
+        serializer.write_unsigned_integer_sz(
+            self.block_number,
+            fit_sz(
+                self.block_number,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.block_number_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_unsigned_integer_sz(
+            self.slot,
+            fit_sz(
+                self.slot,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.slot_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        match &self.prev_hash {
+            Some(x) => serializer.write_bytes_sz(
+                &x.to_raw_bytes(),
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.prev_hash_encoding.clone())
+                    .unwrap_or_default()
+                    .to_str_len_sz(x.to_raw_bytes().len() as u64, force_canonical),
+            ),
+            None => serializer.write_special(cbor_event::Special::Null),
+        }?;
+        serializer.write_bytes_sz(
+            &self.issuer_vkey.to_raw_bytes(),
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.issuer_vkey_encoding.clone())
+                .unwrap_or_default()
+                .to_str_len_sz(
+                    self.issuer_vkey.to_raw_bytes().len() as u64,
+                    force_canonical,
+                ),
+        )?;
+        serializer.write_bytes_sz(
+            &self.v_r_f_vkey.to_raw_bytes(),
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.v_r_f_vkey_encoding.clone())
+                .unwrap_or_default()
+                .to_str_len_sz(self.v_r_f_vkey.to_raw_bytes().len() as u64, force_canonical),
+        )?;
+        self.nonce_vrf.serialize(serializer, force_canonical)?;
+        self.leader_vrf.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(
+            self.block_body_size,
+            fit_sz(
+                self.block_body_size,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.block_body_size_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        serializer.write_bytes_sz(
+            &self.block_body_hash.to_raw_bytes(),
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.block_body_hash_encoding.clone())
+                .unwrap_or_default()
+                .to_str_len_sz(
+                    self.block_body_hash.to_raw_bytes().len() as u64,
+                    force_canonical,
+                ),
+        )?;
+        self.operational_cert
+            .serialize_as_embedded_group(serializer, force_canonical)?;
+        self.protocol_version
+            .serialize_as_embedded_group(serializer, force_canonical)?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyHeaderBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(15)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let (block_number, block_number_encoding) = raw
+                .unsigned_integer_sz()
+                .map(|(x, enc)| (x, Some(enc)))
+                .map_err(Into::<DeserializeError>::into)
+                .map_err(|e: DeserializeError| e.annotate("block_number"))?;
+            let (slot, slot_encoding) = raw
+                .unsigned_integer_sz()
+                .map(|(x, enc)| (x, Some(enc)))
+                .map_err(Into::<DeserializeError>::into)
+                .map_err(|e: DeserializeError| e.annotate("slot"))?;
+            let (prev_hash, prev_hash_encoding) = (|| -> Result<_, DeserializeError> {
+                Ok(match raw.cbor_type()? != cbor_event::Type::Special {
+                    true => Result::<_, DeserializeError>::Ok(
+                        raw.bytes_sz()
+                            .map_err(Into::<DeserializeError>::into)
+                            .and_then(|(bytes, enc)| {
+                                BlockHeaderHash::from_raw_bytes(&bytes)
+                                    .map(|bytes| (bytes, StringEncoding::from(enc)))
+                                    .map_err(|e| {
+                                        DeserializeFailure::InvalidStructure(Box::new(e)).into()
+                                    })
+                            })?,
+                    )
+                    .map(|(x, prev_hash_encoding)| (Some(x), prev_hash_encoding))?,
+                    false => {
+                        if raw.special()? != cbor_event::Special::Null {
+                            return Err(DeserializeFailure::ExpectedNull.into());
+                        }
+                        (None, StringEncoding::default())
+                    }
+                })
+            })()
+            .map_err(|e| e.annotate("prev_hash"))?;
+            let (issuer_vkey, issuer_vkey_encoding) = raw
+                .bytes_sz()
+                .map_err(Into::<DeserializeError>::into)
+                .and_then(|(bytes, enc)| {
+                    Vkey::from_raw_bytes(&bytes)
+                        .map(|bytes| (bytes, StringEncoding::from(enc)))
+                        .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into())
+                })
+                .map_err(|e: DeserializeError| e.annotate("issuer_vkey"))?;
+            let (v_r_f_vkey, v_r_f_vkey_encoding) = raw
+                .bytes_sz()
+                .map_err(Into::<DeserializeError>::into)
+                .and_then(|(bytes, enc)| {
+                    VRFVkey::from_raw_bytes(&bytes)
+                        .map(|bytes| (bytes, StringEncoding::from(enc)))
+                        .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into())
+                })
+                .map_err(|e: DeserializeError| e.annotate("v_r_f_vkey"))?;
+            let nonce_vrf =
+                VRFCert::deserialize(raw).map_err(|e: DeserializeError| e.annotate("nonce_vrf"))?;
+            let leader_vrf = VRFCert::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("leader_vrf"))?;
+            let (block_body_size, block_body_size_encoding) = raw
+                .unsigned_integer_sz()
+                .map(|(x, enc)| (x, Some(enc)))
+                .map_err(Into::<DeserializeError>::into)
+                .map_err(|e: DeserializeError| e.annotate("block_body_size"))?;
+            let (block_body_hash, block_body_hash_encoding) = raw
+                .bytes_sz()
+                .map_err(Into::<DeserializeError>::into)
+                .and_then(|(bytes, enc)| {
+                    BlockBodyHash::from_raw_bytes(&bytes)
+                        .map(|bytes| (bytes, StringEncoding::from(enc)))
+                        .map_err(|e| DeserializeFailure::InvalidStructure(Box::new(e)).into())
+                })
+                .map_err(|e: DeserializeError| e.annotate("block_body_hash"))?;
+            let operational_cert =
+                OperationalCert::deserialize_as_embedded_group(raw, &mut read_len, len)
+                    .map_err(|e: DeserializeError| e.annotate("operational_cert"))?;
+            let protocol_version =
+                ProtocolVersion::deserialize_as_embedded_group(raw, &mut read_len, len)
+                    .map_err(|e: DeserializeError| e.annotate("protocol_version"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyHeaderBody {
+                block_number,
+                slot,
+                prev_hash,
+                issuer_vkey,
+                v_r_f_vkey,
+                nonce_vrf,
+                leader_vrf,
+                block_body_size,
+                block_body_hash,
+                operational_cert,
+                protocol_version,
+                encodings: Some(ShelleyHeaderBodyEncoding {
+                    len_encoding,
+                    block_number_encoding,
+                    slot_encoding,
+                    prev_hash_encoding,
+                    issuer_vkey_encoding,
+                    v_r_f_vkey_encoding,
+                    block_body_size_encoding,
+                    block_body_hash_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyHeaderBody"))
+    }
+}
+
+impl Serialize for ShelleyProtocolParamUpdate {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    match &self.minfee_a {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.minfee_b {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_block_body_size {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_transaction_size {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.max_block_header_size {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.key_deposit {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.pool_deposit {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.maximum_epoch {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.n_opt {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.pool_pledge_influence {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.expansion_rate {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.treasury_growth_rate {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.decentralization_constant {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.extra_entropy {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.protocol_version {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.min_utxo_value {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == match &self.minfee_a {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.minfee_b {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_block_body_size {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_transaction_size {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.max_block_header_size {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.key_deposit {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.pool_deposit {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.maximum_epoch {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.n_opt {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.pool_pledge_influence {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.expansion_rate {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.treasury_growth_rate {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.decentralization_constant {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.extra_entropy {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.protocol_version {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.min_utxo_value {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    if let Some(field) = &self.minfee_a {
+                        serializer.write_unsigned_integer_sz(
+                            0u64,
+                            fit_sz(
+                                0u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_a_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_a_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                1 => {
+                    if let Some(field) = &self.minfee_b {
+                        serializer.write_unsigned_integer_sz(
+                            1u64,
+                            fit_sz(
+                                1u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_b_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.minfee_b_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                2 => {
+                    if let Some(field) = &self.max_block_body_size {
+                        serializer.write_unsigned_integer_sz(
+                            2u64,
+                            fit_sz(
+                                2u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_body_size_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_body_size_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                3 => {
+                    if let Some(field) = &self.max_transaction_size {
+                        serializer.write_unsigned_integer_sz(
+                            3u64,
+                            fit_sz(
+                                3u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_transaction_size_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_transaction_size_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                4 => {
+                    if let Some(field) = &self.max_block_header_size {
+                        serializer.write_unsigned_integer_sz(
+                            4u64,
+                            fit_sz(
+                                4u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_header_size_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.max_block_header_size_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                5 => {
+                    if let Some(field) = &self.key_deposit {
+                        serializer.write_unsigned_integer_sz(
+                            5u64,
+                            fit_sz(
+                                5u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.key_deposit_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.key_deposit_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                6 => {
+                    if let Some(field) = &self.pool_deposit {
+                        serializer.write_unsigned_integer_sz(
+                            6u64,
+                            fit_sz(
+                                6u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.pool_deposit_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.pool_deposit_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                7 => {
+                    if let Some(field) = &self.maximum_epoch {
+                        serializer.write_unsigned_integer_sz(
+                            7u64,
+                            fit_sz(
+                                7u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.maximum_epoch_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.maximum_epoch_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                8 => {
+                    if let Some(field) = &self.n_opt {
+                        serializer.write_unsigned_integer_sz(
+                            8u64,
+                            fit_sz(
+                                8u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.n_opt_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.n_opt_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                9 => {
+                    if let Some(field) = &self.pool_pledge_influence {
+                        serializer.write_unsigned_integer_sz(
+                            9u64,
+                            fit_sz(
+                                9u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.pool_pledge_influence_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                10 => {
+                    if let Some(field) = &self.expansion_rate {
+                        serializer.write_unsigned_integer_sz(
+                            10u64,
+                            fit_sz(
+                                10u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.expansion_rate_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                11 => {
+                    if let Some(field) = &self.treasury_growth_rate {
+                        serializer.write_unsigned_integer_sz(
+                            11u64,
+                            fit_sz(
+                                11u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.treasury_growth_rate_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                12 => {
+                    if let Some(field) = &self.decentralization_constant {
+                        serializer.write_unsigned_integer_sz(
+                            12u64,
+                            fit_sz(
+                                12u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.decentralization_constant_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                13 => {
+                    if let Some(field) = &self.extra_entropy {
+                        serializer.write_unsigned_integer_sz(
+                            13u64,
+                            fit_sz(
+                                13u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.extra_entropy_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                14 => {
+                    if let Some(field) = &self.protocol_version {
+                        serializer.write_unsigned_integer_sz(
+                            14u64,
+                            fit_sz(
+                                14u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.protocol_version_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                15 => {
+                    if let Some(field) = &self.min_utxo_value {
+                        serializer.write_unsigned_integer_sz(
+                            15u64,
+                            fit_sz(
+                                15u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.min_utxo_value_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_unsigned_integer_sz(
+                            *field,
+                            fit_sz(
+                                *field,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.min_utxo_value_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyProtocolParamUpdate {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut minfee_a_encoding = None;
+            let mut minfee_a_key_encoding = None;
+            let mut minfee_a = None;
+            let mut minfee_b_encoding = None;
+            let mut minfee_b_key_encoding = None;
+            let mut minfee_b = None;
+            let mut max_block_body_size_encoding = None;
+            let mut max_block_body_size_key_encoding = None;
+            let mut max_block_body_size = None;
+            let mut max_transaction_size_encoding = None;
+            let mut max_transaction_size_key_encoding = None;
+            let mut max_transaction_size = None;
+            let mut max_block_header_size_encoding = None;
+            let mut max_block_header_size_key_encoding = None;
+            let mut max_block_header_size = None;
+            let mut key_deposit_encoding = None;
+            let mut key_deposit_key_encoding = None;
+            let mut key_deposit = None;
+            let mut pool_deposit_encoding = None;
+            let mut pool_deposit_key_encoding = None;
+            let mut pool_deposit = None;
+            let mut maximum_epoch_encoding = None;
+            let mut maximum_epoch_key_encoding = None;
+            let mut maximum_epoch = None;
+            let mut n_opt_encoding = None;
+            let mut n_opt_key_encoding = None;
+            let mut n_opt = None;
+            let mut pool_pledge_influence_key_encoding = None;
+            let mut pool_pledge_influence = None;
+            let mut expansion_rate_key_encoding = None;
+            let mut expansion_rate = None;
+            let mut treasury_growth_rate_key_encoding = None;
+            let mut treasury_growth_rate = None;
+            let mut decentralization_constant_key_encoding = None;
+            let mut decentralization_constant = None;
+            let mut extra_entropy_key_encoding = None;
+            let mut extra_entropy = None;
+            let mut protocol_version_key_encoding = None;
+            let mut protocol_version = None;
+            let mut min_utxo_value_encoding = None;
+            let mut min_utxo_value_key_encoding = None;
+            let mut min_utxo_value = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if minfee_a.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_minfee_a, tmp_minfee_a_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("minfee_a"))?;
+                            minfee_a = Some(tmp_minfee_a);
+                            minfee_a_encoding = tmp_minfee_a_encoding;
+                            minfee_a_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (1, key_enc) => {
+                            if minfee_b.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_minfee_b, tmp_minfee_b_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("minfee_b"))?;
+                            minfee_b = Some(tmp_minfee_b);
+                            minfee_b_encoding = tmp_minfee_b_encoding;
+                            minfee_b_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        }
+                        (2, key_enc) => {
+                            if max_block_body_size.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_max_block_body_size, tmp_max_block_body_size_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max_block_body_size"))?;
+                            max_block_body_size = Some(tmp_max_block_body_size);
+                            max_block_body_size_encoding = tmp_max_block_body_size_encoding;
+                            max_block_body_size_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        }
+                        (3, key_enc) => {
+                            if max_transaction_size.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_max_transaction_size, tmp_max_transaction_size_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max_transaction_size"))?;
+                            max_transaction_size = Some(tmp_max_transaction_size);
+                            max_transaction_size_encoding = tmp_max_transaction_size_encoding;
+                            max_transaction_size_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        }
+                        (4, key_enc) => {
+                            if max_block_header_size.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_max_block_header_size, tmp_max_block_header_size_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("max_block_header_size"))?;
+                            max_block_header_size = Some(tmp_max_block_header_size);
+                            max_block_header_size_encoding = tmp_max_block_header_size_encoding;
+                            max_block_header_size_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        }
+                        (5, key_enc) => {
+                            if key_deposit.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (tmp_key_deposit, tmp_key_deposit_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("key_deposit"))?;
+                            key_deposit = Some(tmp_key_deposit);
+                            key_deposit_encoding = tmp_key_deposit_encoding;
+                            key_deposit_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        }
+                        (6, key_enc) => {
+                            if pool_deposit.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let (tmp_pool_deposit, tmp_pool_deposit_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("pool_deposit"))?;
+                            pool_deposit = Some(tmp_pool_deposit);
+                            pool_deposit_encoding = tmp_pool_deposit_encoding;
+                            pool_deposit_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        }
+                        (7, key_enc) => {
+                            if maximum_epoch.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let (tmp_maximum_epoch, tmp_maximum_epoch_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("maximum_epoch"))?;
+                            maximum_epoch = Some(tmp_maximum_epoch);
+                            maximum_epoch_encoding = tmp_maximum_epoch_encoding;
+                            maximum_epoch_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        }
+                        (8, key_enc) => {
+                            if n_opt.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(8)).into());
+                            }
+                            let (tmp_n_opt, tmp_n_opt_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("n_opt"))?;
+                            n_opt = Some(tmp_n_opt);
+                            n_opt_encoding = tmp_n_opt_encoding;
+                            n_opt_key_encoding = Some(key_enc);
+                            orig_deser_order.push(8);
+                        }
+                        (9, key_enc) => {
+                            if pool_pledge_influence.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(9)).into());
+                            }
+                            let tmp_pool_pledge_influence = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Rational::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("pool_pledge_influence"))?;
+                            pool_pledge_influence = Some(tmp_pool_pledge_influence);
+                            pool_pledge_influence_key_encoding = Some(key_enc);
+                            orig_deser_order.push(9);
+                        }
+                        (10, key_enc) => {
+                            if expansion_rate.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(10)).into());
+                            }
+                            let tmp_expansion_rate = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                UnitInterval::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("expansion_rate"))?;
+                            expansion_rate = Some(tmp_expansion_rate);
+                            expansion_rate_key_encoding = Some(key_enc);
+                            orig_deser_order.push(10);
+                        }
+                        (11, key_enc) => {
+                            if treasury_growth_rate.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(11)).into());
+                            }
+                            let tmp_treasury_growth_rate = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                UnitInterval::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("treasury_growth_rate"))?;
+                            treasury_growth_rate = Some(tmp_treasury_growth_rate);
+                            treasury_growth_rate_key_encoding = Some(key_enc);
+                            orig_deser_order.push(11);
+                        }
+                        (12, key_enc) => {
+                            if decentralization_constant.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(12)).into());
+                            }
+                            let tmp_decentralization_constant =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    UnitInterval::deserialize(raw)
+                                })()
+                                .map_err(|e| e.annotate("decentralization_constant"))?;
+                            decentralization_constant = Some(tmp_decentralization_constant);
+                            decentralization_constant_key_encoding = Some(key_enc);
+                            orig_deser_order.push(12);
+                        }
+                        (13, key_enc) => {
+                            if extra_entropy.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(13)).into());
+                            }
+                            let tmp_extra_entropy = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                Nonce::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("extra_entropy"))?;
+                            extra_entropy = Some(tmp_extra_entropy);
+                            extra_entropy_key_encoding = Some(key_enc);
+                            orig_deser_order.push(13);
+                        }
+                        (14, key_enc) => {
+                            if protocol_version.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(14)).into());
+                            }
+                            let tmp_protocol_version = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ProtocolVersionStruct::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("protocol_version"))?;
+                            protocol_version = Some(tmp_protocol_version);
+                            protocol_version_key_encoding = Some(key_enc);
+                            orig_deser_order.push(14);
+                        }
+                        (15, key_enc) => {
+                            if min_utxo_value.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(15)).into());
+                            }
+                            let (tmp_min_utxo_value, tmp_min_utxo_value_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.unsigned_integer_sz()
+                                        .map(|(x, enc)| (x, Some(enc)))
+                                        .map_err(Into::<DeserializeError>::into)
+                                })()
+                                .map_err(|e| e.annotate("min_utxo_value"))?;
+                            min_utxo_value = Some(tmp_min_utxo_value);
+                            min_utxo_value_encoding = tmp_min_utxo_value_encoding;
+                            min_utxo_value_key_encoding = Some(key_enc);
+                            orig_deser_order.push(15);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                minfee_a,
+                minfee_b,
+                max_block_body_size,
+                max_transaction_size,
+                max_block_header_size,
+                key_deposit,
+                pool_deposit,
+                maximum_epoch,
+                n_opt,
+                pool_pledge_influence,
+                expansion_rate,
+                treasury_growth_rate,
+                decentralization_constant,
+                extra_entropy,
+                protocol_version,
+                min_utxo_value,
+                encodings: Some(ShelleyProtocolParamUpdateEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    minfee_a_key_encoding,
+                    minfee_a_encoding,
+                    minfee_b_key_encoding,
+                    minfee_b_encoding,
+                    max_block_body_size_key_encoding,
+                    max_block_body_size_encoding,
+                    max_transaction_size_key_encoding,
+                    max_transaction_size_encoding,
+                    max_block_header_size_key_encoding,
+                    max_block_header_size_encoding,
+                    key_deposit_key_encoding,
+                    key_deposit_encoding,
+                    pool_deposit_key_encoding,
+                    pool_deposit_encoding,
+                    maximum_epoch_key_encoding,
+                    maximum_epoch_encoding,
+                    n_opt_key_encoding,
+                    n_opt_encoding,
+                    pool_pledge_influence_key_encoding,
+                    expansion_rate_key_encoding,
+                    treasury_growth_rate_key_encoding,
+                    decentralization_constant_key_encoding,
+                    extra_entropy_key_encoding,
+                    protocol_version_key_encoding,
+                    min_utxo_value_key_encoding,
+                    min_utxo_value_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyProtocolParamUpdate"))
+    }
+}
+
+impl Serialize for ShelleyTransaction {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(3, force_canonical),
+        )?;
+        self.body.serialize(serializer, force_canonical)?;
+        self.witness_set.serialize(serializer, force_canonical)?;
+        match &self.metadata {
+            Some(x) => x.serialize(serializer, force_canonical),
+            None => serializer.write_special(cbor_event::Special::Null),
+        }?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyTransaction {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let body = ShelleyTransactionBody::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("body"))?;
+            let witness_set = ShelleyTransactionWitnessSet::deserialize(raw)
+                .map_err(|e: DeserializeError| e.annotate("witness_set"))?;
+            let metadata = (|| -> Result<_, DeserializeError> {
+                Ok(match raw.cbor_type()? != cbor_event::Type::Special {
+                    true => Some(Metadata::deserialize(raw)?),
+                    false => {
+                        if raw.special()? != cbor_event::Special::Null {
+                            return Err(DeserializeFailure::ExpectedNull.into());
+                        }
+                        None
+                    }
+                })
+            })()
+            .map_err(|e| e.annotate("metadata"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyTransaction {
+                body,
+                witness_set,
+                metadata,
+                encodings: Some(ShelleyTransactionEncoding { len_encoding }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyTransaction"))
+    }
+}
+
+impl Serialize for ShelleyTransactionBody {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    4 + match &self.certs {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.withdrawals {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.update {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.auxiliary_data_hash {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == 4 + match &self.certs {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.withdrawals {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.update {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.auxiliary_data_hash {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    serializer.write_unsigned_integer_sz(
+                        0u64,
+                        fit_sz(
+                            0u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.inputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.inputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.inputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.inputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.inputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                1 => {
+                    serializer.write_unsigned_integer_sz(
+                        1u64,
+                        fit_sz(
+                            1u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.outputs_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_array_sz(
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.outputs_encoding)
+                            .unwrap_or_default()
+                            .to_len_sz(self.outputs.len() as u64, force_canonical),
+                    )?;
+                    for element in self.outputs.iter() {
+                        element.serialize(serializer, force_canonical)?;
+                    }
+                    self.encodings
+                        .as_ref()
+                        .map(|encs| encs.outputs_encoding)
+                        .unwrap_or_default()
+                        .end(serializer, force_canonical)?;
+                }
+                2 => {
+                    serializer.write_unsigned_integer_sz(
+                        2u64,
+                        fit_sz(
+                            2u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_unsigned_integer_sz(
+                        self.fee,
+                        fit_sz(
+                            self.fee,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.fee_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                }
+                3 => {
+                    serializer.write_unsigned_integer_sz(
+                        3u64,
+                        fit_sz(
+                            3u64,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.ttl_key_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                    serializer.write_unsigned_integer_sz(
+                        self.ttl,
+                        fit_sz(
+                            self.ttl,
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.ttl_encoding)
+                                .unwrap_or_default(),
+                            force_canonical,
+                        ),
+                    )?;
+                }
+                4 => {
+                    if let Some(field) = &self.certs {
+                        serializer.write_unsigned_integer_sz(
+                            4u64,
+                            fit_sz(
+                                4u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.certs_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.certs_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.certs_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                5 => {
+                    if let Some(field) = &self.withdrawals {
+                        serializer.write_unsigned_integer_sz(
+                            5u64,
+                            fit_sz(
+                                5u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.withdrawals_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_map_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.withdrawals_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        let mut key_order = field
+                            .iter()
+                            .map(|(k, v)| {
+                                let mut buf = cbor_event::se::Serializer::new_vec();
+                                k.serialize(&mut buf, force_canonical)?;
+                                Ok((buf.finalize(), k, v))
+                            })
+                            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+                        if force_canonical {
+                            key_order.sort_by(
+                                |(lhs_bytes, _, _), (rhs_bytes, _, _)| match lhs_bytes
+                                    .len()
+                                    .cmp(&rhs_bytes.len())
+                                {
+                                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                                    diff_ord => diff_ord,
+                                },
+                            );
+                        }
+                        for (key_bytes, key, value) in key_order {
+                            serializer.write_raw_bytes(&key_bytes)?;
+                            let withdrawals_value_encoding = self
+                                .encodings
+                                .as_ref()
+                                .and_then(|encs| encs.withdrawals_value_encodings.get(key))
+                                .cloned()
+                                .unwrap_or_default();
+                            serializer.write_unsigned_integer_sz(
+                                *value,
+                                fit_sz(*value, withdrawals_value_encoding, force_canonical),
+                            )?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.withdrawals_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                6 => {
+                    if let Some(field) = &self.update {
+                        serializer.write_unsigned_integer_sz(
+                            6u64,
+                            fit_sz(
+                                6u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.update_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        field.serialize(serializer, force_canonical)?;
+                    }
+                }
+                7 => {
+                    if let Some(field) = &self.auxiliary_data_hash {
+                        serializer.write_unsigned_integer_sz(
+                            7u64,
+                            fit_sz(
+                                7u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.auxiliary_data_hash_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_bytes_sz(
+                            &field.to_raw_bytes(),
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.auxiliary_data_hash_encoding.clone())
+                                .unwrap_or_default()
+                                .to_str_len_sz(field.to_raw_bytes().len() as u64, force_canonical),
+                        )?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyTransactionBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(4)?;
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut inputs_encoding = LenEncoding::default();
+            let mut inputs_key_encoding = None;
+            let mut inputs = None;
+            let mut outputs_encoding = LenEncoding::default();
+            let mut outputs_key_encoding = None;
+            let mut outputs = None;
+            let mut fee_encoding = None;
+            let mut fee_key_encoding = None;
+            let mut fee = None;
+            let mut ttl_encoding = None;
+            let mut ttl_key_encoding = None;
+            let mut ttl = None;
+            let mut certs_encoding = LenEncoding::default();
+            let mut certs_key_encoding = None;
+            let mut certs = None;
+            let mut withdrawals_encoding = LenEncoding::default();
+            let mut withdrawals_value_encodings = BTreeMap::new();
+            let mut withdrawals_key_encoding = None;
+            let mut withdrawals = None;
+            let mut update_key_encoding = None;
+            let mut update = None;
+            let mut auxiliary_data_hash_encoding = StringEncoding::default();
+            let mut auxiliary_data_hash_key_encoding = None;
+            let mut auxiliary_data_hash = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if inputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_inputs, tmp_inputs_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    let mut inputs_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let inputs_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (inputs_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        inputs_arr.push(TransactionInput::deserialize(raw)?);
+                                    }
+                                    Ok((inputs_arr, inputs_encoding))
+                                })()
+                                .map_err(|e| e.annotate("inputs"))?;
+                            inputs = Some(tmp_inputs);
+                            inputs_encoding = tmp_inputs_encoding;
+                            inputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (1, key_enc) => {
+                            if outputs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_outputs, tmp_outputs_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    let mut outputs_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let outputs_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (outputs_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        outputs_arr
+                                            .push(ShelleyTransactionOutput::deserialize(raw)?);
+                                    }
+                                    Ok((outputs_arr, outputs_encoding))
+                                })()
+                                .map_err(|e| e.annotate("outputs"))?;
+                            outputs = Some(tmp_outputs);
+                            outputs_encoding = tmp_outputs_encoding;
+                            outputs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        }
+                        (2, key_enc) => {
+                            if fee.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_fee, tmp_fee_encoding) = raw
+                                .unsigned_integer_sz()
+                                .map(|(x, enc)| (x, Some(enc)))
+                                .map_err(Into::<DeserializeError>::into)
+                                .map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            fee = Some(tmp_fee);
+                            fee_encoding = tmp_fee_encoding;
+                            fee_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        }
+                        (3, key_enc) => {
+                            if ttl.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
+                            }
+                            let (tmp_ttl, tmp_ttl_encoding) = raw
+                                .unsigned_integer_sz()
+                                .map(|(x, enc)| (x, Some(enc)))
+                                .map_err(Into::<DeserializeError>::into)
+                                .map_err(|e: DeserializeError| e.annotate("ttl"))?;
+                            ttl = Some(tmp_ttl);
+                            ttl_encoding = tmp_ttl_encoding;
+                            ttl_key_encoding = Some(key_enc);
+                            orig_deser_order.push(3);
+                        }
+                        (4, key_enc) => {
+                            if certs.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
+                            }
+                            let (tmp_certs, tmp_certs_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut certs_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let certs_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (certs_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        certs_arr.push(Certificate::deserialize(raw)?);
+                                    }
+                                    Ok((certs_arr, certs_encoding))
+                                })()
+                                .map_err(|e| e.annotate("certs"))?;
+                            certs = Some(tmp_certs);
+                            certs_encoding = tmp_certs_encoding;
+                            certs_key_encoding = Some(key_enc);
+                            orig_deser_order.push(4);
+                        }
+                        (5, key_enc) => {
+                            if withdrawals.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
+                            }
+                            let (
+                                tmp_withdrawals,
+                                tmp_withdrawals_encoding,
+                                tmp_withdrawals_value_encodings,
+                            ) = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                let mut withdrawals_table = OrderedHashMap::new();
+                                let withdrawals_len = raw.map_sz()?;
+                                let withdrawals_encoding = withdrawals_len.into();
+                                let mut withdrawals_value_encodings = BTreeMap::new();
+                                while match withdrawals_len {
+                                    cbor_event::LenSz::Len(n, _) => {
+                                        (withdrawals_table.len() as u64) < n
+                                    }
+                                    cbor_event::LenSz::Indefinite => true,
+                                } {
+                                    if raw.cbor_type()? == cbor_event::Type::Special {
+                                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                        break;
+                                    }
+                                    let withdrawals_key = RewardAccount::deserialize(raw)?;
+                                    let (withdrawals_value, withdrawals_value_encoding) =
+                                        raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc)))?;
+                                    if withdrawals_table
+                                        .insert(withdrawals_key.clone(), withdrawals_value)
+                                        .is_some()
+                                    {
+                                        return Err(DeserializeFailure::DuplicateKey(Key::Str(
+                                            String::from("some complicated/unsupported type"),
+                                        ))
+                                        .into());
+                                    }
+                                    withdrawals_value_encodings
+                                        .insert(withdrawals_key, withdrawals_value_encoding);
+                                }
+                                Ok((
+                                    withdrawals_table,
+                                    withdrawals_encoding,
+                                    withdrawals_value_encodings,
+                                ))
+                            })()
+                            .map_err(|e| e.annotate("withdrawals"))?;
+                            withdrawals = Some(tmp_withdrawals);
+                            withdrawals_encoding = tmp_withdrawals_encoding;
+                            withdrawals_value_encodings = tmp_withdrawals_value_encodings;
+                            withdrawals_key_encoding = Some(key_enc);
+                            orig_deser_order.push(5);
+                        }
+                        (6, key_enc) => {
+                            if update.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(6)).into());
+                            }
+                            let tmp_update = (|| -> Result<_, DeserializeError> {
+                                read_len.read_elems(1)?;
+                                ShelleyUpdate::deserialize(raw)
+                            })()
+                            .map_err(|e| e.annotate("update"))?;
+                            update = Some(tmp_update);
+                            update_key_encoding = Some(key_enc);
+                            orig_deser_order.push(6);
+                        }
+                        (7, key_enc) => {
+                            if auxiliary_data_hash.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(7)).into());
+                            }
+                            let (tmp_auxiliary_data_hash, tmp_auxiliary_data_hash_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    raw.bytes_sz()
+                                        .map_err(Into::<DeserializeError>::into)
+                                        .and_then(|(bytes, enc)| {
+                                            AuxiliaryDataHash::from_raw_bytes(&bytes)
+                                                .map(|bytes| (bytes, StringEncoding::from(enc)))
+                                                .map_err(|e| {
+                                                    DeserializeFailure::InvalidStructure(Box::new(
+                                                        e,
+                                                    ))
+                                                    .into()
+                                                })
+                                        })
+                                })()
+                                .map_err(|e| e.annotate("auxiliary_data_hash"))?;
+                            auxiliary_data_hash = Some(tmp_auxiliary_data_hash);
+                            auxiliary_data_hash_encoding = tmp_auxiliary_data_hash_encoding;
+                            auxiliary_data_hash_key_encoding = Some(key_enc);
+                            orig_deser_order.push(7);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            let inputs = match inputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(0)).into()),
+            };
+            let outputs = match outputs {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(1)).into()),
+            };
+            let fee = match fee {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(2)).into()),
+            };
+            let ttl = match ttl {
+                Some(x) => x,
+                None => return Err(DeserializeFailure::MandatoryFieldMissing(Key::Uint(3)).into()),
+            };
+            read_len.finish()?;
+            Ok(Self {
+                inputs,
+                outputs,
+                fee,
+                ttl,
+                certs,
+                withdrawals,
+                update,
+                auxiliary_data_hash,
+                encodings: Some(ShelleyTransactionBodyEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    inputs_key_encoding,
+                    inputs_encoding,
+                    outputs_key_encoding,
+                    outputs_encoding,
+                    fee_key_encoding,
+                    fee_encoding,
+                    ttl_key_encoding,
+                    ttl_encoding,
+                    certs_key_encoding,
+                    certs_encoding,
+                    withdrawals_key_encoding,
+                    withdrawals_encoding,
+                    withdrawals_value_encodings,
+                    update_key_encoding,
+                    auxiliary_data_hash_key_encoding,
+                    auxiliary_data_hash_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyTransactionBody"))
+    }
+}
+
+impl Serialize for ShelleyTransactionOutput {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        self.address.serialize(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(
+            self.amount,
+            fit_sz(
+                self.amount,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.amount_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyTransactionOutput {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let address =
+                Address::deserialize(raw).map_err(|e: DeserializeError| e.annotate("address"))?;
+            let (amount, amount_encoding) = raw
+                .unsigned_integer_sz()
+                .map(|(x, enc)| (x, Some(enc)))
+                .map_err(Into::<DeserializeError>::into)
+                .map_err(|e: DeserializeError| e.annotate("amount"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyTransactionOutput {
+                address,
+                amount,
+                encodings: Some(ShelleyTransactionOutputEncoding {
+                    len_encoding,
+                    amount_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyTransactionOutput"))
+    }
+}
+
+impl Serialize for ShelleyTransactionWitnessSet {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    match &self.vkeywitnesses {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.native_scripts {
+                        Some(_) => 1,
+                        None => 0,
+                    } + match &self.bootstrap_witnesses {
+                        Some(_) => 1,
+                        None => 0,
+                    },
+                    force_canonical,
+                ),
+        )?;
+        let deser_order = self
+            .encodings
+            .as_ref()
+            .filter(|encs| {
+                !force_canonical
+                    && encs.orig_deser_order.len()
+                        == match &self.vkeywitnesses {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.native_scripts {
+                            Some(_) => 1,
+                            None => 0,
+                        } + match &self.bootstrap_witnesses {
+                            Some(_) => 1,
+                            None => 0,
+                        }
+            })
+            .map(|encs| encs.orig_deser_order.clone())
+            .unwrap_or_else(|| vec![0, 1, 2]);
+        for field_index in deser_order {
+            match field_index {
+                0 => {
+                    if let Some(field) = &self.vkeywitnesses {
+                        serializer.write_unsigned_integer_sz(
+                            0u64,
+                            fit_sz(
+                                0u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.vkeywitnesses_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.vkeywitnesses_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.vkeywitnesses_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                1 => {
+                    if let Some(field) = &self.native_scripts {
+                        serializer.write_unsigned_integer_sz(
+                            1u64,
+                            fit_sz(
+                                1u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.native_scripts_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.native_scripts_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.native_scripts_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                2 => {
+                    if let Some(field) = &self.bootstrap_witnesses {
+                        serializer.write_unsigned_integer_sz(
+                            2u64,
+                            fit_sz(
+                                2u64,
+                                self.encodings
+                                    .as_ref()
+                                    .map(|encs| encs.bootstrap_witnesses_key_encoding)
+                                    .unwrap_or_default(),
+                                force_canonical,
+                            ),
+                        )?;
+                        serializer.write_array_sz(
+                            self.encodings
+                                .as_ref()
+                                .map(|encs| encs.bootstrap_witnesses_encoding)
+                                .unwrap_or_default()
+                                .to_len_sz(field.len() as u64, force_canonical),
+                        )?;
+                        for element in field.iter() {
+                            element.serialize(serializer, force_canonical)?;
+                        }
+                        self.encodings
+                            .as_ref()
+                            .map(|encs| encs.bootstrap_witnesses_encoding)
+                            .unwrap_or_default()
+                            .end(serializer, force_canonical)?;
+                    }
+                }
+                _ => unreachable!(),
+            };
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyTransactionWitnessSet {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.map_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        (|| -> Result<_, DeserializeError> {
+            let mut orig_deser_order = Vec::new();
+            let mut vkeywitnesses_encoding = LenEncoding::default();
+            let mut vkeywitnesses_key_encoding = None;
+            let mut vkeywitnesses = None;
+            let mut native_scripts_encoding = LenEncoding::default();
+            let mut native_scripts_key_encoding = None;
+            let mut native_scripts = None;
+            let mut bootstrap_witnesses_encoding = LenEncoding::default();
+            let mut bootstrap_witnesses_key_encoding = None;
+            let mut bootstrap_witnesses = None;
+            let mut read = 0;
+            while match len {
+                cbor_event::LenSz::Len(n, _) => read < n,
+                cbor_event::LenSz::Indefinite => true,
+            } {
+                match raw.cbor_type()? {
+                    cbor_event::Type::UnsignedInteger => match raw.unsigned_integer_sz()? {
+                        (0, key_enc) => {
+                            if vkeywitnesses.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
+                            }
+                            let (tmp_vkeywitnesses, tmp_vkeywitnesses_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut vkeywitnesses_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let vkeywitnesses_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (vkeywitnesses_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        vkeywitnesses_arr.push(Vkeywitness::deserialize(raw)?);
+                                    }
+                                    Ok((vkeywitnesses_arr, vkeywitnesses_encoding))
+                                })()
+                                .map_err(|e| e.annotate("vkeywitnesses"))?;
+                            vkeywitnesses = Some(tmp_vkeywitnesses);
+                            vkeywitnesses_encoding = tmp_vkeywitnesses_encoding;
+                            vkeywitnesses_key_encoding = Some(key_enc);
+                            orig_deser_order.push(0);
+                        }
+                        (1, key_enc) => {
+                            if native_scripts.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
+                            }
+                            let (tmp_native_scripts, tmp_native_scripts_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut native_scripts_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let native_scripts_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (native_scripts_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        native_scripts_arr.push(MultisigScript::deserialize(raw)?);
+                                    }
+                                    Ok((native_scripts_arr, native_scripts_encoding))
+                                })()
+                                .map_err(|e| e.annotate("native_scripts"))?;
+                            native_scripts = Some(tmp_native_scripts);
+                            native_scripts_encoding = tmp_native_scripts_encoding;
+                            native_scripts_key_encoding = Some(key_enc);
+                            orig_deser_order.push(1);
+                        }
+                        (2, key_enc) => {
+                            if bootstrap_witnesses.is_some() {
+                                return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                            }
+                            let (tmp_bootstrap_witnesses, tmp_bootstrap_witnesses_encoding) =
+                                (|| -> Result<_, DeserializeError> {
+                                    read_len.read_elems(1)?;
+                                    let mut bootstrap_witnesses_arr = Vec::new();
+                                    let len = raw.array_sz()?;
+                                    let bootstrap_witnesses_encoding = len.into();
+                                    while match len {
+                                        cbor_event::LenSz::Len(n, _) => {
+                                            (bootstrap_witnesses_arr.len() as u64) < n
+                                        }
+                                        cbor_event::LenSz::Indefinite => true,
+                                    } {
+                                        if raw.cbor_type()? == cbor_event::Type::Special {
+                                            assert_eq!(raw.special()?, cbor_event::Special::Break);
+                                            break;
+                                        }
+                                        bootstrap_witnesses_arr
+                                            .push(BootstrapWitness::deserialize(raw)?);
+                                    }
+                                    Ok((bootstrap_witnesses_arr, bootstrap_witnesses_encoding))
+                                })()
+                                .map_err(|e| e.annotate("bootstrap_witnesses"))?;
+                            bootstrap_witnesses = Some(tmp_bootstrap_witnesses);
+                            bootstrap_witnesses_encoding = tmp_bootstrap_witnesses_encoding;
+                            bootstrap_witnesses_key_encoding = Some(key_enc);
+                            orig_deser_order.push(2);
+                        }
+                        (unknown_key, _enc) => {
+                            return Err(
+                                DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()
+                            )
+                        }
+                    },
+                    cbor_event::Type::Text => {
+                        return Err(DeserializeFailure::UnknownKey(Key::Str(raw.text()?)).into())
+                    }
+                    cbor_event::Type::Special => match len {
+                        cbor_event::LenSz::Len(_, _) => {
+                            return Err(DeserializeFailure::BreakInDefiniteLen.into())
+                        }
+                        cbor_event::LenSz::Indefinite => match raw.special()? {
+                            cbor_event::Special::Break => break,
+                            _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                        },
+                    },
+                    other_type => {
+                        return Err(DeserializeFailure::UnexpectedKeyType(other_type).into())
+                    }
+                }
+                read += 1;
+            }
+            read_len.finish()?;
+            Ok(Self {
+                vkeywitnesses,
+                native_scripts,
+                bootstrap_witnesses,
+                encodings: Some(ShelleyTransactionWitnessSetEncoding {
+                    len_encoding,
+                    orig_deser_order,
+                    vkeywitnesses_key_encoding,
+                    vkeywitnesses_encoding,
+                    native_scripts_key_encoding,
+                    native_scripts_encoding,
+                    bootstrap_witnesses_key_encoding,
+                    bootstrap_witnesses_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyTransactionWitnessSet"))
+    }
+}
+
+impl Serialize for ShelleyUpdate {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+        force_canonical: bool,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.len_encoding)
+                .unwrap_or_default()
+                .to_len_sz(2, force_canonical),
+        )?;
+        serializer.write_map_sz(
+            self.encodings
+                .as_ref()
+                .map(|encs| encs.shelley_proposed_protocol_parameter_updates_encoding)
+                .unwrap_or_default()
+                .to_len_sz(
+                    self.shelley_proposed_protocol_parameter_updates.len() as u64,
+                    force_canonical,
+                ),
+        )?;
+        let mut key_order = self
+            .shelley_proposed_protocol_parameter_updates
+            .iter()
+            .map(|(k, v)| {
+                let mut buf = cbor_event::se::Serializer::new_vec();
+                let shelley_proposed_protocol_parameter_updates_key_encoding = self
+                    .encodings
+                    .as_ref()
+                    .and_then(|encs| {
+                        encs.shelley_proposed_protocol_parameter_updates_key_encodings
+                            .get(k)
+                    })
+                    .cloned()
+                    .unwrap_or_default();
+                buf.write_bytes_sz(
+                    &k.to_raw_bytes(),
+                    shelley_proposed_protocol_parameter_updates_key_encoding
+                        .to_str_len_sz(k.to_raw_bytes().len() as u64, force_canonical),
+                )?;
+                Ok((buf.finalize(), k, v))
+            })
+            .collect::<Result<Vec<(Vec<u8>, &_, &_)>, cbor_event::Error>>()?;
+        if force_canonical {
+            key_order.sort_by(|(lhs_bytes, _, _), (rhs_bytes, _, _)| {
+                match lhs_bytes.len().cmp(&rhs_bytes.len()) {
+                    std::cmp::Ordering::Equal => lhs_bytes.cmp(rhs_bytes),
+                    diff_ord => diff_ord,
+                }
+            });
+        }
+        for (key_bytes, _key, value) in key_order {
+            serializer.write_raw_bytes(&key_bytes)?;
+            value.serialize(serializer, force_canonical)?;
+        }
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.shelley_proposed_protocol_parameter_updates_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)?;
+        serializer.write_unsigned_integer_sz(
+            self.epoch,
+            fit_sz(
+                self.epoch,
+                self.encodings
+                    .as_ref()
+                    .map(|encs| encs.epoch_encoding)
+                    .unwrap_or_default(),
+                force_canonical,
+            ),
+        )?;
+        self.encodings
+            .as_ref()
+            .map(|encs| encs.len_encoding)
+            .unwrap_or_default()
+            .end(serializer, force_canonical)
+    }
+}
+
+impl Deserialize for ShelleyUpdate {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array_sz()?;
+        let len_encoding: LenEncoding = len.into();
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(2)?;
+        read_len.finish()?;
+        (|| -> Result<_, DeserializeError> {
+            let (
+                shelley_proposed_protocol_parameter_updates,
+                shelley_proposed_protocol_parameter_updates_encoding,
+                shelley_proposed_protocol_parameter_updates_key_encodings,
+            ) = (|| -> Result<_, DeserializeError> {
+                let mut shelley_proposed_protocol_parameter_updates_table = OrderedHashMap::new();
+                let shelley_proposed_protocol_parameter_updates_len = raw.map_sz()?;
+                let shelley_proposed_protocol_parameter_updates_encoding =
+                    shelley_proposed_protocol_parameter_updates_len.into();
+                let mut shelley_proposed_protocol_parameter_updates_key_encodings = BTreeMap::new();
+                while match shelley_proposed_protocol_parameter_updates_len {
+                    cbor_event::LenSz::Len(n, _) => {
+                        (shelley_proposed_protocol_parameter_updates_table.len() as u64) < n
+                    }
+                    cbor_event::LenSz::Indefinite => true,
+                } {
+                    if raw.cbor_type()? == cbor_event::Type::Special {
+                        assert_eq!(raw.special()?, cbor_event::Special::Break);
+                        break;
+                    }
+                    let (
+                        shelley_proposed_protocol_parameter_updates_key,
+                        shelley_proposed_protocol_parameter_updates_key_encoding,
+                    ) = raw
+                        .bytes_sz()
+                        .map_err(Into::<DeserializeError>::into)
+                        .and_then(|(bytes, enc)| {
+                            GenesisHash::from_raw_bytes(&bytes)
+                                .map(|bytes| (bytes, StringEncoding::from(enc)))
+                                .map_err(|e| {
+                                    DeserializeFailure::InvalidStructure(Box::new(e)).into()
+                                })
+                        })?;
+                    let shelley_proposed_protocol_parameter_updates_value =
+                        ShelleyProtocolParamUpdate::deserialize(raw)?;
+                    if shelley_proposed_protocol_parameter_updates_table
+                        .insert(
+                            shelley_proposed_protocol_parameter_updates_key.clone(),
+                            shelley_proposed_protocol_parameter_updates_value,
+                        )
+                        .is_some()
+                    {
+                        return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from(
+                            "some complicated/unsupported type",
+                        )))
+                        .into());
+                    }
+                    shelley_proposed_protocol_parameter_updates_key_encodings.insert(
+                        shelley_proposed_protocol_parameter_updates_key.clone(),
+                        shelley_proposed_protocol_parameter_updates_key_encoding,
+                    );
+                }
+                Ok((
+                    shelley_proposed_protocol_parameter_updates_table,
+                    shelley_proposed_protocol_parameter_updates_encoding,
+                    shelley_proposed_protocol_parameter_updates_key_encodings,
+                ))
+            })()
+            .map_err(|e| e.annotate("shelley_proposed_protocol_parameter_updates"))?;
+            let (epoch, epoch_encoding) = raw
+                .unsigned_integer_sz()
+                .map(|(x, enc)| (x, Some(enc)))
+                .map_err(Into::<DeserializeError>::into)
+                .map_err(|e: DeserializeError| e.annotate("epoch"))?;
+            match len {
+                cbor_event::LenSz::Len(_, _) => (),
+                cbor_event::LenSz::Indefinite => match raw.special()? {
+                    cbor_event::Special::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ShelleyUpdate {
+                shelley_proposed_protocol_parameter_updates,
+                epoch,
+                encodings: Some(ShelleyUpdateEncoding {
+                    len_encoding,
+                    shelley_proposed_protocol_parameter_updates_encoding,
+                    shelley_proposed_protocol_parameter_updates_key_encodings,
+                    epoch_encoding,
+                }),
+            })
+        })()
+        .map_err(|e| e.annotate("ShelleyUpdate"))
+    }
+}

--- a/multi-era/wasm/Cargo.toml
+++ b/multi-era/wasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cml-multi-era-wasm"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+cml-chain = { path = "../../chain/rust" }
+cml-chain-wasm = { path = "../../chain/wasm" }
+cml-crypto-wasm = { path = "../../crypto/wasm" }
+cml-core = { path = "../../core/rust" }
+cml-multi-era = { path = "../rust" }
+cbor_event = "2.4.0"
+linked-hash-map = "0.5.3"
+serde_json = "1.0.57"
+serde-wasm-bindgen = "0.4.5"
+wasm-bindgen = { version = "0.2", features=["serde-serialize"] }

--- a/multi-era/wasm/json-gen/Cargo.toml
+++ b/multi-era/wasm/json-gen/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cml-multi-era-json-schema-gen"
+version = "0.0.1"
+edition = "2018"
+
+
+[dependencies]
+serde_json = "1.0.57"
+schemars = "0.8.8"
+cml-multi-era = { path = "../../rust" }

--- a/multi-era/wasm/json-gen/src/main.rs
+++ b/multi-era/wasm/json-gen/src/main.rs
@@ -1,0 +1,46 @@
+fn main() {
+    macro_rules! gen_json_schema {
+        ($name:ty) => {
+            let dest_path =
+                std::path::Path::new(&"schemas").join(&format!("{}.json", stringify!($name)));
+            std::fs::write(
+                &dest_path,
+                serde_json::to_string_pretty(&schemars::schema_for!($name)).unwrap(),
+            )
+            .unwrap();
+        };
+    }
+    let schema_path = std::path::Path::new(&"schemas");
+    if !schema_path.exists() {
+        std::fs::create_dir(schema_path).unwrap();
+    }
+    // allegra.rs
+    gen_json_schema!(cml_multi_era::allegra::AllegraAuxiliaryData);
+    gen_json_schema!(cml_multi_era::allegra::AllegraTransactionBody);
+    gen_json_schema!(cml_multi_era::allegra::AllegraTransactionWitnessSet);
+    // alonzo.rs
+    gen_json_schema!(cml_multi_era::alonzo::AlonzoAuxiliaryData);
+    gen_json_schema!(cml_multi_era::alonzo::AlonzoCostmdls);
+    gen_json_schema!(cml_multi_era::alonzo::AlonzoOnlyAuxData);
+    gen_json_schema!(cml_multi_era::alonzo::AlonzoProtocolParamUpdate);
+    gen_json_schema!(cml_multi_era::alonzo::AlonzoTransactionBody);
+    gen_json_schema!(cml_multi_era::alonzo::AlonzoTransactionWitnessSet);
+    gen_json_schema!(cml_multi_era::alonzo::AlonzoUpdate);
+    // lib.rs
+    gen_json_schema!(cml_multi_era::Int);
+    // mary.rs
+    gen_json_schema!(cml_multi_era::mary::MaryTransactionBody);
+    // shelley.rs
+    gen_json_schema!(cml_multi_era::shelley::MultisigAll);
+    gen_json_schema!(cml_multi_era::shelley::MultisigAny);
+    gen_json_schema!(cml_multi_era::shelley::MultisigNOfK);
+    gen_json_schema!(cml_multi_era::shelley::MultisigPubkey);
+    gen_json_schema!(cml_multi_era::shelley::MultisigScript);
+    gen_json_schema!(cml_multi_era::shelley::ShelleyHeader);
+    gen_json_schema!(cml_multi_era::shelley::ShelleyHeaderBody);
+    gen_json_schema!(cml_multi_era::shelley::ShelleyProtocolParamUpdate);
+    gen_json_schema!(cml_multi_era::shelley::ShelleyTransactionBody);
+    gen_json_schema!(cml_multi_era::shelley::ShelleyTransactionOutput);
+    gen_json_schema!(cml_multi_era::shelley::ShelleyTransactionWitnessSet);
+    gen_json_schema!(cml_multi_era::shelley::ShelleyUpdate);
+}

--- a/multi-era/wasm/src/allegra/mod.rs
+++ b/multi-era/wasm/src/allegra/mod.rs
@@ -1,0 +1,482 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_chain_wasm::assets::Coin;
+use cml_chain_wasm::auxdata::{ShelleyAuxData, ShelleyMaAuxData};
+use cml_crypto_wasm::AuxiliaryDataHash;
+use cml_chain_wasm::Withdrawals;
+use crate::shelley::{ShelleyHeader, ShelleyUpdate};
+use cml_chain_wasm::{
+    BootstrapWitnessList, NativeScriptList, VkeywitnessList, TransactionInputList, CertificateList, 
+};
+use crate::{
+    AllegraTransactionBodyList, AllegraTransactionWitnessSetList,
+    MapTransactionIndexToAllegraAuxiliaryData, ShelleyTransactionOutputList,
+};
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AllegraAuxiliaryData(cml_multi_era::allegra::AllegraAuxiliaryData);
+
+#[wasm_bindgen]
+impl AllegraAuxiliaryData {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraAuxiliaryData, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AllegraAuxiliaryData, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_shelley_aux_data(shelley_aux_data: &ShelleyAuxData) -> Self {
+        Self(
+            cml_multi_era::allegra::AllegraAuxiliaryData::new_shelley_aux_data(
+                shelley_aux_data.clone().into(),
+            ),
+        )
+    }
+
+    pub fn new_shelley_ma_aux_data(shelley_ma_aux_data: &ShelleyMaAuxData) -> Self {
+        Self(
+            cml_multi_era::allegra::AllegraAuxiliaryData::new_shelley_ma_aux_data(
+                shelley_ma_aux_data.clone().into(),
+            ),
+        )
+    }
+
+    pub fn kind(&self) -> AllegraAuxiliaryDataKind {
+        match &self.0 {
+            cml_multi_era::allegra::AllegraAuxiliaryData::ShelleyAuxData(_) => {
+                AllegraAuxiliaryDataKind::ShelleyAuxData
+            }
+            cml_multi_era::allegra::AllegraAuxiliaryData::ShelleyMaAuxData(_) => {
+                AllegraAuxiliaryDataKind::ShelleyMaAuxData
+            }
+        }
+    }
+
+    pub fn as_shelley_aux_data(&self) -> Option<ShelleyAuxData> {
+        match &self.0 {
+            cml_multi_era::allegra::AllegraAuxiliaryData::ShelleyAuxData(shelley_aux_data) => {
+                Some(shelley_aux_data.clone().into())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_shelley_ma_aux_data(&self) -> Option<ShelleyMaAuxData> {
+        match &self.0 {
+            cml_multi_era::allegra::AllegraAuxiliaryData::ShelleyMaAuxData(shelley_ma_aux_data) => {
+                Some(shelley_ma_aux_data.clone().into())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<cml_multi_era::allegra::AllegraAuxiliaryData> for AllegraAuxiliaryData {
+    fn from(native: cml_multi_era::allegra::AllegraAuxiliaryData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AllegraAuxiliaryData> for cml_multi_era::allegra::AllegraAuxiliaryData {
+    fn from(wasm: AllegraAuxiliaryData) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::allegra::AllegraAuxiliaryData> for AllegraAuxiliaryData {
+    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraAuxiliaryData {
+        &self.0
+    }
+}
+
+#[wasm_bindgen]
+pub enum AllegraAuxiliaryDataKind {
+    ShelleyAuxData,
+    ShelleyMaAuxData,
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AllegraBlock(cml_multi_era::allegra::AllegraBlock);
+
+#[wasm_bindgen]
+impl AllegraBlock {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraBlock, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AllegraBlock, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn header(&self) -> ShelleyHeader {
+        self.0.header.clone().into()
+    }
+
+    pub fn transaction_bodies(&self) -> AllegraTransactionBodyList {
+        self.0.transaction_bodies.clone().into()
+    }
+
+    pub fn transaction_witness_sets(&self) -> AllegraTransactionWitnessSetList {
+        self.0.transaction_witness_sets.clone().into()
+    }
+
+    pub fn auxiliary_data_set(&self) -> MapTransactionIndexToAllegraAuxiliaryData {
+        self.0.auxiliary_data_set.clone().into()
+    }
+
+    pub fn new(
+        header: &ShelleyHeader,
+        transaction_bodies: &AllegraTransactionBodyList,
+        transaction_witness_sets: &AllegraTransactionWitnessSetList,
+        auxiliary_data_set: &MapTransactionIndexToAllegraAuxiliaryData,
+    ) -> Self {
+        Self(cml_multi_era::allegra::AllegraBlock::new(
+            header.clone().into(),
+            transaction_bodies.clone().into(),
+            transaction_witness_sets.clone().into(),
+            auxiliary_data_set.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::allegra::AllegraBlock> for AllegraBlock {
+    fn from(native: cml_multi_era::allegra::AllegraBlock) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AllegraBlock> for cml_multi_era::allegra::AllegraBlock {
+    fn from(wasm: AllegraBlock) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::allegra::AllegraBlock> for AllegraBlock {
+    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraBlock {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AllegraTransaction(cml_multi_era::allegra::AllegraTransaction);
+
+#[wasm_bindgen]
+impl AllegraTransaction {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraTransaction, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AllegraTransaction, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn body(&self) -> AllegraTransactionBody {
+        self.0.body.clone().into()
+    }
+
+    pub fn witness_set(&self) -> AllegraTransactionWitnessSet {
+        self.0.witness_set.clone().into()
+    }
+
+    pub fn auxiliary_data(&self) -> Option<AllegraAuxiliaryData> {
+        self.0.auxiliary_data.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(
+        body: &AllegraTransactionBody,
+        witness_set: &AllegraTransactionWitnessSet,
+        auxiliary_data: Option<AllegraAuxiliaryData>,
+    ) -> Self {
+        Self(cml_multi_era::allegra::AllegraTransaction::new(
+            body.clone().into(),
+            witness_set.clone().into(),
+            auxiliary_data.map(Into::into),
+        ))
+    }
+}
+
+impl From<cml_multi_era::allegra::AllegraTransaction> for AllegraTransaction {
+    fn from(native: cml_multi_era::allegra::AllegraTransaction) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AllegraTransaction> for cml_multi_era::allegra::AllegraTransaction {
+    fn from(wasm: AllegraTransaction) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::allegra::AllegraTransaction> for AllegraTransaction {
+    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraTransaction {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AllegraTransactionBody(cml_multi_era::allegra::AllegraTransactionBody);
+
+#[wasm_bindgen]
+impl AllegraTransactionBody {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraTransactionBody, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AllegraTransactionBody, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn inputs(&self) -> TransactionInputList {
+        self.0.inputs.clone().into()
+    }
+
+    pub fn outputs(&self) -> ShelleyTransactionOutputList {
+        self.0.outputs.clone().into()
+    }
+
+    pub fn fee(&self) -> Coin {
+        self.0.fee
+    }
+
+    pub fn set_ttl(&mut self, ttl: u64) {
+        self.0.ttl = Some(ttl)
+    }
+
+    pub fn ttl(&self) -> Option<u64> {
+        self.0.ttl
+    }
+
+    pub fn set_certs(&mut self, certs: &CertificateList) {
+        self.0.certs = Some(certs.clone().into())
+    }
+
+    pub fn certs(&self) -> Option<CertificateList> {
+        self.0.certs.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_withdrawals(&mut self, withdrawals: &Withdrawals) {
+        self.0.withdrawals = Some(withdrawals.clone().into())
+    }
+
+    pub fn withdrawals(&self) -> Option<Withdrawals> {
+        self.0.withdrawals.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_update(&mut self, update: &ShelleyUpdate) {
+        self.0.update = Some(update.clone().into())
+    }
+
+    pub fn update(&self) -> Option<ShelleyUpdate> {
+        self.0.update.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_auxiliary_data_hash(&mut self, auxiliary_data_hash: &AuxiliaryDataHash) {
+        self.0.auxiliary_data_hash = Some(auxiliary_data_hash.clone().into())
+    }
+
+    pub fn auxiliary_data_hash(&self) -> Option<AuxiliaryDataHash> {
+        self.0
+            .auxiliary_data_hash
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_validity_interval_start(&mut self, validity_interval_start: u64) {
+        self.0.validity_interval_start = Some(validity_interval_start)
+    }
+
+    pub fn validity_interval_start(&self) -> Option<u64> {
+        self.0.validity_interval_start
+    }
+
+    pub fn new(
+        inputs: &TransactionInputList,
+        outputs: &ShelleyTransactionOutputList,
+        fee: Coin,
+    ) -> Self {
+        Self(cml_multi_era::allegra::AllegraTransactionBody::new(
+            inputs.clone().into(),
+            outputs.clone().into(),
+            fee,
+        ))
+    }
+}
+
+impl From<cml_multi_era::allegra::AllegraTransactionBody> for AllegraTransactionBody {
+    fn from(native: cml_multi_era::allegra::AllegraTransactionBody) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AllegraTransactionBody> for cml_multi_era::allegra::AllegraTransactionBody {
+    fn from(wasm: AllegraTransactionBody) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::allegra::AllegraTransactionBody> for AllegraTransactionBody {
+    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraTransactionBody {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AllegraTransactionWitnessSet(cml_multi_era::allegra::AllegraTransactionWitnessSet);
+
+#[wasm_bindgen]
+impl AllegraTransactionWitnessSet {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraTransactionWitnessSet, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AllegraTransactionWitnessSet, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_vkeywitnesses(&mut self, vkeywitnesses: &VkeywitnessList) {
+        self.0.vkeywitnesses = Some(vkeywitnesses.clone().into())
+    }
+
+    pub fn vkeywitnesses(&self) -> Option<VkeywitnessList> {
+        self.0.vkeywitnesses.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_native_scripts(&mut self, native_scripts: &NativeScriptList) {
+        self.0.native_scripts = Some(native_scripts.clone().into())
+    }
+
+    pub fn native_scripts(&self) -> Option<NativeScriptList> {
+        self.0.native_scripts.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_bootstrap_witnesses(&mut self, bootstrap_witnesses: &BootstrapWitnessList) {
+        self.0.bootstrap_witnesses = Some(bootstrap_witnesses.clone().into())
+    }
+
+    pub fn bootstrap_witnesses(&self) -> Option<BootstrapWitnessList> {
+        self.0
+            .bootstrap_witnesses
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn new() -> Self {
+        Self(cml_multi_era::allegra::AllegraTransactionWitnessSet::new())
+    }
+}
+
+impl From<cml_multi_era::allegra::AllegraTransactionWitnessSet> for AllegraTransactionWitnessSet {
+    fn from(native: cml_multi_era::allegra::AllegraTransactionWitnessSet) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AllegraTransactionWitnessSet> for cml_multi_era::allegra::AllegraTransactionWitnessSet {
+    fn from(wasm: AllegraTransactionWitnessSet) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::allegra::AllegraTransactionWitnessSet> for AllegraTransactionWitnessSet {
+    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraTransactionWitnessSet {
+        &self.0
+    }
+}

--- a/multi-era/wasm/src/alonzo/mod.rs
+++ b/multi-era/wasm/src/alonzo/mod.rs
@@ -1,0 +1,1236 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_chain_wasm::{
+    GenesisHashList,
+    TransactionIndex,
+    ProtocolVersionStruct,
+};
+use cml_chain_wasm::assets::{Coin, Mint};
+use cml_chain_wasm::auxdata::{Metadata, ShelleyAuxData, ShelleyMaAuxData};
+use cml_chain_wasm::crypto::{Nonce};
+use cml_chain_wasm::plutus::{ExUnitPrices, ExUnits};
+use cml_chain_wasm::transaction::{RequiredSigners};
+use cml_chain_wasm::{Epoch, NetworkId, Rational, UnitInterval, Withdrawals};
+use crate::shelley::ShelleyHeader;
+use cml_chain_wasm::{
+    CertificateList, IntList, NativeScriptList, PlutusDataList, PlutusV1ScriptList,
+    RedeemerList, TransactionInputList, VkeywitnessList, BootstrapWitnessList
+};
+use cml_crypto_wasm::{AuxiliaryDataHash, GenesisHash, ScriptDataHash};
+use crate::{
+    AlonzoTransactionBodyList, AlonzoTransactionWitnessSetList, AlonzoTxOutList, MapTransactionIndexToAlonzoAuxiliaryData,
+};
+use cml_core::ordered_hash_map::OrderedHashMap;
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoAuxiliaryData(cml_multi_era::alonzo::AlonzoAuxiliaryData);
+
+#[wasm_bindgen]
+impl AlonzoAuxiliaryData {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoAuxiliaryData, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoAuxiliaryData, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_shelley(shelley: &ShelleyAuxData) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoAuxiliaryData::new_shelley(
+            shelley.clone().into(),
+        ))
+    }
+
+    pub fn new_shelley_m_a(shelley_m_a: &ShelleyMaAuxData) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoAuxiliaryData::new_shelley_m_a(
+            shelley_m_a.clone().into(),
+        ))
+    }
+
+    pub fn new_alonzo(alonzo: &AlonzoOnlyAuxData) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoAuxiliaryData::new_alonzo(
+            alonzo.clone().into(),
+        ))
+    }
+
+    pub fn kind(&self) -> AlonzoAuxiliaryDataKind {
+        match &self.0 {
+            cml_multi_era::alonzo::AlonzoAuxiliaryData::Shelley(_) => {
+                AlonzoAuxiliaryDataKind::Shelley
+            }
+            cml_multi_era::alonzo::AlonzoAuxiliaryData::ShelleyMA(_) => {
+                AlonzoAuxiliaryDataKind::ShelleyMA
+            }
+            cml_multi_era::alonzo::AlonzoAuxiliaryData::Alonzo(_) => {
+                AlonzoAuxiliaryDataKind::Alonzo
+            }
+        }
+    }
+
+    pub fn as_shelley(&self) -> Option<ShelleyAuxData> {
+        match &self.0 {
+            cml_multi_era::alonzo::AlonzoAuxiliaryData::Shelley(shelley) => {
+                Some(shelley.clone().into())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_shelley_m_a(&self) -> Option<ShelleyMaAuxData> {
+        match &self.0 {
+            cml_multi_era::alonzo::AlonzoAuxiliaryData::ShelleyMA(shelley_m_a) => {
+                Some(shelley_m_a.clone().into())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_alonzo(&self) -> Option<AlonzoOnlyAuxData> {
+        match &self.0 {
+            cml_multi_era::alonzo::AlonzoAuxiliaryData::Alonzo(alonzo) => {
+                Some(alonzo.clone().into())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoAuxiliaryData> for AlonzoAuxiliaryData {
+    fn from(native: cml_multi_era::alonzo::AlonzoAuxiliaryData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoAuxiliaryData> for cml_multi_era::alonzo::AlonzoAuxiliaryData {
+    fn from(wasm: AlonzoAuxiliaryData) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoAuxiliaryData> for AlonzoAuxiliaryData {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoAuxiliaryData {
+        &self.0
+    }
+}
+
+#[wasm_bindgen]
+pub enum AlonzoAuxiliaryDataKind {
+    Shelley,
+    ShelleyMA,
+    Alonzo,
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoBlock(cml_multi_era::alonzo::AlonzoBlock);
+
+#[wasm_bindgen]
+impl AlonzoBlock {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoBlock, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoBlock, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn header(&self) -> ShelleyHeader {
+        self.0.header.clone().into()
+    }
+
+    pub fn transaction_bodies(&self) -> AlonzoTransactionBodyList {
+        self.0.transaction_bodies.clone().into()
+    }
+
+    pub fn transaction_witness_sets(&self) -> AlonzoTransactionWitnessSetList {
+        self.0.transaction_witness_sets.clone().into()
+    }
+
+    pub fn auxiliary_data_set(&self) -> MapTransactionIndexToAlonzoAuxiliaryData {
+        self.0.auxiliary_data_set.clone().into()
+    }
+
+    pub fn invalid_transactions(&self) -> Vec<TransactionIndex> {
+        self.0.invalid_transactions.clone()
+    }
+
+    pub fn new(
+        header: &ShelleyHeader,
+        transaction_bodies: &AlonzoTransactionBodyList,
+        transaction_witness_sets: &AlonzoTransactionWitnessSetList,
+        auxiliary_data_set: &MapTransactionIndexToAlonzoAuxiliaryData,
+        invalid_transactions: Vec<TransactionIndex>,
+    ) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoBlock::new(
+            header.clone().into(),
+            transaction_bodies.clone().into(),
+            transaction_witness_sets.clone().into(),
+            auxiliary_data_set.clone().into(),
+            invalid_transactions,
+        ))
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoBlock> for AlonzoBlock {
+    fn from(native: cml_multi_era::alonzo::AlonzoBlock) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoBlock> for cml_multi_era::alonzo::AlonzoBlock {
+    fn from(wasm: AlonzoBlock) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoBlock> for AlonzoBlock {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoBlock {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoCostmdls(cml_multi_era::alonzo::AlonzoCostmdls);
+
+#[wasm_bindgen]
+impl AlonzoCostmdls {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoCostmdls, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoCostmdls, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn plutus_v1(&self) -> IntList {
+        self.0.plutus_v1.clone().into()
+    }
+
+    pub fn new(plutus_v1: &IntList) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoCostmdls::new(
+            plutus_v1.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoCostmdls> for AlonzoCostmdls {
+    fn from(native: cml_multi_era::alonzo::AlonzoCostmdls) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoCostmdls> for cml_multi_era::alonzo::AlonzoCostmdls {
+    fn from(wasm: AlonzoCostmdls) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoCostmdls> for AlonzoCostmdls {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoCostmdls {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoOnlyAuxData(cml_multi_era::alonzo::AlonzoOnlyAuxData);
+
+#[wasm_bindgen]
+impl AlonzoOnlyAuxData {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoOnlyAuxData, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoOnlyAuxData, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_metadata(&mut self, metadata: &Metadata) {
+        self.0.metadata = Some(metadata.clone().into())
+    }
+
+    pub fn metadata(&self) -> Option<Metadata> {
+        self.0.metadata.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_native_scripts(&mut self, native_scripts: &NativeScriptList) {
+        self.0.native_scripts = Some(native_scripts.clone().into())
+    }
+
+    pub fn native_scripts(&self) -> Option<NativeScriptList> {
+        self.0.native_scripts.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_plutus_v1_scripts(&mut self, plutus_v1_scripts: &PlutusV1ScriptList) {
+        self.0.plutus_v1_scripts = Some(plutus_v1_scripts.clone().into())
+    }
+
+    pub fn plutus_v1_scripts(&self) -> Option<PlutusV1ScriptList> {
+        self.0
+            .plutus_v1_scripts
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn new() -> Self {
+        Self(cml_multi_era::alonzo::AlonzoOnlyAuxData::new())
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoOnlyAuxData> for AlonzoOnlyAuxData {
+    fn from(native: cml_multi_era::alonzo::AlonzoOnlyAuxData) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoOnlyAuxData> for cml_multi_era::alonzo::AlonzoOnlyAuxData {
+    fn from(wasm: AlonzoOnlyAuxData) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoOnlyAuxData> for AlonzoOnlyAuxData {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoOnlyAuxData {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoProposedProtocolParameterUpdates(
+    cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates,
+);
+
+#[wasm_bindgen]
+impl AlonzoProposedProtocolParameterUpdates {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(
+        &mut self,
+        key: &GenesisHash,
+        value: &AlonzoProtocolParamUpdate,
+    ) -> Option<AlonzoProtocolParamUpdate> {
+        self.0
+            .insert(key.clone().into(), value.clone().into())
+            .map(Into::into)
+    }
+
+    pub fn get(&self, key: &GenesisHash) -> Option<AlonzoProtocolParamUpdate> {
+        self.0.get(key.as_ref()).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> GenesisHashList {
+        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>().into()
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates>
+    for AlonzoProposedProtocolParameterUpdates
+{
+    fn from(native: cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoProposedProtocolParameterUpdates>
+    for cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates
+{
+    fn from(wasm: AlonzoProposedProtocolParameterUpdates) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates>
+    for AlonzoProposedProtocolParameterUpdates
+{
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoProtocolParamUpdate(cml_multi_era::alonzo::AlonzoProtocolParamUpdate);
+
+#[wasm_bindgen]
+impl AlonzoProtocolParamUpdate {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoProtocolParamUpdate, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoProtocolParamUpdate, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_minfee_a(&mut self, minfee_a: u64) {
+        self.0.minfee_a = Some(minfee_a)
+    }
+
+    pub fn minfee_a(&self) -> Option<u64> {
+        self.0.minfee_a
+    }
+
+    pub fn set_minfee_b(&mut self, minfee_b: u64) {
+        self.0.minfee_b = Some(minfee_b)
+    }
+
+    pub fn minfee_b(&self) -> Option<u64> {
+        self.0.minfee_b
+    }
+
+    pub fn set_max_block_body_size(&mut self, max_block_body_size: u64) {
+        self.0.max_block_body_size = Some(max_block_body_size)
+    }
+
+    pub fn max_block_body_size(&self) -> Option<u64> {
+        self.0.max_block_body_size
+    }
+
+    pub fn set_max_transaction_size(&mut self, max_transaction_size: u64) {
+        self.0.max_transaction_size = Some(max_transaction_size)
+    }
+
+    pub fn max_transaction_size(&self) -> Option<u64> {
+        self.0.max_transaction_size
+    }
+
+    pub fn set_max_block_header_size(&mut self, max_block_header_size: u64) {
+        self.0.max_block_header_size = Some(max_block_header_size)
+    }
+
+    pub fn max_block_header_size(&self) -> Option<u64> {
+        self.0.max_block_header_size
+    }
+
+    pub fn set_key_deposit(&mut self, key_deposit: Coin) {
+        self.0.key_deposit = Some(key_deposit)
+    }
+
+    pub fn key_deposit(&self) -> Option<Coin> {
+        self.0.key_deposit
+    }
+
+    pub fn set_pool_deposit(&mut self, pool_deposit: Coin) {
+        self.0.pool_deposit = Some(pool_deposit)
+    }
+
+    pub fn pool_deposit(&self) -> Option<Coin> {
+        self.0.pool_deposit
+    }
+
+    pub fn set_maximum_epoch(&mut self, maximum_epoch: Epoch) {
+        self.0.maximum_epoch = Some(maximum_epoch)
+    }
+
+    pub fn maximum_epoch(&self) -> Option<Epoch> {
+        self.0.maximum_epoch
+    }
+
+    pub fn set_n_opt(&mut self, n_opt: u64) {
+        self.0.n_opt = Some(n_opt)
+    }
+
+    pub fn n_opt(&self) -> Option<u64> {
+        self.0.n_opt
+    }
+
+    pub fn set_pool_pledge_influence(&mut self, pool_pledge_influence: &Rational) {
+        self.0.pool_pledge_influence = Some(pool_pledge_influence.clone().into())
+    }
+
+    pub fn pool_pledge_influence(&self) -> Option<Rational> {
+        self.0
+            .pool_pledge_influence
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_expansion_rate(&mut self, expansion_rate: &UnitInterval) {
+        self.0.expansion_rate = Some(expansion_rate.clone().into())
+    }
+
+    pub fn expansion_rate(&self) -> Option<UnitInterval> {
+        self.0.expansion_rate.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_treasury_growth_rate(&mut self, treasury_growth_rate: &UnitInterval) {
+        self.0.treasury_growth_rate = Some(treasury_growth_rate.clone().into())
+    }
+
+    pub fn treasury_growth_rate(&self) -> Option<UnitInterval> {
+        self.0
+            .treasury_growth_rate
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_decentralization_constant(&mut self, decentralization_constant: &UnitInterval) {
+        self.0.decentralization_constant = Some(decentralization_constant.clone().into())
+    }
+
+    pub fn decentralization_constant(&self) -> Option<UnitInterval> {
+        self.0
+            .decentralization_constant
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_extra_entropy(&mut self, extra_entropy: &Nonce) {
+        self.0.extra_entropy = Some(extra_entropy.clone().into())
+    }
+
+    pub fn extra_entropy(&self) -> Option<Nonce> {
+        self.0.extra_entropy.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_protocol_version(&mut self, protocol_version: &ProtocolVersionStruct) {
+        self.0.protocol_version = Some(protocol_version.clone().into())
+    }
+
+    pub fn protocol_version(&self) -> Option<ProtocolVersionStruct> {
+        self.0
+            .protocol_version
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_min_pool_cost(&mut self, min_pool_cost: Coin) {
+        self.0.min_pool_cost = Some(min_pool_cost)
+    }
+
+    pub fn min_pool_cost(&self) -> Option<Coin> {
+        self.0.min_pool_cost
+    }
+
+    pub fn set_ada_per_utxo_byte(&mut self, ada_per_utxo_byte: Coin) {
+        self.0.ada_per_utxo_byte = Some(ada_per_utxo_byte)
+    }
+
+    pub fn ada_per_utxo_byte(&self) -> Option<Coin> {
+        self.0.ada_per_utxo_byte
+    }
+
+    pub fn set_cost_models_for_script_languages(
+        &mut self,
+        cost_models_for_script_languages: &AlonzoCostmdls,
+    ) {
+        self.0.cost_models_for_script_languages =
+            Some(cost_models_for_script_languages.clone().into())
+    }
+
+    pub fn cost_models_for_script_languages(&self) -> Option<AlonzoCostmdls> {
+        self.0
+            .cost_models_for_script_languages
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_execution_costs(&mut self, execution_costs: &ExUnitPrices) {
+        self.0.execution_costs = Some(execution_costs.clone().into())
+    }
+
+    pub fn execution_costs(&self) -> Option<ExUnitPrices> {
+        self.0.execution_costs.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_max_tx_ex_units(&mut self, max_tx_ex_units: &ExUnits) {
+        self.0.max_tx_ex_units = Some(max_tx_ex_units.clone().into())
+    }
+
+    pub fn max_tx_ex_units(&self) -> Option<ExUnits> {
+        self.0.max_tx_ex_units.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_max_block_ex_units(&mut self, max_block_ex_units: &ExUnits) {
+        self.0.max_block_ex_units = Some(max_block_ex_units.clone().into())
+    }
+
+    pub fn max_block_ex_units(&self) -> Option<ExUnits> {
+        self.0
+            .max_block_ex_units
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_max(&mut self, max: u64) {
+        self.0.max = Some(max)
+    }
+
+    pub fn max(&self) -> Option<u64> {
+        self.0.max
+    }
+
+    pub fn set_collateral_percentage(&mut self, collateral_percentage: u64) {
+        self.0.collateral_percentage = Some(collateral_percentage)
+    }
+
+    pub fn collateral_percentage(&self) -> Option<u64> {
+        self.0.collateral_percentage
+    }
+
+    pub fn set_max_collateral_inputs(&mut self, max_collateral_inputs: u64) {
+        self.0.max_collateral_inputs = Some(max_collateral_inputs)
+    }
+
+    pub fn max_collateral_inputs(&self) -> Option<u64> {
+        self.0.max_collateral_inputs
+    }
+
+    pub fn new() -> Self {
+        Self(cml_multi_era::alonzo::AlonzoProtocolParamUpdate::new())
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoProtocolParamUpdate> for AlonzoProtocolParamUpdate {
+    fn from(native: cml_multi_era::alonzo::AlonzoProtocolParamUpdate) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoProtocolParamUpdate> for cml_multi_era::alonzo::AlonzoProtocolParamUpdate {
+    fn from(wasm: AlonzoProtocolParamUpdate) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoProtocolParamUpdate> for AlonzoProtocolParamUpdate {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoProtocolParamUpdate {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoTransaction(cml_multi_era::alonzo::AlonzoTransaction);
+
+#[wasm_bindgen]
+impl AlonzoTransaction {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransaction, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoTransaction, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn body(&self) -> AlonzoTransactionBody {
+        self.0.body.clone().into()
+    }
+
+    pub fn witness_set(&self) -> AlonzoTransactionWitnessSet {
+        self.0.witness_set.clone().into()
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.0.is_valid
+    }
+
+    pub fn auxiliary_data(&self) -> Option<AlonzoAuxiliaryData> {
+        self.0.auxiliary_data.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(
+        body: &AlonzoTransactionBody,
+        witness_set: &AlonzoTransactionWitnessSet,
+        is_valid: bool,
+        auxiliary_data: Option<AlonzoAuxiliaryData>,
+    ) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoTransaction::new(
+            body.clone().into(),
+            witness_set.clone().into(),
+            is_valid,
+            auxiliary_data.map(Into::into),
+        ))
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoTransaction> for AlonzoTransaction {
+    fn from(native: cml_multi_era::alonzo::AlonzoTransaction) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTransaction> for cml_multi_era::alonzo::AlonzoTransaction {
+    fn from(wasm: AlonzoTransaction) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoTransaction> for AlonzoTransaction {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransaction {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoTransactionBody(cml_multi_era::alonzo::AlonzoTransactionBody);
+
+#[wasm_bindgen]
+impl AlonzoTransactionBody {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransactionBody, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoTransactionBody, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn inputs(&self) -> TransactionInputList {
+        self.0.inputs.clone().into()
+    }
+
+    pub fn outputs(&self) -> AlonzoTxOutList {
+        self.0.outputs.clone().into()
+    }
+
+    pub fn fee(&self) -> Coin {
+        self.0.fee
+    }
+
+    pub fn set_ttl(&mut self, ttl: u64) {
+        self.0.ttl = Some(ttl)
+    }
+
+    pub fn ttl(&self) -> Option<u64> {
+        self.0.ttl
+    }
+
+    pub fn set_certs(&mut self, certs: &CertificateList) {
+        self.0.certs = Some(certs.clone().into())
+    }
+
+    pub fn certs(&self) -> Option<CertificateList> {
+        self.0.certs.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_withdrawals(&mut self, withdrawals: &Withdrawals) {
+        self.0.withdrawals = Some(withdrawals.clone().into())
+    }
+
+    pub fn withdrawals(&self) -> Option<Withdrawals> {
+        self.0.withdrawals.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_update(&mut self, update: &AlonzoUpdate) {
+        self.0.update = Some(update.clone().into())
+    }
+
+    pub fn update(&self) -> Option<AlonzoUpdate> {
+        self.0.update.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_auxiliary_data_hash(&mut self, auxiliary_data_hash: &AuxiliaryDataHash) {
+        self.0.auxiliary_data_hash = Some(auxiliary_data_hash.clone().into())
+    }
+
+    pub fn auxiliary_data_hash(&self) -> Option<AuxiliaryDataHash> {
+        self.0
+            .auxiliary_data_hash
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_validity_interval_start(&mut self, validity_interval_start: u64) {
+        self.0.validity_interval_start = Some(validity_interval_start)
+    }
+
+    pub fn validity_interval_start(&self) -> Option<u64> {
+        self.0.validity_interval_start
+    }
+
+    pub fn set_mint(&mut self, mint: &Mint) {
+        self.0.mint = Some(mint.clone().into())
+    }
+
+    pub fn mint(&self) -> Option<Mint> {
+        self.0.mint.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_script_data_hash(&mut self, script_data_hash: &ScriptDataHash) {
+        self.0.script_data_hash = Some(script_data_hash.clone().into())
+    }
+
+    pub fn script_data_hash(&self) -> Option<ScriptDataHash> {
+        self.0
+            .script_data_hash
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_collateral_inputs(&mut self, collateral_inputs: &TransactionInputList) {
+        self.0.collateral_inputs = Some(collateral_inputs.clone().into())
+    }
+
+    pub fn collateral_inputs(&self) -> Option<TransactionInputList> {
+        self.0
+            .collateral_inputs
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_required_signers(&mut self, required_signers: &RequiredSigners) {
+        self.0.required_signers = Some(required_signers.clone().into())
+    }
+
+    pub fn required_signers(&self) -> Option<RequiredSigners> {
+        self.0
+            .required_signers
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_network_id(&mut self, network_id: NetworkId) {
+        self.0.network_id = Some(network_id)
+    }
+
+    pub fn network_id(&self) -> Option<NetworkId> {
+        self.0.network_id
+    }
+
+    pub fn new(
+        inputs: &TransactionInputList,
+        outputs: &AlonzoTransactionOutputList,
+        fee: Coin,
+    ) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoTransactionBody::new(
+            inputs.clone().into(),
+            outputs.clone().into(),
+            fee,
+        ))
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoTransactionBody> for AlonzoTransactionBody {
+    fn from(native: cml_multi_era::alonzo::AlonzoTransactionBody) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTransactionBody> for cml_multi_era::alonzo::AlonzoTransactionBody {
+    fn from(wasm: AlonzoTransactionBody) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoTransactionBody> for AlonzoTransactionBody {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransactionBody {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoTransactionOutput(cml_multi_era::alonzo::AlonzoTransactionOutput);
+
+#[wasm_bindgen]
+impl AlonzoTransactionOutput {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_multi_era::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransactionOutput, JsValue> {
+        cml_multi_era::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoTransactionOutput, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_shelley_tx_out(shelley_tx_out: &ShelleyTxOut) -> Self {
+        Self(
+            cml_multi_era::alonzo::AlonzoTransactionOutput::new_shelley_tx_out(
+                shelley_tx_out.clone().into(),
+            ),
+        )
+    }
+
+    pub fn new_alonzo_tx_out(alonzo_tx_out: &AlonzoTxOut) -> Self {
+        Self(
+            cml_multi_era::alonzo::AlonzoTransactionOutput::new_alonzo_tx_out(
+                alonzo_tx_out.clone().into(),
+            ),
+        )
+    }
+
+    pub fn kind(&self) -> AlonzoTransactionOutputKind {
+        match &self.0 {
+            cml_multi_era::alonzo::AlonzoTransactionOutput::ShelleyTxOut(_) => {
+                AlonzoTransactionOutputKind::ShelleyTxOut
+            }
+            cml_multi_era::alonzo::AlonzoTransactionOutput::AlonzoTxOut(_) => {
+                AlonzoTransactionOutputKind::AlonzoTxOut
+            }
+        }
+    }
+
+    pub fn as_shelley_tx_out(&self) -> Option<ShelleyTxOut> {
+        match &self.0 {
+            cml_multi_era::alonzo::AlonzoTransactionOutput::ShelleyTxOut(shelley_tx_out) => {
+                Some(shelley_tx_out.clone().into())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_alonzo_tx_out(&self) -> Option<AlonzoTxOut> {
+        match &self.0 {
+            cml_multi_era::alonzo::AlonzoTransactionOutput::AlonzoTxOut(alonzo_tx_out) => {
+                Some(alonzo_tx_out.clone().into())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoTransactionOutput> for AlonzoTransactionOutput {
+    fn from(native: cml_multi_era::alonzo::AlonzoTransactionOutput) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTransactionOutput> for cml_multi_era::alonzo::AlonzoTransactionOutput {
+    fn from(wasm: AlonzoTransactionOutput) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoTransactionOutput> for AlonzoTransactionOutput {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransactionOutput {
+        &self.0
+    }
+}
+
+#[wasm_bindgen]
+pub enum AlonzoTransactionOutputKind {
+    ShelleyTxOut,
+    AlonzoTxOut,
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoTransactionWitnessSet(cml_multi_era::alonzo::AlonzoTransactionWitnessSet);
+
+#[wasm_bindgen]
+impl AlonzoTransactionWitnessSet {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransactionWitnessSet, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoTransactionWitnessSet, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_vkeywitnesses(&mut self, vkeywitnesses: &VkeywitnessList) {
+        self.0.vkeywitnesses = Some(vkeywitnesses.clone().into())
+    }
+
+    pub fn vkeywitnesses(&self) -> Option<VkeywitnessList> {
+        self.0.vkeywitnesses.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_native_scripts(&mut self, native_scripts: &NativeScriptList) {
+        self.0.native_scripts = Some(native_scripts.clone().into())
+    }
+
+    pub fn native_scripts(&self) -> Option<NativeScriptList> {
+        self.0.native_scripts.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_bootstrap_witnesses(&mut self, bootstrap_witnesses: &BootstrapWitnessList) {
+        self.0.bootstrap_witnesses = Some(bootstrap_witnesses.clone().into())
+    }
+
+    pub fn bootstrap_witnesses(&self) -> Option<BootstrapWitnessList> {
+        self.0
+            .bootstrap_witnesses
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_plutus_v1_scripts(&mut self, plutus_v1_scripts: &PlutusV1ScriptList) {
+        self.0.plutus_v1_scripts = Some(plutus_v1_scripts.clone().into())
+    }
+
+    pub fn plutus_v1_scripts(&self) -> Option<PlutusV1ScriptList> {
+        self.0
+            .plutus_v1_scripts
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_plutus_datums(&mut self, plutus_datums: &PlutusDataList) {
+        self.0.plutus_datums = Some(plutus_datums.clone().into())
+    }
+
+    pub fn plutus_datums(&self) -> Option<PlutusDataList> {
+        self.0.plutus_datums.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_redeemers(&mut self, redeemers: &RedeemerList) {
+        self.0.redeemers = Some(redeemers.clone().into())
+    }
+
+    pub fn redeemers(&self) -> Option<RedeemerList> {
+        self.0.redeemers.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new() -> Self {
+        Self(cml_multi_era::alonzo::AlonzoTransactionWitnessSet::new())
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoTransactionWitnessSet> for AlonzoTransactionWitnessSet {
+    fn from(native: cml_multi_era::alonzo::AlonzoTransactionWitnessSet) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTransactionWitnessSet> for cml_multi_era::alonzo::AlonzoTransactionWitnessSet {
+    fn from(wasm: AlonzoTransactionWitnessSet) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoTransactionWitnessSet> for AlonzoTransactionWitnessSet {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransactionWitnessSet {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoUpdate(cml_multi_era::alonzo::AlonzoUpdate);
+
+#[wasm_bindgen]
+impl AlonzoUpdate {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoUpdate, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<AlonzoUpdate, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn proposed_protocol_parameter_updates(&self) -> AlonzoProposedProtocolParameterUpdates {
+        self.0.proposed_protocol_parameter_updates.clone().into()
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.0.epoch
+    }
+
+    pub fn new(
+        proposed_protocol_parameter_updates: &AlonzoProposedProtocolParameterUpdates,
+        epoch: Epoch,
+    ) -> Self {
+        Self(cml_multi_era::alonzo::AlonzoUpdate::new(
+            proposed_protocol_parameter_updates.clone().into(),
+            epoch,
+        ))
+    }
+}
+
+impl From<cml_multi_era::alonzo::AlonzoUpdate> for AlonzoUpdate {
+    fn from(native: cml_multi_era::alonzo::AlonzoUpdate) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoUpdate> for cml_multi_era::alonzo::AlonzoUpdate {
+    fn from(wasm: AlonzoUpdate) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::alonzo::AlonzoUpdate> for AlonzoUpdate {
+    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoUpdate {
+        &self.0
+    }
+}

--- a/multi-era/wasm/src/lib.rs
+++ b/multi-era/wasm/src/lib.rs
@@ -1,0 +1,896 @@
+#![allow(
+    clippy::len_without_is_empty,
+    clippy::too_many_arguments,
+    clippy::new_without_default
+)]
+pub mod allegra;
+pub mod alonzo;
+pub mod mary;
+pub mod shelley;
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_chain_wasm::{
+    block::Block,
+    certs::{StakeCredential},
+    transaction::{AlonzoTxOut, ShelleyTxOut},
+    Coin, TransactionIndex, StakeCredentialList,
+};
+use cml_core::ordered_hash_map::OrderedHashMap;
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+use crate::{
+    alonzo::{
+        AlonzoAuxiliaryData,
+        AlonzoBlock,
+        AlonzoTransactionBody,
+        AlonzoTransactionWitnessSet
+    },
+    allegra::{
+        AllegraAuxiliaryData,
+        AllegraBlock,
+        AllegraTransactionBody,
+        AllegraTransactionWitnessSet,
+    },
+    mary::{
+        MaryBlock,
+        MaryTransactionBody
+    },
+    shelley::{
+        ShelleyBlock,
+        ShelleyTransactionBody,
+        ShelleyTransactionOutput,
+        ShelleyTransactionWitnessSet,
+        MultisigScript,
+    }
+};
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AllegraTransactionBodyList(Vec<cml_multi_era::allegra::AllegraTransactionBody>);
+
+#[wasm_bindgen]
+impl AllegraTransactionBodyList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AllegraTransactionBody {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &AllegraTransactionBody) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::allegra::AllegraTransactionBody>> for AllegraTransactionBodyList {
+    fn from(native: Vec<cml_multi_era::allegra::AllegraTransactionBody>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AllegraTransactionBodyList> for Vec<cml_multi_era::allegra::AllegraTransactionBody> {
+    fn from(wasm: AllegraTransactionBodyList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::allegra::AllegraTransactionBody>> for AllegraTransactionBodyList {
+    fn as_ref(&self) -> &Vec<cml_multi_era::allegra::AllegraTransactionBody> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AllegraTransactionWitnessSetList(
+    Vec<cml_multi_era::allegra::AllegraTransactionWitnessSet>,
+);
+
+#[wasm_bindgen]
+impl AllegraTransactionWitnessSetList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AllegraTransactionWitnessSet {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &AllegraTransactionWitnessSet) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::allegra::AllegraTransactionWitnessSet>>
+    for AllegraTransactionWitnessSetList
+{
+    fn from(native: Vec<cml_multi_era::allegra::AllegraTransactionWitnessSet>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AllegraTransactionWitnessSetList>
+    for Vec<cml_multi_era::allegra::AllegraTransactionWitnessSet>
+{
+    fn from(wasm: AllegraTransactionWitnessSetList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::allegra::AllegraTransactionWitnessSet>>
+    for AllegraTransactionWitnessSetList
+{
+    fn as_ref(&self) -> &Vec<cml_multi_era::allegra::AllegraTransactionWitnessSet> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoTransactionBodyList(Vec<cml_multi_era::alonzo::AlonzoTransactionBody>);
+
+#[wasm_bindgen]
+impl AlonzoTransactionBodyList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AlonzoTransactionBody {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &AlonzoTransactionBody) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::alonzo::AlonzoTransactionBody>> for AlonzoTransactionBodyList {
+    fn from(native: Vec<cml_multi_era::alonzo::AlonzoTransactionBody>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTransactionBodyList> for Vec<cml_multi_era::alonzo::AlonzoTransactionBody> {
+    fn from(wasm: AlonzoTransactionBodyList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::alonzo::AlonzoTransactionBody>> for AlonzoTransactionBodyList {
+    fn as_ref(&self) -> &Vec<cml_multi_era::alonzo::AlonzoTransactionBody> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoTransactionWitnessSetList(Vec<cml_multi_era::alonzo::AlonzoTransactionWitnessSet>);
+
+#[wasm_bindgen]
+impl AlonzoTransactionWitnessSetList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AlonzoTransactionWitnessSet {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &AlonzoTransactionWitnessSet) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::alonzo::AlonzoTransactionWitnessSet>>
+    for AlonzoTransactionWitnessSetList
+{
+    fn from(native: Vec<cml_multi_era::alonzo::AlonzoTransactionWitnessSet>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTransactionWitnessSetList>
+    for Vec<cml_multi_era::alonzo::AlonzoTransactionWitnessSet>
+{
+    fn from(wasm: AlonzoTransactionWitnessSetList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::alonzo::AlonzoTransactionWitnessSet>>
+    for AlonzoTransactionWitnessSetList
+{
+    fn as_ref(&self) -> &Vec<cml_multi_era::alonzo::AlonzoTransactionWitnessSet> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct AlonzoTxOutList(Vec<cml_chain::transaction::AlonzoTxOut>);
+
+#[wasm_bindgen]
+impl AlonzoTxOutList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AlonzoTxOut {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &AlonzoTxOut) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_chain::transaction::AlonzoTxOut>> for AlonzoTxOutList {
+    fn from(native: Vec<cml_chain::transaction::AlonzoTxOut>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<AlonzoTxOutList> for Vec<cml_chain::transaction::AlonzoTxOut> {
+    fn from(wasm: AlonzoTxOutList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_chain::transaction::AlonzoTxOut>> for AlonzoTxOutList {
+    fn as_ref(&self) -> &Vec<cml_chain::transaction::AlonzoTxOut> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MapStakeCredentialToCoin(
+    OrderedHashMap<
+        cml_chain::certs::StakeCredential,
+        cml_chain::assets::Coin,
+    >,
+);
+
+#[wasm_bindgen]
+impl MapStakeCredentialToCoin {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &StakeCredential, value: Coin) -> Option<Coin> {
+        self.0.insert(key.clone().into(), value)
+    }
+
+    pub fn get(&self, key: &StakeCredential) -> Option<Coin> {
+        self.0.get(key.as_ref()).copied()
+    }
+
+    pub fn keys(&self) -> StakeCredentialList {
+        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>().into()
+    }
+}
+
+impl
+    From<
+        OrderedHashMap<
+            cml_chain::certs::StakeCredential,
+            cml_chain::assets::Coin,
+        >,
+    > for MapStakeCredentialToCoin
+{
+    fn from(
+        native: OrderedHashMap<
+            cml_chain::certs::StakeCredential,
+            cml_chain::assets::Coin,
+        >,
+    ) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MapStakeCredentialToCoin>
+    for OrderedHashMap<
+        cml_chain::certs::StakeCredential,
+        cml_chain::assets::Coin,
+    >
+{
+    fn from(wasm: MapStakeCredentialToCoin) -> Self {
+        wasm.0
+    }
+}
+
+impl
+    AsRef<
+        OrderedHashMap<
+            cml_chain::certs::StakeCredential,
+            cml_chain::assets::Coin,
+        >,
+    > for MapStakeCredentialToCoin
+{
+    fn as_ref(
+        &self,
+    ) -> &OrderedHashMap<
+        cml_chain::certs::StakeCredential,
+        cml_chain::assets::Coin,
+    > {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MapTransactionIndexToAllegraAuxiliaryData(
+    OrderedHashMap<
+        cml_chain::TransactionIndex,
+        cml_multi_era::allegra::AllegraAuxiliaryData,
+    >,
+);
+
+#[wasm_bindgen]
+impl MapTransactionIndexToAllegraAuxiliaryData {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(
+        &mut self,
+        key: TransactionIndex,
+        value: &AllegraAuxiliaryData,
+    ) -> Option<AllegraAuxiliaryData> {
+        self.0.insert(key, value.clone().into()).map(Into::into)
+    }
+
+    pub fn get(&self, key: TransactionIndex) -> Option<AllegraAuxiliaryData> {
+        self.0.get(&key).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> Vec<TransactionIndex> {
+        self.0.keys().copied().collect::<Vec<_>>()
+    }
+}
+
+impl
+    From<
+        OrderedHashMap<
+            cml_chain::TransactionIndex,
+            cml_multi_era::allegra::AllegraAuxiliaryData,
+        >,
+    > for MapTransactionIndexToAllegraAuxiliaryData
+{
+    fn from(
+        native: OrderedHashMap<
+            cml_chain::TransactionIndex,
+            cml_multi_era::allegra::AllegraAuxiliaryData,
+        >,
+    ) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MapTransactionIndexToAllegraAuxiliaryData>
+    for OrderedHashMap<
+        cml_chain::TransactionIndex,
+        cml_multi_era::allegra::AllegraAuxiliaryData,
+    >
+{
+    fn from(wasm: MapTransactionIndexToAllegraAuxiliaryData) -> Self {
+        wasm.0
+    }
+}
+
+impl
+    AsRef<
+        OrderedHashMap<
+            cml_chain::TransactionIndex,
+            cml_multi_era::allegra::AllegraAuxiliaryData,
+        >,
+    > for MapTransactionIndexToAllegraAuxiliaryData
+{
+    fn as_ref(
+        &self,
+    ) -> &OrderedHashMap<
+        cml_chain::TransactionIndex,
+        cml_multi_era::allegra::AllegraAuxiliaryData,
+    > {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MapTransactionIndexToAlonzoAuxiliaryData(
+    OrderedHashMap<
+        cml_chain::TransactionIndex,
+        cml_multi_era::alonzo::AlonzoAuxiliaryData,
+    >,
+);
+
+#[wasm_bindgen]
+impl MapTransactionIndexToAlonzoAuxiliaryData {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(
+        &mut self,
+        key: TransactionIndex,
+        value: &AlonzoAuxiliaryData,
+    ) -> Option<AlonzoAuxiliaryData> {
+        self.0.insert(key, value.clone().into()).map(Into::into)
+    }
+
+    pub fn get(&self, key: TransactionIndex) -> Option<AlonzoAuxiliaryData> {
+        self.0.get(&key).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> Vec<TransactionIndex> {
+        self.0.keys().copied().collect::<Vec<_>>()
+    }
+}
+
+impl
+    From<
+        OrderedHashMap<
+            cml_chain::TransactionIndex,
+            cml_multi_era::alonzo::AlonzoAuxiliaryData,
+        >,
+    > for MapTransactionIndexToAlonzoAuxiliaryData
+{
+    fn from(
+        native: OrderedHashMap<
+            cml_chain::TransactionIndex,
+            cml_multi_era::alonzo::AlonzoAuxiliaryData,
+        >,
+    ) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MapTransactionIndexToAlonzoAuxiliaryData>
+    for OrderedHashMap<
+        cml_chain::TransactionIndex,
+        cml_multi_era::alonzo::AlonzoAuxiliaryData,
+    >
+{
+    fn from(wasm: MapTransactionIndexToAlonzoAuxiliaryData) -> Self {
+        wasm.0
+    }
+}
+
+impl
+    AsRef<
+        OrderedHashMap<
+            cml_chain::TransactionIndex,
+            cml_multi_era::alonzo::AlonzoAuxiliaryData,
+        >,
+    > for MapTransactionIndexToAlonzoAuxiliaryData
+{
+    fn as_ref(
+        &self,
+    ) -> &OrderedHashMap<
+        cml_chain::TransactionIndex,
+        cml_multi_era::alonzo::AlonzoAuxiliaryData,
+    > {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MaryTransactionBodyList(Vec<cml_multi_era::mary::MaryTransactionBody>);
+
+#[wasm_bindgen]
+impl MaryTransactionBodyList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> MaryTransactionBody {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &MaryTransactionBody) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::mary::MaryTransactionBody>> for MaryTransactionBodyList {
+    fn from(native: Vec<cml_multi_era::mary::MaryTransactionBody>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MaryTransactionBodyList> for Vec<cml_multi_era::mary::MaryTransactionBody> {
+    fn from(wasm: MaryTransactionBodyList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::mary::MaryTransactionBody>> for MaryTransactionBodyList {
+    fn as_ref(&self) -> &Vec<cml_multi_era::mary::MaryTransactionBody> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MultisigScriptList(Vec<cml_multi_era::shelley::MultisigScript>);
+
+#[wasm_bindgen]
+impl MultisigScriptList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> MultisigScript {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &MultisigScript) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::shelley::MultisigScript>> for MultisigScriptList {
+    fn from(native: Vec<cml_multi_era::shelley::MultisigScript>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultisigScriptList> for Vec<cml_multi_era::shelley::MultisigScript> {
+    fn from(wasm: MultisigScriptList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::shelley::MultisigScript>> for MultisigScriptList {
+    fn as_ref(&self) -> &Vec<cml_multi_era::shelley::MultisigScript> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MultiEraBlock(cml_multi_era::MultiEraBlock);
+
+#[wasm_bindgen]
+impl MultiEraBlock {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultiEraBlock, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MultiEraBlock, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_shelley(shelley: &ShelleyBlock) -> Self {
+        Self(cml_multi_era::MultiEraBlock::new_shelley(
+            shelley.clone().into(),
+        ))
+    }
+
+    pub fn new_allegra(allegra: &AllegraBlock) -> Self {
+        Self(cml_multi_era::MultiEraBlock::new_allegra(
+            allegra.clone().into(),
+        ))
+    }
+
+    pub fn new_mary(mary: &MaryBlock) -> Self {
+        Self(cml_multi_era::MultiEraBlock::new_mary(mary.clone().into()))
+    }
+
+    pub fn new_alonzo(alonzo: &AlonzoBlock) -> Self {
+        Self(cml_multi_era::MultiEraBlock::new_alonzo(
+            alonzo.clone().into(),
+        ))
+    }
+
+    pub fn new_babbage(babbage: &Block) -> Self {
+        Self(cml_multi_era::MultiEraBlock::new_babbage(
+            babbage.clone().into(),
+        ))
+    }
+
+    pub fn kind(&self) -> MultiEraBlockKind {
+        match &self.0 {
+            cml_multi_era::MultiEraBlock::Shelley(_) => MultiEraBlockKind::Shelley,
+            cml_multi_era::MultiEraBlock::Allegra(_) => MultiEraBlockKind::Allegra,
+            cml_multi_era::MultiEraBlock::Mary(_) => MultiEraBlockKind::Mary,
+            cml_multi_era::MultiEraBlock::Alonzo(_) => MultiEraBlockKind::Alonzo,
+            cml_multi_era::MultiEraBlock::Babbage(_) => MultiEraBlockKind::Babbage,
+        }
+    }
+
+    pub fn as_shelley(&self) -> Option<ShelleyBlock> {
+        match &self.0 {
+            cml_multi_era::MultiEraBlock::Shelley(shelley) => Some(shelley.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_allegra(&self) -> Option<AllegraBlock> {
+        match &self.0 {
+            cml_multi_era::MultiEraBlock::Allegra(allegra) => Some(allegra.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_mary(&self) -> Option<MaryBlock> {
+        match &self.0 {
+            cml_multi_era::MultiEraBlock::Mary(mary) => Some(mary.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_alonzo(&self) -> Option<AlonzoBlock> {
+        match &self.0 {
+            cml_multi_era::MultiEraBlock::Alonzo(alonzo) => Some(alonzo.clone().into()),
+            _ => None,
+        }
+    }
+
+    pub fn as_babbage(&self) -> Option<Block> {
+        match &self.0 {
+            cml_multi_era::MultiEraBlock::Babbage(babbage) => Some(babbage.clone().into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<cml_multi_era::MultiEraBlock> for MultiEraBlock {
+    fn from(native: cml_multi_era::MultiEraBlock) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultiEraBlock> for cml_multi_era::MultiEraBlock {
+    fn from(wasm: MultiEraBlock) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::MultiEraBlock> for MultiEraBlock {
+    fn as_ref(&self) -> &cml_multi_era::MultiEraBlock {
+        &self.0
+    }
+}
+
+#[wasm_bindgen]
+pub enum MultiEraBlockKind {
+    Shelley,
+    Allegra,
+    Mary,
+    Alonzo,
+    Babbage,
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTransactionBodyList(Vec<cml_multi_era::shelley::ShelleyTransactionBody>);
+
+#[wasm_bindgen]
+impl ShelleyTransactionBodyList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> ShelleyTransactionBody {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &ShelleyTransactionBody) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::shelley::ShelleyTransactionBody>> for ShelleyTransactionBodyList {
+    fn from(native: Vec<cml_multi_era::shelley::ShelleyTransactionBody>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTransactionBodyList> for Vec<cml_multi_era::shelley::ShelleyTransactionBody> {
+    fn from(wasm: ShelleyTransactionBodyList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::shelley::ShelleyTransactionBody>> for ShelleyTransactionBodyList {
+    fn as_ref(&self) -> &Vec<cml_multi_era::shelley::ShelleyTransactionBody> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTransactionOutputList(Vec<cml_multi_era::shelley::ShelleyTransactionOutput>);
+
+#[wasm_bindgen]
+impl ShelleyTransactionOutputList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> ShelleyTransactionOutput {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &ShelleyTransactionOutput) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::shelley::ShelleyTransactionOutput>> for ShelleyTransactionOutputList {
+    fn from(native: Vec<cml_multi_era::shelley::ShelleyTransactionOutput>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTransactionOutputList> for Vec<cml_multi_era::shelley::ShelleyTransactionOutput> {
+    fn from(wasm: ShelleyTransactionOutputList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::shelley::ShelleyTransactionOutput>> for ShelleyTransactionOutputList {
+    fn as_ref(&self) -> &Vec<cml_multi_era::shelley::ShelleyTransactionOutput> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTransactionWitnessSetList(
+    Vec<cml_multi_era::shelley::ShelleyTransactionWitnessSet>,
+);
+
+#[wasm_bindgen]
+impl ShelleyTransactionWitnessSetList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> ShelleyTransactionWitnessSet {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &ShelleyTransactionWitnessSet) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_multi_era::shelley::ShelleyTransactionWitnessSet>>
+    for ShelleyTransactionWitnessSetList
+{
+    fn from(native: Vec<cml_multi_era::shelley::ShelleyTransactionWitnessSet>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTransactionWitnessSetList>
+    for Vec<cml_multi_era::shelley::ShelleyTransactionWitnessSet>
+{
+    fn from(wasm: ShelleyTransactionWitnessSetList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_multi_era::shelley::ShelleyTransactionWitnessSet>>
+    for ShelleyTransactionWitnessSetList
+{
+    fn as_ref(&self) -> &Vec<cml_multi_era::shelley::ShelleyTransactionWitnessSet> {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTxOutList(Vec<cml_chain::transaction::ShelleyTxOut>);
+
+#[wasm_bindgen]
+impl ShelleyTxOutList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> ShelleyTxOut {
+        self.0[index].clone().into()
+    }
+
+    pub fn add(&mut self, elem: &ShelleyTxOut) {
+        self.0.push(elem.clone().into());
+    }
+}
+
+impl From<Vec<cml_chain::transaction::ShelleyTxOut>> for ShelleyTxOutList {
+    fn from(native: Vec<cml_chain::transaction::ShelleyTxOut>) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTxOutList> for Vec<cml_chain::transaction::ShelleyTxOut> {
+    fn from(wasm: ShelleyTxOutList) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<Vec<cml_chain::transaction::ShelleyTxOut>> for ShelleyTxOutList {
+    fn as_ref(&self) -> &Vec<cml_chain::transaction::ShelleyTxOut> {
+        &self.0
+    }
+}

--- a/multi-era/wasm/src/mary/mod.rs
+++ b/multi-era/wasm/src/mary/mod.rs
@@ -1,0 +1,302 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use crate::allegra::{AllegraAuxiliaryData, AllegraTransactionWitnessSet};
+use cml_chain_wasm::assets::{Coin, Mint};
+use cml_chain_wasm::Withdrawals;
+use crate::shelley::{ShelleyHeader, ShelleyUpdate};
+use cml_chain_wasm::{
+    CertificateList, TransactionInputList
+};
+use cml_crypto_wasm::{AuxiliaryDataHash};
+use crate::{
+    AllegraTransactionWitnessSetList, MapTransactionIndexToAllegraAuxiliaryData,
+    MaryTransactionBodyList, ShelleyTxOutList,
+};
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MaryBlock(cml_multi_era::mary::MaryBlock);
+
+#[wasm_bindgen]
+impl MaryBlock {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MaryBlock, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MaryBlock, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn header(&self) -> ShelleyHeader {
+        self.0.header.clone().into()
+    }
+
+    pub fn transaction_bodies(&self) -> MaryTransactionBodyList {
+        self.0.transaction_bodies.clone().into()
+    }
+
+    pub fn transaction_witness_sets(&self) -> AllegraTransactionWitnessSetList {
+        self.0.transaction_witness_sets.clone().into()
+    }
+
+    pub fn auxiliary_data_set(&self) -> MapTransactionIndexToAllegraAuxiliaryData {
+        self.0.auxiliary_data_set.clone().into()
+    }
+
+    pub fn new(
+        header: &ShelleyHeader,
+        transaction_bodies: &MaryTransactionBodyList,
+        transaction_witness_sets: &AllegraTransactionWitnessSetList,
+        auxiliary_data_set: &MapTransactionIndexToAllegraAuxiliaryData,
+    ) -> Self {
+        Self(cml_multi_era::mary::MaryBlock::new(
+            header.clone().into(),
+            transaction_bodies.clone().into(),
+            transaction_witness_sets.clone().into(),
+            auxiliary_data_set.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::mary::MaryBlock> for MaryBlock {
+    fn from(native: cml_multi_era::mary::MaryBlock) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MaryBlock> for cml_multi_era::mary::MaryBlock {
+    fn from(wasm: MaryBlock) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::mary::MaryBlock> for MaryBlock {
+    fn as_ref(&self) -> &cml_multi_era::mary::MaryBlock {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MaryTransaction(cml_multi_era::mary::MaryTransaction);
+
+#[wasm_bindgen]
+impl MaryTransaction {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MaryTransaction, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MaryTransaction, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn body(&self) -> MaryTransactionBody {
+        self.0.body.clone().into()
+    }
+
+    pub fn witness_set(&self) -> AllegraTransactionWitnessSet {
+        self.0.witness_set.clone().into()
+    }
+
+    pub fn auxiliary_data(&self) -> Option<AllegraAuxiliaryData> {
+        self.0.auxiliary_data.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(
+        body: &MaryTransactionBody,
+        witness_set: &AllegraTransactionWitnessSet,
+        auxiliary_data: Option<AllegraAuxiliaryData>,
+    ) -> Self {
+        Self(cml_multi_era::mary::MaryTransaction::new(
+            body.clone().into(),
+            witness_set.clone().into(),
+            auxiliary_data.map(Into::into),
+        ))
+    }
+}
+
+impl From<cml_multi_era::mary::MaryTransaction> for MaryTransaction {
+    fn from(native: cml_multi_era::mary::MaryTransaction) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MaryTransaction> for cml_multi_era::mary::MaryTransaction {
+    fn from(wasm: MaryTransaction) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::mary::MaryTransaction> for MaryTransaction {
+    fn as_ref(&self) -> &cml_multi_era::mary::MaryTransaction {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MaryTransactionBody(cml_multi_era::mary::MaryTransactionBody);
+
+#[wasm_bindgen]
+impl MaryTransactionBody {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MaryTransactionBody, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MaryTransactionBody, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn inputs(&self) -> TransactionInputList {
+        self.0.inputs.clone().into()
+    }
+
+    pub fn outputs(&self) -> ShelleyTxOutList {
+        self.0.outputs.clone().into()
+    }
+
+    pub fn fee(&self) -> Coin {
+        self.0.fee
+    }
+
+    pub fn set_ttl(&mut self, ttl: u64) {
+        self.0.ttl = Some(ttl)
+    }
+
+    pub fn ttl(&self) -> Option<u64> {
+        self.0.ttl
+    }
+
+    pub fn set_certs(&mut self, certs: &CertificateList) {
+        self.0.certs = Some(certs.clone().into())
+    }
+
+    pub fn certs(&self) -> Option<CertificateList> {
+        self.0.certs.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_withdrawals(&mut self, withdrawals: &Withdrawals) {
+        self.0.withdrawals = Some(withdrawals.clone().into())
+    }
+
+    pub fn withdrawals(&self) -> Option<Withdrawals> {
+        self.0.withdrawals.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_update(&mut self, update: &ShelleyUpdate) {
+        self.0.update = Some(update.clone().into())
+    }
+
+    pub fn update(&self) -> Option<ShelleyUpdate> {
+        self.0.update.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_auxiliary_data_hash(&mut self, auxiliary_data_hash: &AuxiliaryDataHash) {
+        self.0.auxiliary_data_hash = Some(auxiliary_data_hash.clone().into())
+    }
+
+    pub fn auxiliary_data_hash(&self) -> Option<AuxiliaryDataHash> {
+        self.0
+            .auxiliary_data_hash
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_validity_interval_start(&mut self, validity_interval_start: u64) {
+        self.0.validity_interval_start = Some(validity_interval_start)
+    }
+
+    pub fn validity_interval_start(&self) -> Option<u64> {
+        self.0.validity_interval_start
+    }
+
+    pub fn set_mint(&mut self, mint: &Mint) {
+        self.0.mint = Some(mint.clone().into())
+    }
+
+    pub fn mint(&self) -> Option<Mint> {
+        self.0.mint.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(inputs: &TransactionInputList, outputs: &ShelleyTxOutList, fee: Coin) -> Self {
+        Self(cml_multi_era::mary::MaryTransactionBody::new(
+            inputs.clone().into(),
+            outputs.clone().into(),
+            fee,
+        ))
+    }
+}
+
+impl From<cml_multi_era::mary::MaryTransactionBody> for MaryTransactionBody {
+    fn from(native: cml_multi_era::mary::MaryTransactionBody) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MaryTransactionBody> for cml_multi_era::mary::MaryTransactionBody {
+    fn from(wasm: MaryTransactionBody) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::mary::MaryTransactionBody> for MaryTransactionBody {
+    fn as_ref(&self) -> &cml_multi_era::mary::MaryTransactionBody {
+        &self.0
+    }
+}

--- a/multi-era/wasm/src/shelley/mod.rs
+++ b/multi-era/wasm/src/shelley/mod.rs
@@ -1,0 +1,1419 @@
+// This file was code-generated using an experimental CDDL to rust tool:
+// https://github.com/dcSpark/cddl-codegen
+
+use cml_chain_wasm::{
+    GenesisHashList,
+    ProtocolVersionStruct,
+};
+use cml_chain_wasm::address::Address;
+use cml_chain_wasm::assets::Coin;
+use cml_chain_wasm::auxdata::Metadata;
+use cml_chain_wasm::block::{OperationalCert, ProtocolVersion};
+use cml_chain_wasm::certs::MIRPot;
+use cml_chain_wasm::crypto::{
+    KESSignature, Nonce, VRFCert, Vkey
+};
+use cml_crypto_wasm::{
+    AuxiliaryDataHash, BlockBodyHash, BlockHeaderHash, Ed25519KeyHash, GenesisHash, VRFVkey,
+};
+use cml_chain_wasm::{Epoch, Rational, UnitInterval, Withdrawals};
+use cml_chain_wasm::{
+    BootstrapWitnessList, CertificateList, VkeywitnessList, TransactionInputList,
+};
+use crate::{
+    MapStakeCredentialToCoin, MultisigScriptList,
+    ShelleyTransactionBodyList, ShelleyTransactionOutputList, ShelleyTransactionWitnessSetList,
+};
+use cml_core::ordered_hash_map::OrderedHashMap;
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MoveInstantaneousReward(cml_multi_era::shelley::MoveInstantaneousReward);
+
+#[wasm_bindgen]
+impl MoveInstantaneousReward {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MoveInstantaneousReward, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MoveInstantaneousReward, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn pot(&self) -> MIRPot {
+        self.0.pot
+    }
+
+    pub fn to_stake_credentials(&self) -> MapStakeCredentialToCoin {
+        self.0.to_stake_credentials.clone().into()
+    }
+
+    pub fn new(pot: MIRPot, to_stake_credentials: &MapStakeCredentialToCoin) -> Self {
+        Self(cml_multi_era::shelley::MoveInstantaneousReward::new(
+            pot.into(),
+            to_stake_credentials.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::MoveInstantaneousReward> for MoveInstantaneousReward {
+    fn from(native: cml_multi_era::shelley::MoveInstantaneousReward) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MoveInstantaneousReward> for cml_multi_era::shelley::MoveInstantaneousReward {
+    fn from(wasm: MoveInstantaneousReward) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::MoveInstantaneousReward> for MoveInstantaneousReward {
+    fn as_ref(&self) -> &cml_multi_era::shelley::MoveInstantaneousReward {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MultisigAll(cml_multi_era::shelley::MultisigAll);
+
+#[wasm_bindgen]
+impl MultisigAll {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigAll, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MultisigAll, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn multisig_scripts(&self) -> MultisigScriptList {
+        self.0.multisig_scripts.clone().into()
+    }
+
+    pub fn new(multisig_scripts: &MultisigScriptList) -> Self {
+        Self(cml_multi_era::shelley::MultisigAll::new(
+            multisig_scripts.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::MultisigAll> for MultisigAll {
+    fn from(native: cml_multi_era::shelley::MultisigAll) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultisigAll> for cml_multi_era::shelley::MultisigAll {
+    fn from(wasm: MultisigAll) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::MultisigAll> for MultisigAll {
+    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigAll {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MultisigAny(cml_multi_era::shelley::MultisigAny);
+
+#[wasm_bindgen]
+impl MultisigAny {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigAny, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MultisigAny, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn multisig_scripts(&self) -> MultisigScriptList {
+        self.0.multisig_scripts.clone().into()
+    }
+
+    pub fn new(multisig_scripts: &MultisigScriptList) -> Self {
+        Self(cml_multi_era::shelley::MultisigAny::new(
+            multisig_scripts.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::MultisigAny> for MultisigAny {
+    fn from(native: cml_multi_era::shelley::MultisigAny) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultisigAny> for cml_multi_era::shelley::MultisigAny {
+    fn from(wasm: MultisigAny) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::MultisigAny> for MultisigAny {
+    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigAny {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MultisigNOfK(cml_multi_era::shelley::MultisigNOfK);
+
+#[wasm_bindgen]
+impl MultisigNOfK {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigNOfK, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MultisigNOfK, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn n(&self) -> u64 {
+        self.0.n
+    }
+
+    pub fn multisig_scripts(&self) -> MultisigScriptList {
+        self.0.multisig_scripts.clone().into()
+    }
+
+    pub fn new(n: u64, multisig_scripts: &MultisigScriptList) -> Self {
+        Self(cml_multi_era::shelley::MultisigNOfK::new(
+            n,
+            multisig_scripts.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::MultisigNOfK> for MultisigNOfK {
+    fn from(native: cml_multi_era::shelley::MultisigNOfK) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultisigNOfK> for cml_multi_era::shelley::MultisigNOfK {
+    fn from(wasm: MultisigNOfK) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::MultisigNOfK> for MultisigNOfK {
+    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigNOfK {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MultisigPubkey(cml_multi_era::shelley::MultisigPubkey);
+
+#[wasm_bindgen]
+impl MultisigPubkey {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigPubkey, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MultisigPubkey, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn ed25519_key_hash(&self) -> Ed25519KeyHash {
+        self.0.ed25519_key_hash.clone().into()
+    }
+
+    pub fn new(ed25519_key_hash: &Ed25519KeyHash) -> Self {
+        Self(cml_multi_era::shelley::MultisigPubkey::new(
+            ed25519_key_hash.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::MultisigPubkey> for MultisigPubkey {
+    fn from(native: cml_multi_era::shelley::MultisigPubkey) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultisigPubkey> for cml_multi_era::shelley::MultisigPubkey {
+    fn from(wasm: MultisigPubkey) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::MultisigPubkey> for MultisigPubkey {
+    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigPubkey {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct MultisigScript(cml_multi_era::shelley::MultisigScript);
+
+#[wasm_bindgen]
+impl MultisigScript {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigScript, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<MultisigScript, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn new_multisig_pubkey(ed25519_key_hash: &Ed25519KeyHash) -> Self {
+        Self(cml_multi_era::shelley::MultisigScript::new_multisig_pubkey(
+            ed25519_key_hash.clone().into(),
+        ))
+    }
+
+    pub fn new_multisig_all(multisig_scripts: &MultisigScriptList) -> Self {
+        Self(cml_multi_era::shelley::MultisigScript::new_multisig_all(
+            multisig_scripts.clone().into(),
+        ))
+    }
+
+    pub fn new_multisig_any(multisig_scripts: &MultisigScriptList) -> Self {
+        Self(cml_multi_era::shelley::MultisigScript::new_multisig_any(
+            multisig_scripts.clone().into(),
+        ))
+    }
+
+    pub fn new_multisig_n_of_k(n: u64, multisig_scripts: &MultisigScriptList) -> Self {
+        Self(cml_multi_era::shelley::MultisigScript::new_multisig_n_of_k(
+            n,
+            multisig_scripts.clone().into(),
+        ))
+    }
+
+    pub fn kind(&self) -> MultisigScriptKind {
+        match &self.0 {
+            cml_multi_era::shelley::MultisigScript::MultisigPubkey(_) => {
+                MultisigScriptKind::MultisigPubkey
+            }
+            cml_multi_era::shelley::MultisigScript::MultisigAll(_) => {
+                MultisigScriptKind::MultisigAll
+            }
+            cml_multi_era::shelley::MultisigScript::MultisigAny(_) => {
+                MultisigScriptKind::MultisigAny
+            }
+            cml_multi_era::shelley::MultisigScript::MultisigNOfK(_) => {
+                MultisigScriptKind::MultisigNOfK
+            }
+        }
+    }
+
+    pub fn as_multisig_pubkey(&self) -> Option<MultisigPubkey> {
+        match &self.0 {
+            cml_multi_era::shelley::MultisigScript::MultisigPubkey(multisig_pubkey) => {
+                Some(multisig_pubkey.clone().into())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_multisig_all(&self) -> Option<MultisigAll> {
+        match &self.0 {
+            cml_multi_era::shelley::MultisigScript::MultisigAll(multisig_all) => {
+                Some(multisig_all.clone().into())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_multisig_any(&self) -> Option<MultisigAny> {
+        match &self.0 {
+            cml_multi_era::shelley::MultisigScript::MultisigAny(multisig_any) => {
+                Some(multisig_any.clone().into())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_multisig_n_of_k(&self) -> Option<MultisigNOfK> {
+        match &self.0 {
+            cml_multi_era::shelley::MultisigScript::MultisigNOfK(multisig_n_of_k) => {
+                Some(multisig_n_of_k.clone().into())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<cml_multi_era::shelley::MultisigScript> for MultisigScript {
+    fn from(native: cml_multi_era::shelley::MultisigScript) -> Self {
+        Self(native)
+    }
+}
+
+impl From<MultisigScript> for cml_multi_era::shelley::MultisigScript {
+    fn from(wasm: MultisigScript) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::MultisigScript> for MultisigScript {
+    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigScript {
+        &self.0
+    }
+}
+
+#[wasm_bindgen]
+pub enum MultisigScriptKind {
+    MultisigPubkey,
+    MultisigAll,
+    MultisigAny,
+    MultisigNOfK,
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyBlock(cml_multi_era::shelley::ShelleyBlock);
+
+#[wasm_bindgen]
+impl ShelleyBlock {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyBlock, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyBlock, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn header(&self) -> ShelleyHeader {
+        self.0.header.clone().into()
+    }
+
+    pub fn transaction_bodies(&self) -> ShelleyTransactionBodyList {
+        self.0.transaction_bodies.clone().into()
+    }
+
+    pub fn transaction_witness_sets(&self) -> ShelleyTransactionWitnessSetList {
+        self.0.transaction_witness_sets.clone().into()
+    }
+
+    pub fn transaction_metadata_set(&self) -> Metadata {
+        self.0.transaction_metadata_set.clone().into()
+    }
+
+    pub fn new(
+        header: &ShelleyHeader,
+        transaction_bodies: &ShelleyTransactionBodyList,
+        transaction_witness_sets: &ShelleyTransactionWitnessSetList,
+        transaction_metadata_set: &Metadata,
+    ) -> Self {
+        Self(cml_multi_era::shelley::ShelleyBlock::new(
+            header.clone().into(),
+            transaction_bodies.clone().into(),
+            transaction_witness_sets.clone().into(),
+            transaction_metadata_set.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyBlock> for ShelleyBlock {
+    fn from(native: cml_multi_era::shelley::ShelleyBlock) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyBlock> for cml_multi_era::shelley::ShelleyBlock {
+    fn from(wasm: ShelleyBlock) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyBlock> for ShelleyBlock {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyBlock {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyHeader(cml_multi_era::shelley::ShelleyHeader);
+
+#[wasm_bindgen]
+impl ShelleyHeader {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyHeader, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyHeader, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn body(&self) -> ShelleyHeaderBody {
+        self.0.body.clone().into()
+    }
+
+    pub fn signature(&self) -> KESSignature {
+        self.0.signature.clone().into()
+    }
+
+    pub fn new(body: &ShelleyHeaderBody, signature: &KESSignature) -> Self {
+        Self(cml_multi_era::shelley::ShelleyHeader::new(
+            body.clone().into(),
+            signature.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyHeader> for ShelleyHeader {
+    fn from(native: cml_multi_era::shelley::ShelleyHeader) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyHeader> for cml_multi_era::shelley::ShelleyHeader {
+    fn from(wasm: ShelleyHeader) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyHeader> for ShelleyHeader {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyHeader {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyHeaderBody(cml_multi_era::shelley::ShelleyHeaderBody);
+
+#[wasm_bindgen]
+impl ShelleyHeaderBody {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyHeaderBody, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyHeaderBody, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn block_number(&self) -> u64 {
+        self.0.block_number
+    }
+
+    pub fn slot(&self) -> u64 {
+        self.0.slot
+    }
+
+    pub fn prev_hash(&self) -> Option<BlockHeaderHash> {
+        self.0.prev_hash.clone().map(std::convert::Into::into)
+    }
+
+    pub fn issuer_vkey(&self) -> Vkey {
+        self.0.issuer_vkey.clone().into()
+    }
+
+    pub fn v_r_f_vkey(&self) -> VRFVkey {
+        self.0.v_r_f_vkey.clone().into()
+    }
+
+    pub fn nonce_vrf(&self) -> VRFCert {
+        self.0.nonce_vrf.clone().into()
+    }
+
+    pub fn leader_vrf(&self) -> VRFCert {
+        self.0.leader_vrf.clone().into()
+    }
+
+    pub fn block_body_size(&self) -> u64 {
+        self.0.block_body_size
+    }
+
+    pub fn block_body_hash(&self) -> BlockBodyHash {
+        self.0.block_body_hash.clone().into()
+    }
+
+    pub fn operational_cert(&self) -> OperationalCert {
+        self.0.operational_cert.clone().into()
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.0.protocol_version.clone().into()
+    }
+
+    pub fn new(
+        block_number: u64,
+        slot: u64,
+        prev_hash: Option<BlockHeaderHash>,
+        issuer_vkey: &Vkey,
+        v_r_f_vkey: &VRFVkey,
+        nonce_vrf: &VRFCert,
+        leader_vrf: &VRFCert,
+        block_body_size: u64,
+        block_body_hash: &BlockBodyHash,
+        operational_cert: &OperationalCert,
+        protocol_version: &ProtocolVersion,
+    ) -> Self {
+        Self(cml_multi_era::shelley::ShelleyHeaderBody::new(
+            block_number,
+            slot,
+            prev_hash.map(Into::into),
+            issuer_vkey.clone().into(),
+            v_r_f_vkey.clone().into(),
+            nonce_vrf.clone().into(),
+            leader_vrf.clone().into(),
+            block_body_size,
+            block_body_hash.clone().into(),
+            operational_cert.clone().into(),
+            protocol_version.clone().into(),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyHeaderBody> for ShelleyHeaderBody {
+    fn from(native: cml_multi_era::shelley::ShelleyHeaderBody) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyHeaderBody> for cml_multi_era::shelley::ShelleyHeaderBody {
+    fn from(wasm: ShelleyHeaderBody) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyHeaderBody> for ShelleyHeaderBody {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyHeaderBody {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyProposedProtocolParameterUpdates(
+    cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates,
+);
+
+#[wasm_bindgen]
+impl ShelleyProposedProtocolParameterUpdates {
+    pub fn new() -> Self {
+        Self(OrderedHashMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(
+        &mut self,
+        key: &GenesisHash,
+        value: &ShelleyProtocolParamUpdate,
+    ) -> Option<ShelleyProtocolParamUpdate> {
+        self.0
+            .insert(key.clone().into(), value.clone().into())
+            .map(Into::into)
+    }
+
+    pub fn get(&self, key: &GenesisHash) -> Option<ShelleyProtocolParamUpdate> {
+        self.0.get(key.as_ref()).map(|v| v.clone().into())
+    }
+
+    pub fn keys(&self) -> GenesisHashList {
+        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>().into()
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates>
+    for ShelleyProposedProtocolParameterUpdates
+{
+    fn from(native: cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyProposedProtocolParameterUpdates>
+    for cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates
+{
+    fn from(wasm: ShelleyProposedProtocolParameterUpdates) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates>
+    for ShelleyProposedProtocolParameterUpdates
+{
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyProtocolParamUpdate(cml_multi_era::shelley::ShelleyProtocolParamUpdate);
+
+#[wasm_bindgen]
+impl ShelleyProtocolParamUpdate {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyProtocolParamUpdate, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyProtocolParamUpdate, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_minfee_a(&mut self, minfee_a: u64) {
+        self.0.minfee_a = Some(minfee_a)
+    }
+
+    pub fn minfee_a(&self) -> Option<u64> {
+        self.0.minfee_a
+    }
+
+    pub fn set_minfee_b(&mut self, minfee_b: u64) {
+        self.0.minfee_b = Some(minfee_b)
+    }
+
+    pub fn minfee_b(&self) -> Option<u64> {
+        self.0.minfee_b
+    }
+
+    pub fn set_max_block_body_size(&mut self, max_block_body_size: u64) {
+        self.0.max_block_body_size = Some(max_block_body_size)
+    }
+
+    pub fn max_block_body_size(&self) -> Option<u64> {
+        self.0.max_block_body_size
+    }
+
+    pub fn set_max_transaction_size(&mut self, max_transaction_size: u64) {
+        self.0.max_transaction_size = Some(max_transaction_size)
+    }
+
+    pub fn max_transaction_size(&self) -> Option<u64> {
+        self.0.max_transaction_size
+    }
+
+    pub fn set_max_block_header_size(&mut self, max_block_header_size: u64) {
+        self.0.max_block_header_size = Some(max_block_header_size)
+    }
+
+    pub fn max_block_header_size(&self) -> Option<u64> {
+        self.0.max_block_header_size
+    }
+
+    pub fn set_key_deposit(&mut self, key_deposit: Coin) {
+        self.0.key_deposit = Some(key_deposit)
+    }
+
+    pub fn key_deposit(&self) -> Option<Coin> {
+        self.0.key_deposit
+    }
+
+    pub fn set_pool_deposit(&mut self, pool_deposit: Coin) {
+        self.0.pool_deposit = Some(pool_deposit)
+    }
+
+    pub fn pool_deposit(&self) -> Option<Coin> {
+        self.0.pool_deposit
+    }
+
+    pub fn set_maximum_epoch(&mut self, maximum_epoch: Epoch) {
+        self.0.maximum_epoch = Some(maximum_epoch)
+    }
+
+    pub fn maximum_epoch(&self) -> Option<Epoch> {
+        self.0.maximum_epoch
+    }
+
+    pub fn set_n_opt(&mut self, n_opt: u64) {
+        self.0.n_opt = Some(n_opt)
+    }
+
+    pub fn n_opt(&self) -> Option<u64> {
+        self.0.n_opt
+    }
+
+    pub fn set_pool_pledge_influence(&mut self, pool_pledge_influence: &Rational) {
+        self.0.pool_pledge_influence = Some(pool_pledge_influence.clone().into())
+    }
+
+    pub fn pool_pledge_influence(&self) -> Option<Rational> {
+        self.0
+            .pool_pledge_influence
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_expansion_rate(&mut self, expansion_rate: &UnitInterval) {
+        self.0.expansion_rate = Some(expansion_rate.clone().into())
+    }
+
+    pub fn expansion_rate(&self) -> Option<UnitInterval> {
+        self.0.expansion_rate.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_treasury_growth_rate(&mut self, treasury_growth_rate: &UnitInterval) {
+        self.0.treasury_growth_rate = Some(treasury_growth_rate.clone().into())
+    }
+
+    pub fn treasury_growth_rate(&self) -> Option<UnitInterval> {
+        self.0
+            .treasury_growth_rate
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_decentralization_constant(&mut self, decentralization_constant: &UnitInterval) {
+        self.0.decentralization_constant = Some(decentralization_constant.clone().into())
+    }
+
+    pub fn decentralization_constant(&self) -> Option<UnitInterval> {
+        self.0
+            .decentralization_constant
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_extra_entropy(&mut self, extra_entropy: &Nonce) {
+        self.0.extra_entropy = Some(extra_entropy.clone().into())
+    }
+
+    pub fn extra_entropy(&self) -> Option<Nonce> {
+        self.0.extra_entropy.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_protocol_version(&mut self, protocol_version: &ProtocolVersionStruct) {
+        self.0.protocol_version = Some(protocol_version.clone().into())
+    }
+
+    pub fn protocol_version(&self) -> Option<ProtocolVersionStruct> {
+        self.0
+            .protocol_version
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn set_min_utxo_value(&mut self, min_utxo_value: Coin) {
+        self.0.min_utxo_value = Some(min_utxo_value)
+    }
+
+    pub fn min_utxo_value(&self) -> Option<Coin> {
+        self.0.min_utxo_value
+    }
+
+    pub fn new() -> Self {
+        Self(cml_multi_era::shelley::ShelleyProtocolParamUpdate::new())
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyProtocolParamUpdate> for ShelleyProtocolParamUpdate {
+    fn from(native: cml_multi_era::shelley::ShelleyProtocolParamUpdate) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyProtocolParamUpdate> for cml_multi_era::shelley::ShelleyProtocolParamUpdate {
+    fn from(wasm: ShelleyProtocolParamUpdate) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyProtocolParamUpdate> for ShelleyProtocolParamUpdate {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyProtocolParamUpdate {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTransaction(cml_multi_era::shelley::ShelleyTransaction);
+
+#[wasm_bindgen]
+impl ShelleyTransaction {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransaction, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyTransaction, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn body(&self) -> ShelleyTransactionBody {
+        self.0.body.clone().into()
+    }
+
+    pub fn witness_set(&self) -> ShelleyTransactionWitnessSet {
+        self.0.witness_set.clone().into()
+    }
+
+    pub fn metadata(&self) -> Option<Metadata> {
+        self.0.metadata.clone().map(std::convert::Into::into)
+    }
+
+    pub fn new(
+        body: &ShelleyTransactionBody,
+        witness_set: &ShelleyTransactionWitnessSet,
+        metadata: Option<Metadata>,
+    ) -> Self {
+        Self(cml_multi_era::shelley::ShelleyTransaction::new(
+            body.clone().into(),
+            witness_set.clone().into(),
+            metadata.map(Into::into),
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyTransaction> for ShelleyTransaction {
+    fn from(native: cml_multi_era::shelley::ShelleyTransaction) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTransaction> for cml_multi_era::shelley::ShelleyTransaction {
+    fn from(wasm: ShelleyTransaction) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyTransaction> for ShelleyTransaction {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransaction {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTransactionBody(cml_multi_era::shelley::ShelleyTransactionBody);
+
+#[wasm_bindgen]
+impl ShelleyTransactionBody {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransactionBody, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyTransactionBody, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn inputs(&self) -> TransactionInputList {
+        self.0.inputs.clone().into()
+    }
+
+    pub fn outputs(&self) -> ShelleyTransactionOutputList {
+        self.0.outputs.clone().into()
+    }
+
+    pub fn fee(&self) -> Coin {
+        self.0.fee
+    }
+
+    pub fn ttl(&self) -> u64 {
+        self.0.ttl
+    }
+
+    pub fn set_certs(&mut self, certs: &CertificateList) {
+        self.0.certs = Some(certs.clone().into())
+    }
+
+    pub fn certs(&self) -> Option<CertificateList> {
+        self.0.certs.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_withdrawals(&mut self, withdrawals: &Withdrawals) {
+        self.0.withdrawals = Some(withdrawals.clone().into())
+    }
+
+    pub fn withdrawals(&self) -> Option<Withdrawals> {
+        self.0.withdrawals.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_update(&mut self, update: &ShelleyUpdate) {
+        self.0.update = Some(update.clone().into())
+    }
+
+    pub fn update(&self) -> Option<ShelleyUpdate> {
+        self.0.update.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_auxiliary_data_hash(&mut self, auxiliary_data_hash: &AuxiliaryDataHash) {
+        self.0.auxiliary_data_hash = Some(auxiliary_data_hash.clone().into())
+    }
+
+    pub fn auxiliary_data_hash(&self) -> Option<AuxiliaryDataHash> {
+        self.0
+            .auxiliary_data_hash
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn new(
+        inputs: &TransactionInputList,
+        outputs: &ShelleyTransactionOutputList,
+        fee: Coin,
+        ttl: u64,
+    ) -> Self {
+        Self(cml_multi_era::shelley::ShelleyTransactionBody::new(
+            inputs.clone().into(),
+            outputs.clone().into(),
+            fee,
+            ttl,
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyTransactionBody> for ShelleyTransactionBody {
+    fn from(native: cml_multi_era::shelley::ShelleyTransactionBody) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTransactionBody> for cml_multi_era::shelley::ShelleyTransactionBody {
+    fn from(wasm: ShelleyTransactionBody) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyTransactionBody> for ShelleyTransactionBody {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransactionBody {
+        &self.0
+    }
+}
+
+pub type ShelleyTransactionIndex = u16;
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTransactionOutput(cml_multi_era::shelley::ShelleyTransactionOutput);
+
+#[wasm_bindgen]
+impl ShelleyTransactionOutput {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransactionOutput, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyTransactionOutput, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn address(&self) -> Address {
+        self.0.address.clone().into()
+    }
+
+    pub fn amount(&self) -> Coin {
+        self.0.amount
+    }
+
+    pub fn new(address: &Address, amount: Coin) -> Self {
+        Self(cml_multi_era::shelley::ShelleyTransactionOutput::new(
+            address.clone().into(),
+            amount,
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyTransactionOutput> for ShelleyTransactionOutput {
+    fn from(native: cml_multi_era::shelley::ShelleyTransactionOutput) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTransactionOutput> for cml_multi_era::shelley::ShelleyTransactionOutput {
+    fn from(wasm: ShelleyTransactionOutput) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyTransactionOutput> for ShelleyTransactionOutput {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransactionOutput {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyTransactionWitnessSet(cml_multi_era::shelley::ShelleyTransactionWitnessSet);
+
+#[wasm_bindgen]
+impl ShelleyTransactionWitnessSet {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransactionWitnessSet, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyTransactionWitnessSet, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn set_vkeywitnesses(&mut self, vkeywitnesses: &VkeywitnessList) {
+        self.0.vkeywitnesses = Some(vkeywitnesses.clone().into())
+    }
+
+    pub fn vkeywitnesses(&self) -> Option<VkeywitnessList> {
+        self.0.vkeywitnesses.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_native_scripts(&mut self, native_scripts: &MultisigScriptList) {
+        self.0.native_scripts = Some(native_scripts.clone().into())
+    }
+
+    pub fn native_scripts(&self) -> Option<MultisigScriptList> {
+        self.0.native_scripts.clone().map(std::convert::Into::into)
+    }
+
+    pub fn set_bootstrap_witnesses(&mut self, bootstrap_witnesses: &BootstrapWitnessList) {
+        self.0.bootstrap_witnesses = Some(bootstrap_witnesses.clone().into())
+    }
+
+    pub fn bootstrap_witnesses(&self) -> Option<BootstrapWitnessList> {
+        self.0
+            .bootstrap_witnesses
+            .clone()
+            .map(std::convert::Into::into)
+    }
+
+    pub fn new() -> Self {
+        Self(cml_multi_era::shelley::ShelleyTransactionWitnessSet::new())
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyTransactionWitnessSet> for ShelleyTransactionWitnessSet {
+    fn from(native: cml_multi_era::shelley::ShelleyTransactionWitnessSet) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyTransactionWitnessSet> for cml_multi_era::shelley::ShelleyTransactionWitnessSet {
+    fn from(wasm: ShelleyTransactionWitnessSet) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyTransactionWitnessSet> for ShelleyTransactionWitnessSet {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransactionWitnessSet {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ShelleyUpdate(cml_multi_era::shelley::ShelleyUpdate);
+
+#[wasm_bindgen]
+impl ShelleyUpdate {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyUpdate, JsValue> {
+        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
+    }
+
+    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+        serde_wasm_bindgen::to_value(&self.0)
+            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
+    }
+
+    pub fn from_json(json: &str) -> Result<ShelleyUpdate, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
+    }
+
+    pub fn shelley_proposed_protocol_parameter_updates(
+        &self,
+    ) -> ShelleyProposedProtocolParameterUpdates {
+        self.0
+            .shelley_proposed_protocol_parameter_updates
+            .clone()
+            .into()
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.0.epoch
+    }
+
+    pub fn new(
+        shelley_proposed_protocol_parameter_updates: &ShelleyProposedProtocolParameterUpdates,
+        epoch: Epoch,
+    ) -> Self {
+        Self(cml_multi_era::shelley::ShelleyUpdate::new(
+            shelley_proposed_protocol_parameter_updates.clone().into(),
+            epoch,
+        ))
+    }
+}
+
+impl From<cml_multi_era::shelley::ShelleyUpdate> for ShelleyUpdate {
+    fn from(native: cml_multi_era::shelley::ShelleyUpdate) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ShelleyUpdate> for cml_multi_era::shelley::ShelleyUpdate {
+    fn from(wasm: ShelleyUpdate) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<cml_multi_era::shelley::ShelleyUpdate> for ShelleyUpdate {
+    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyUpdate {
+        &self.0
+    }
+}

--- a/specs/multiera/allegra/mod.cddl
+++ b/specs/multiera/allegra/mod.cddl
@@ -1,0 +1,43 @@
+allegra_block = [
+  header: shelley_header,
+  transaction_bodies         : [* allegra_transaction_body],
+  transaction_witness_sets   : [* allegra_transaction_witness_set],
+  auxiliary_data_set   :
+      { * transaction_index => allegra_auxiliary_data }
+  ]; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
+
+allegra_transaction = [
+  body: allegra_transaction_body,
+  witness_set: allegra_transaction_witness_set,
+  auxiliary_data: allegra_auxiliary_data / null,
+]
+
+allegra_transaction_witness_set = {
+  ? 0: [* vkeywitness ],        ; @name vkeywitnesses
+  ? 1: [* native_script ],      ; @name native_scripts
+  ? 2: [* bootstrap_witness ],  ; @name bootstrap_witnesses
+  ; In the future, new kinds of witnesses can be added like this:
+  ; , ? 4: [* foo_script ]
+  ; , ? 5: [* plutus_script ]
+  }
+
+
+
+allegra_auxiliary_data = shelley_aux_data / shelley_ma_aux_data
+
+; allegra differences
+allegra_transaction_body = {
+  0 : [* transaction_input],           ; @name inputs
+  1 : [* shelley_transaction_output],  ; @name outputs
+  2 : coin,                            ; @name fee
+  ? 3 : uint,                          ; @name ttl
+  ? 4 : [* certificate],               ; @name certs
+  ? 5 : withdrawals,                   ; @name withdrawals
+  ? 6 : shelley_update,                ; @name update
+  ? 7 : auxiliary_data_hash,           ; @name auxiliary_data_hash
+  ? 8 : uint,                          ; @name validity_interval_start
+  }

--- a/specs/multiera/alonzo/mod.cddl
+++ b/specs/multiera/alonzo/mod.cddl
@@ -1,0 +1,101 @@
+alonzo_block =
+  [ header: shelley_header
+  , transaction_bodies         : [* alonzo_transaction_body]
+  , transaction_witness_sets   : [* alonzo_transaction_witness_set]
+  , auxiliary_data_set         : {* transaction_index => alonzo_auxiliary_data }
+  , invalid_transactions       : [* transaction_index ]                   
+  ]; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
+
+alonzo_transaction = [
+  body: alonzo_transaction_body,
+  witness_set: alonzo_transaction_witness_set,
+  is_valid: bool,
+  auxiliary_data: alonzo_auxiliary_data / null,
+]
+
+alonzo_transaction_output = shelley_tx_out / alonzo_tx_out
+
+alonzo_transaction_body = {
+    0 : [* transaction_input],   ; @name inputs
+    1 : [* alonzo_transaction_output], ; @name outputs
+    2 : coin,                    ; @name fee
+  ? 3 : uint,                    ; @name ttl
+  ? 4 : [* certificate],         ; @name certs
+  ? 5 : withdrawals,             ; @name withdrawals
+  ? 6 : alonzo_update,           ; @name update
+  ? 7 : auxiliary_data_hash,     ; @name auxiliary_data_hash
+  ? 8 : uint,                    ; @name validity_interval_start
+  ? 9 : mint,                    ; @name mint
+  ? 11 : script_data_hash,       ; @name script_data_hash
+  ? 13 : [* transaction_input],  ; @name collateral_inputs
+  ? 14 : required_signers,       ; @name required_signers
+  ? 15 : network_id,             ; @name network_id
+ }
+
+alonzo_update = [
+  proposed_protocol_parameter_updates: alonzo_proposed_protocol_parameter_updates,
+  epoch,
+]
+
+alonzo_proposed_protocol_parameter_updates =
+  { * genesis_hash => alonzo_protocol_param_update }
+
+alonzo_protocol_param_update = {
+  ? 0:  uint,               ; @name minfee_a
+  ? 1:  uint,               ; @name minfee_b
+  ? 2:  uint,               ; @name max_block_body_size
+  ? 3:  uint,               ; @name max_transaction_size
+  ? 4:  uint,               ; @name max_block_header_size
+  ? 5:  coin,               ; @name key_deposit
+  ? 6:  coin,               ; @name pool_deposit
+  ? 7: epoch,               ; @name maximum_epoch
+  ? 8: uint,                ; @name n_opt desired number of stake pools
+  ? 9: rational,            ; @name pool_pledge_influence
+  ? 10: unit_interval,      ; @name expansion_rate
+  ? 11: unit_interval,      ; @name treasury_growth_rate
+  ? 12: unit_interval,      ; @name decentralization_constant
+  ? 13: $nonce,             ; @name extra_entropy
+  ? 14: protocol_version_struct, ; @name protocol_version
+  ? 16: coin,               ; @name min_pool_cost
+  ? 17: coin,               ; @name ada_per_utxo_byte
+  ? 18: alonzo_costmdls,    ; @name cost_models_for_script_languages
+  ? 19: ex_unit_prices,     ; @name execution_costs
+  ? 20: ex_units,           ; @name max_tx_ex_units
+  ? 21: ex_units,           ; @name max_block_ex_units
+  ? 22: uint,               ; @name max value size
+  ? 23: uint,               ; @name collateral_percentage
+  ? 24: uint,               ; @name max_collateral_inputs
+}
+
+alonzo_transaction_witness_set = {
+  ? 0: [* vkeywitness ],        ; @name vkeywitnesses
+  ? 1: [* native_script ],      ; @name native_scripts
+  ? 2: [* bootstrap_witness ],  ; @name bootstrap_witnesses
+  ? 3: [* plutus_v1_script ],   ; @name plutus_v1_scripts
+  ? 4: [* plutus_data ],        ; @name plutus_datums
+  ? 5: [* redeemer ],           ; @name redeemers
+}
+
+; The keys to the cost model map are not present in the serialization.
+; The values in the serialization are assumed to be ordered
+; lexicographically by their correpsonding key value.
+; The key values are listed in sorted_cost_model_keys.txt.
+alonzo_costmdls = {
+  0 : [ 166*166 int ], ; @name plutus_v1
+}
+
+; TODO: rename babbage structs and define them here
+alonzo_only_aux_data = #6.259({
+	? 0 => metadata,               ; @name metadata        
+  ? 1 => [ * native_script ],    ; @name native_scripts
+  ? 2 => [ * plutus_v1_script ], ; @name plutus_v1_scripts
+})
+
+alonzo_auxiliary_data =
+    shelley_aux_data     ; @name shelley
+  / shelley_ma_aux_data  ; @name shelley_m_a
+  / alonzo_only_aux_data ; @name alonzo 

--- a/specs/multiera/cml_chain/address.cddl
+++ b/specs/multiera/cml_chain/address.cddl
@@ -1,0 +1,3 @@
+address = _CDDL_CODEGEN_EXTERN_TYPE_
+reward_address = _CDDL_CODEGEN_EXTERN_TYPE_
+reward_account = _CDDL_CODEGEN_EXTERN_TYPE_

--- a/specs/multiera/cml_chain/assets.cddl
+++ b/specs/multiera/cml_chain/assets.cddl
@@ -1,0 +1,7 @@
+value = _CDDL_CODEGEN_EXTERN_TYPE_
+asset_name = _CDDL_CODEGEN_EXTERN_TYPE_
+policy_id = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+
+int64 = -9223372036854775808 .. 9223372036854775807 ; @no_alias
+mint = { * policy_id => { * asset_name => int64 } }
+coin = uint

--- a/specs/multiera/cml_chain/auxdata.cddl
+++ b/specs/multiera/cml_chain/auxdata.cddl
@@ -1,0 +1,3 @@
+metadata = _CDDL_CODEGEN_EXTERN_TYPE_
+shelley_aux_data = _CDDL_CODEGEN_EXTERN_TYPE_
+shelley_ma_aux_data = _CDDL_CODEGEN_EXTERN_TYPE_

--- a/specs/multiera/cml_chain/block.cddl
+++ b/specs/multiera/cml_chain/block.cddl
@@ -1,0 +1,13 @@
+protocol_version = (
+    major: uint,
+    minor: uint,
+)
+
+protocol_version_struct = [protocol_version]
+
+operational_cert =
+  ( hot_vkey        : $KES_vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : ed25519_signature
+  )

--- a/specs/multiera/cml_chain/byron.cddl
+++ b/specs/multiera/cml_chain/byron.cddl
@@ -1,0 +1,37 @@
+; Basic Cardano Types
+
+; blake2b224 = bytes .size 28
+; bip32_public_key = bytes .size 64
+; script = bytes .size 32
+; public_key = bytes .size 32
+
+blake2b224 = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+blake2b256 = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+bip32_public_key = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+byron_script = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+public_key = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+
+; blake2b224 of sha256 of cbor(byron_addr_type, spending_data, addr_attributes)
+address_id = _CDDL_CODEGEN_RAW_BYTES_TYPE_ ; blake2b224 
+stakeholder_id = _CDDL_CODEGEN_RAW_BYTES_TYPE_; blake2b224
+crc32 = _CDDL_CODEGEN_EXTERN_TYPE_ ; uint .size 4 ; @newtype
+protocol_magic = _CDDL_CODEGEN_EXTERN_TYPE_ ; uint .size 4 ; @newtype
+hd_address_payload = _CDDL_CODEGEN_EXTERN_TYPE_
+
+; Addresses
+
+; cddl had bootstrap as (1, uint) but byron/mod.rs had no uint field.
+stake_distribution = _CDDL_CODEGEN_EXTERN_TYPE_
+
+spending_data = _CDDL_CODEGEN_EXTERN_TYPE_
+
+
+byron_addr_type = 0 ; @name PublicKey
+          / 1 ; @name Script
+          / 2 ; @name Redeem
+
+addr_attributes = _CDDL_CODEGEN_EXTERN_TYPE_
+
+address_content = _CDDL_CODEGEN_EXTERN_TYPE_
+byron_address = _CDDL_CODEGEN_EXTERN_TYPE_
+byron_tx_out = _CDDL_CODEGEN_EXTERN_TYPE_

--- a/specs/multiera/cml_chain/certs.cddl
+++ b/specs/multiera/cml_chain/certs.cddl
@@ -1,0 +1,10 @@
+certificate = _CDDL_CODEGEN_EXTERN_TYPE_
+stake_credential = _CDDL_CODEGEN_EXTERN_TYPE_
+pool_params = _CDDL_CODEGEN_EXTERN_TYPE_
+; also port, ipv4, single_host_addr, etc but these are only used by relay
+relay = _CDDL_CODEGEN_EXTERN_TYPE_
+pool_metadata = _CDDL_CODEGEN_EXTERN_TYPE_
+
+; to be deleted - to make sure it stores the encoding vars
+MIR_pot = 0 ; @name reserve
+        / 1 ; @name treasury

--- a/specs/multiera/cml_chain/crypto.cddl
+++ b/specs/multiera/cml_chain/crypto.cddl
@@ -1,0 +1,23 @@
+vkeywitness = _CDDL_CODEGEN_EXTERN_TYPE_
+bootstrap_witness = _CDDL_CODEGEN_EXTERN_TYPE_
+nonce = _CDDL_CODEGEN_EXTERN_TYPE_
+KES_signature = _CDDL_CODEGEN_EXTERN_TYPE_
+VRF_cert = _CDDL_CODEGEN_EXTERN_TYPE_
+
+vkey = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+VRF_vkey = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+natural = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+KES_vkey = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+ed25519_signature = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+ed25519_key_hash = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+genesis_delegate_hash = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+genesis_hash           = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+VRF_key_hash           = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+auxiliary_data_hash   = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+pool_metadata_hash    = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+script_hash            = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+datum_hash = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+block_body_hash = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+block_header_hash = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+transaction_hash = _CDDL_CODEGEN_RAW_BYTES_TYPE_
+script_data_hash = _CDDL_CODEGEN_RAW_BYTES_TYPE_

--- a/specs/multiera/cml_chain/mod.cddl
+++ b/specs/multiera/cml_chain/mod.cddl
@@ -1,0 +1,21 @@
+; this module is structured so that imports won't have to be changed at all.
+; just replace use crate::cml_chain::{foo, bar, etc...} with use cml_chain::{foo, bar, etc...}
+; some types aren't _CDDL_CODEGEN_EXTERN_TYPE_ or _CDDL_CODEGEN_RAW_BYTES_TYPE_
+; and instead have their original definitions.
+; this is in places where _CDDL_CODEGEN_EXTERN_TYPE_ needs the extra type info
+; to be able to remember encodings (needs to know type and where to store the info
+; since you can't just call member.serialize() generically and have it remember the encodings
+; for when the encodings aren't interally stored (primtives mostly)).
+; so just delete the cml_chain directory afterwards and change the import crate with ctrl-r.
+
+
+unit_interval = _CDDL_CODEGEN_EXTERN_TYPE_
+rational = _CDDL_CODEGEN_EXTERN_TYPE_
+
+
+delta_coin = _CDDL_CODEGEN_EXTERN_TYPE_
+
+network_id = uint .size 4
+
+epoch = uint
+withdrawals = { * reward_account => coin }

--- a/specs/multiera/cml_chain/plutus.cddl
+++ b/specs/multiera/cml_chain/plutus.cddl
@@ -1,0 +1,5 @@
+plutus_data = _CDDL_CODEGEN_EXTERN_TYPE_
+redeemer = _CDDL_CODEGEN_EXTERN_TYPE_
+ex_units = _CDDL_CODEGEN_EXTERN_TYPE_
+ex_unit_prices = _CDDL_CODEGEN_EXTERN_TYPE_
+plutus_v1_script = _CDDL_CODEGEN_EXTERN_TYPE_

--- a/specs/multiera/cml_chain/transaction.cddl
+++ b/specs/multiera/cml_chain/transaction.cddl
@@ -1,0 +1,8 @@
+transaction_input = _CDDL_CODEGEN_EXTERN_TYPE_
+transaction_index = uint .size 2
+transaction_metadatum_label = uint
+transaction_metadatum = _CDDL_CODEGEN_EXTERN_TYPE_
+required_signers = [* ed25519_key_hash]
+native_script = _CDDL_CODEGEN_EXTERN_TYPE_
+shelley_tx_out = _CDDL_CODEGEN_EXTERN_TYPE_
+alonzo_tx_out = _CDDL_CODEGEN_EXTERN_TYPE_

--- a/specs/multiera/lib.cddl
+++ b/specs/multiera/lib.cddl
@@ -1,0 +1,9 @@
+; babbage block
+block = _CDDL_CODEGEN_EXTERN_TYPE_
+
+mutli_era_block =
+    shelley_block ; @name Shelley
+  / allegra_block ; @name Allegra
+  / mary_block    ; @name Mary
+  / alonzo_block  ; @name Alonzo
+  / block         ; @name Babbage

--- a/specs/multiera/mary/mod.cddl
+++ b/specs/multiera/mary/mod.cddl
@@ -1,0 +1,32 @@
+mary_block = [
+  header: shelley_header,
+  transaction_bodies         : [* mary_transaction_body],
+  transaction_witness_sets   : [* allegra_transaction_witness_set],
+  auxiliary_data_set   :
+      { * transaction_index => allegra_auxiliary_data }
+  ]; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
+
+mary_transaction = [
+  body: mary_transaction_body,
+  witness_set: allegra_transaction_witness_set,
+  auxiliary_data: allegra_auxiliary_data / null,
+]
+
+mary_transaction_body = {
+    0 : [* transaction_input],  ; @name inputs
+    1 : [* shelley_tx_out],     ; @name outputs
+    2 : coin,                   ; @name fee
+  ? 3 : uint,                 ; @name ttl
+  ? 4 : [* certificate],      ; @name certs
+  ? 5 : withdrawals,          ; @name withdrawals
+  ? 6 : shelley_update,       ; @name update
+  ? 7 : auxiliary_data_hash,  ; @name auxiliary_data_hash
+  ? 8 : uint,                 ; @name validity_interval_start
+  ? 9 : mint,                 ; @name mint
+}
+
+

--- a/specs/multiera/shelley/mod.cddl
+++ b/specs/multiera/shelley/mod.cddl
@@ -1,0 +1,112 @@
+shelley_block = [
+  header: shelley_header,
+  transaction_bodies         : [* shelley_transaction_body],
+  transaction_witness_sets   : [* shelley_transaction_witness_set],
+  transaction_metadata_set   : metadata,
+]
+   ; Valid blocks must also satisfy the following two constraints:
+   ; 1) the length of transaction_bodies and transaction_witness_sets
+   ;    must be the same
+   ; 2) every transaction_index must be strictly smaller than the
+   ;    length of transaction_bodies
+
+shelley_transaction = [
+  body: shelley_transaction_body,
+  witness_set: shelley_transaction_witness_set,
+  metadata: metadata / null,
+]
+
+shelley_transaction_index = uint .size 2
+
+shelley_header = [
+  body: shelley_header_body,
+  signature : KES_signature,
+]
+
+shelley_header_body = [
+  block_number     : uint,
+  slot             : uint,
+  prev_hash        : block_header_hash / null,
+  issuer_vkey      : $vkey,
+  VRF_vkey         : $VRF_vkey,
+  nonce_vrf        : $VRF_cert,
+  leader_vrf       : $VRF_cert,
+  block_body_size  : uint,
+  block_body_hash  : block_body_hash, ; merkle triple root
+  operational_cert,
+  protocol_version,
+]
+
+shelley_operational_cert =
+  ( hot_vkey        : $kes_vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : $signature
+  )
+
+shelley_transaction_body = {
+    0 : [* transaction_input],           ; @name inputs
+    1 : [* shelley_transaction_output],  ; @name outputs
+    2 : coin,                            ; @name fee
+    3 : uint,                            ; @name ttl
+  ? 4 : [* certificate],                 ; @name certs
+  ? 5 : withdrawals,                     ; @name withdrawals
+  ? 6 : shelley_update,                  ; @name update
+  ? 7 : auxiliary_data_hash,             ; @name auxiliary_data_hash
+}
+
+shelley_transaction_output = [address, amount : coin]
+
+move_instantaneous_reward = [
+  pot: MIR_pot,
+  to_stake_credentials: { * stake_credential => coin }
+]
+; The first field determines where the funds are drawn from.
+; 0 denotes the reserves, 1 denotes the treasury.
+
+shelley_update = [ shelley_proposed_protocol_parameter_updates
+         , epoch
+         ]
+
+shelley_proposed_protocol_parameter_updates =
+  { * genesis_hash => shelley_protocol_param_update }
+
+shelley_protocol_param_update = {
+  ? 0:  uint,               ; @name minfee_a
+  ? 1:  uint,               ; @name minfee_b
+  ? 2:  uint,               ; @name max_block_body_size
+  ? 3:  uint,               ; @name max_transaction_size
+  ? 4:  uint,               ; @name max_block_header_size
+  ? 5:  coin,               ; @name key_deposit
+  ? 6:  coin,               ; @name pool_deposit
+  ? 7: epoch,               ; @name maximum_epoch
+  ? 8: uint,                ; @name n_opt desired number of stake pools
+  ? 9: rational,            ; @name pool_pledge_influence
+  ? 10: unit_interval,      ; @name expansion_rate
+  ? 11: unit_interval,      ; @name treasury_growth_rate
+  ? 12: unit_interval,      ; @name decentralization_constant
+  ? 13: $nonce,             ; @name extra_entropy
+  ? 14: protocol_version_struct, ; @name protocol_version
+  ? 15: coin,               ; @name min_utxo_value
+}
+
+shelley_transaction_witness_set = {
+  ? 0 => [* vkeywitness ],       ; @name vkeywitnesses
+  ? 1 => [* multisig_script ],   ; @name native_scripts
+  ? 2 => [* bootstrap_witness ], ; @name bootstrap_witnesses
+  ; In the future, new kinds of witnesses can be added like this:
+  ; , ?3 => [* monetary_policy_script ]
+  ; , ?4 => [* plutus_script ]
+}
+
+multisig_script =
+  [ multisig_pubkey
+  // multisig_all
+  // multisig_any
+  // multisig_n_of_k
+  ]
+
+multisig_pubkey = (tag: 0, ed25519_key_hash)
+multisig_all = (tag: 1, [ * multisig_script ])
+multisig_any = (tag: 2, [ * multisig_script ])
+multisig_n_of_k = (tag: 3, n: uint, [ * multisig_script ])


### PR DESCRIPTION
Adds `cml-multi-era` + `cml-multi-era-wasm` which allow era-agnostic parsing of Cardano blocks/types.

Eras supported are Shelley, Allegra, Mary, Alonzo and Babbage.

Byron will likely be added at a later date but it requires more work right now for cddl-codegen and testing.

Everything in this crate has been tested on mainnet and preprod for both parsing and round-trip CBOR encoding (preserving encodings).

These crates were generated based off of the `specs/multi-era` directory.

Fixes #228 