### PR TITLE
Change Babbage block header encoding

### DIFF
--- a/specs/babbage/block.cddl
+++ b/specs/babbage/block.cddl
@@ -24,8 +24,8 @@ header_body =
   , vrf_result       : $VRF_cert ; New, replaces nonce_vrf and leader_vrf
   , block_body_size  : uint
   , block_body_hash  : block_body_hash ; merkle triple root
-  , operational_cert
-  , protocol_version
+  , operational_cert: [operational_cert],
+  , protocol_version: [protocol_version],
   ]
 
 operational_cert =


### PR DESCRIPTION
While all other eras have the header use basic encoding for the operational cert + protocol version (i.e. inline the fields inside), the babbage blocks we've seen seem to not follow the CDDL spec and instead treat them as if they were not basic groups but instead array groups.