### PR TITLE
WASM build fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "chain/rust",
     "chain/wasm",
 # names changed - will be replaced in the PR coming soon to regen chain
-#    "chain/wasm/json-gen",
+    "chain/wasm/json-gen",
     "cip25/rust",
     "cip25/wasm",
     "cip25/wasm/json-gen",

--- a/chain/rust/src/assets.rs
+++ b/chain/rust/src/assets.rs
@@ -5,7 +5,7 @@ use cml_core::{
     ordered_hash_map::OrderedHashMap, ArithmeticError,
 };
 use cml_crypto::{ScriptHash, RawBytesEncoding};
-use std::{io::{BufRead, Seek, Write}};
+use std::io::{BufRead, Seek, Write};
 use std::cmp::PartialOrd;
 use crate::PolicyId;
 

--- a/chain/wasm/json-gen/Cargo.toml
+++ b/chain/wasm/json-gen/Cargo.toml
@@ -8,3 +8,4 @@ keywords = ["cardano"]
 serde_json = "1.0.57"
 schemars = "0.8.8"
 cml-chain = { path = "../../rust" }
+cml-crypto = { path = "../../../crypto/rust" }

--- a/chain/wasm/json-gen/src/main.rs
+++ b/chain/wasm/json-gen/src/main.rs
@@ -71,8 +71,8 @@ fn main() {
     gen_json_schema!(cml_chain::crypto::Vkey);
     // lib.rs
     gen_json_schema!(cml_chain::AssetName);
-    gen_json_schema!(cml_chain::BootstrapWitness);
-    gen_json_schema!(cml_chain::BoundedBytes);
+    gen_json_schema!(cml_chain::crypto::BootstrapWitness);
+    //gen_json_schema!(cml_chain::BoundedBytes);
     gen_json_schema!(cml_chain::Int);
     gen_json_schema!(cml_chain::PositiveInterval);
     gen_json_schema!(cml_chain::ProtocolParamUpdate);
@@ -82,11 +82,10 @@ fn main() {
     gen_json_schema!(cml_chain::UnitInterval);
     gen_json_schema!(cml_chain::Update);
     gen_json_schema!(cml_chain::Value);
-    gen_json_schema!(cml_chain::Vkeywitness);
+    gen_json_schema!(cml_chain::crypto::Vkeywitness);
     // plutus.rs
-    gen_json_schema!(cml_chain::plutus::BigInt);
     gen_json_schema!(cml_chain::plutus::ConstrPlutusData);
-    gen_json_schema!(cml_chain::plutus::Costmdls);
+    gen_json_schema!(cml_chain::plutus::CostModels);
     gen_json_schema!(cml_chain::plutus::ExUnitPrices);
     gen_json_schema!(cml_chain::plutus::ExUnits);
     gen_json_schema!(cml_chain::plutus::PlutusData);
@@ -111,4 +110,6 @@ fn main() {
     gen_json_schema!(cml_chain::transaction::TransactionInput);
     gen_json_schema!(cml_chain::transaction::TransactionOutput);
     gen_json_schema!(cml_chain::transaction::TransactionWitnessSet);
+    // utils.rs
+    gen_json_schema!(cml_chain::utils::BigInt);
 }

--- a/chain/wasm/json-gen/src/main.rs
+++ b/chain/wasm/json-gen/src/main.rs
@@ -17,16 +17,35 @@ fn main() {
     // address.rs
     gen_json_schema!(cml_chain::address::Address);
     gen_json_schema!(cml_chain::address::RewardAccount);
+    // assets.rs
+    gen_json_schema!(cml_chain::assets::AssetBundle<u64>);
+    gen_json_schema!(cml_chain::assets::AssetBundle<i64>);
     // auxdata.rs
     gen_json_schema!(cml_chain::auxdata::AlonzoAuxData);
     gen_json_schema!(cml_chain::auxdata::AuxiliaryData);
     gen_json_schema!(cml_chain::auxdata::ShelleyMaAuxData);
     gen_json_schema!(cml_chain::auxdata::TransactionMetadatum);
+    gen_json_schema!(cml_chain::auxdata::Metadata);
+    gen_json_schema!(cml_chain::auxdata::MetadatumMap);
     // block.rs
+    gen_json_schema!(cml_chain::block::Block);
     gen_json_schema!(cml_chain::block::Header);
     gen_json_schema!(cml_chain::block::HeaderBody);
     gen_json_schema!(cml_chain::block::OperationalCert);
     gen_json_schema!(cml_chain::block::ProtocolVersion);
+    // byron.rs
+    gen_json_schema!(cml_chain::byron::AddrAttributes);
+    gen_json_schema!(cml_chain::byron::AddressContent);
+    gen_json_schema!(cml_chain::byron::ByronAddress);
+    gen_json_schema!(cml_chain::byron::ByronAddrType);
+    gen_json_schema!(cml_chain::byron::ByronTxOut);
+    gen_json_schema!(cml_chain::byron::Crc32);
+    gen_json_schema!(cml_chain::byron::HDAddressPayload);
+    gen_json_schema!(cml_chain::byron::SpendingData);
+    gen_json_schema!(cml_chain::byron::ProtocolMagic);
+    gen_json_schema!(cml_chain::byron::StakeDistribution);
+    gen_json_schema!(cml_chain::byron::StakeholderId);
+    gen_json_schema!(cml_crypto::Bip32PublicKey);
     // certs.rs
     gen_json_schema!(cml_chain::certs::Certificate);
     gen_json_schema!(cml_chain::certs::DnsName);
@@ -61,6 +80,7 @@ fn main() {
     gen_json_schema!(cml_chain::crypto::GenesisHash);
     gen_json_schema!(cml_chain::crypto::KESSignature);
     gen_json_schema!(cml_chain::crypto::KESVkey);
+    gen_json_schema!(cml_chain::crypto::Nonce);
     gen_json_schema!(cml_chain::crypto::PoolMetadataHash);
     gen_json_schema!(cml_chain::crypto::ScriptDataHash);
     gen_json_schema!(cml_chain::crypto::ScriptHash);
@@ -89,6 +109,7 @@ fn main() {
     gen_json_schema!(cml_chain::plutus::ExUnitPrices);
     gen_json_schema!(cml_chain::plutus::ExUnits);
     gen_json_schema!(cml_chain::plutus::PlutusData);
+    gen_json_schema!(cml_chain::plutus::PlutusMap);
     gen_json_schema!(cml_chain::plutus::PlutusV1Script);
     gen_json_schema!(cml_chain::plutus::PlutusV2Script);
     gen_json_schema!(cml_chain::plutus::Redeemer);
@@ -106,6 +127,7 @@ fn main() {
     gen_json_schema!(cml_chain::transaction::ScriptNOfK);
     gen_json_schema!(cml_chain::transaction::ScriptPubkey);
     gen_json_schema!(cml_chain::transaction::ShelleyTxOut);
+    gen_json_schema!(cml_chain::transaction::Transaction);
     gen_json_schema!(cml_chain::transaction::TransactionBody);
     gen_json_schema!(cml_chain::transaction::TransactionInput);
     gen_json_schema!(cml_chain::transaction::TransactionOutput);

--- a/chain/wasm/src/address.rs
+++ b/chain/wasm/src/address.rs
@@ -2,11 +2,15 @@ use super::*;
 
 pub use cml_chain::address::{AddressKind, AddressHeaderKind};
 
+use cml_core_wasm::impl_wasm_conversions;
+
 use crate::certs::StakeCredential;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct Address(cml_chain::address::Address);
+
+impl_wasm_conversions!(cml_chain::address::Address, Address);
 
 #[wasm_bindgen]
 impl Address {
@@ -112,29 +116,13 @@ impl Address {
     }
 }
 
-impl From<cml_chain::address::Address> for Address {
-    fn from(native: cml_chain::address::Address) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Address> for cml_chain::address::Address {
-    fn from(wasm: Address) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::address::Address> for Address {
-    fn as_ref(&self) -> &cml_chain::address::Address {
-        &self.0
-    }
-}
-
 pub type RewardAccount = RewardAddress;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct RewardAddress(cml_chain::address::RewardAddress);
+
+impl_wasm_conversions!(cml_chain::address::RewardAddress, RewardAddress);
 
 #[wasm_bindgen]
 impl RewardAddress {
@@ -169,20 +157,3 @@ impl RewardAddress {
     }
 }
 
-impl From<cml_chain::address::RewardAddress> for RewardAddress {
-    fn from(native: cml_chain::address::RewardAddress) -> Self {
-        Self(native)
-    }
-}
-
-impl From<RewardAddress> for cml_chain::address::RewardAddress {
-    fn from(wasm: RewardAddress) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::address::RewardAddress> for RewardAddress {
-    fn as_ref(&self) -> &cml_chain::address::RewardAddress {
-        &self.0
-    }
-}

--- a/chain/wasm/src/assets/mod.rs
+++ b/chain/wasm/src/assets/mod.rs
@@ -6,6 +6,8 @@ pub use utils::{Mint, MultiAsset, Value};
 
 pub use cml_chain::assets::Coin;
 
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
+
 // Code below here was code-generated using an experimental CDDL to rust tool:
 // https://github.com/dcSpark/cddl-codegen
 
@@ -13,53 +15,14 @@ pub use cml_chain::assets::Coin;
 #[wasm_bindgen]
 pub struct AssetName(cml_chain::assets::AssetName);
 
+impl_wasm_cbor_json_api!(AssetName);
+
+impl_wasm_conversions!(cml_chain::assets::AssetName, AssetName);
+
 #[wasm_bindgen]
 impl AssetName {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AssetName, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AssetName, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> Vec<u8> {
         self.0.get().clone()
     }
 }
 
-impl From<cml_chain::assets::AssetName> for AssetName {
-    fn from(native: cml_chain::assets::AssetName) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AssetName> for cml_chain::assets::AssetName {
-    fn from(wasm: AssetName) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::assets::AssetName> for AssetName {
-    fn as_ref(&self) -> &cml_chain::assets::AssetName {
-        &self.0
-    }
-}

--- a/chain/wasm/src/assets/utils.rs
+++ b/chain/wasm/src/assets/utils.rs
@@ -163,6 +163,14 @@ impl Value {
     pub fn new(coin: Coin, multiasset: &MultiAsset) -> Self {
         cml_chain::assets::Value::new(coin, multiasset.clone().into()).into()
     }
+
+    pub fn coin(&self) -> Coin {
+        self.0.coin
+    }
+
+    pub fn multi_asset(&self) -> MultiAsset {
+        self.0.multiasset.clone().into()
+    }
     
     pub fn zero() -> Value {
         cml_chain::assets::Value::zero().into()

--- a/chain/wasm/src/auxdata/mod.rs
+++ b/chain/wasm/src/auxdata/mod.rs
@@ -5,40 +5,19 @@ use super::{
     NativeScriptList, PlutusV1ScriptList, PlutusV2ScriptList,
 };
 pub use cml_core_wasm::metadata::{Metadata, TransactionMetadatum, TransactionMetadatumLabel};
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoAuxData(cml_chain::auxdata::AlonzoAuxData);
 
+impl_wasm_cbor_json_api!(AlonzoAuxData);
+
+impl_wasm_conversions!(cml_chain::auxdata::AlonzoAuxData, AlonzoAuxData);
+
 #[wasm_bindgen]
 impl AlonzoAuxData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoAuxData, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoAuxData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_metadata(&mut self, metadata: &Metadata) {
         self.0.metadata = Some(metadata.clone().into())
     }
@@ -82,56 +61,16 @@ impl AlonzoAuxData {
     }
 }
 
-impl From<cml_chain::auxdata::AlonzoAuxData> for AlonzoAuxData {
-    fn from(native: cml_chain::auxdata::AlonzoAuxData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoAuxData> for cml_chain::auxdata::AlonzoAuxData {
-    fn from(wasm: AlonzoAuxData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::auxdata::AlonzoAuxData> for AlonzoAuxData {
-    fn as_ref(&self) -> &cml_chain::auxdata::AlonzoAuxData {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AuxiliaryData(cml_chain::auxdata::AuxiliaryData);
 
+impl_wasm_cbor_json_api!(AuxiliaryData);
+
+impl_wasm_conversions!(cml_chain::auxdata::AuxiliaryData, AuxiliaryData);
+
 #[wasm_bindgen]
 impl AuxiliaryData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AuxiliaryData, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AuxiliaryData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_shelley(shelley: &ShelleyAuxData) -> Self {
         Self(cml_chain::auxdata::AuxiliaryData::new_shelley(
             shelley.clone().into(),
@@ -184,24 +123,6 @@ impl AuxiliaryData {
     }
 }
 
-impl From<cml_chain::auxdata::AuxiliaryData> for AuxiliaryData {
-    fn from(native: cml_chain::auxdata::AuxiliaryData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AuxiliaryData> for cml_chain::auxdata::AuxiliaryData {
-    fn from(wasm: AuxiliaryData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::auxdata::AuxiliaryData> for AuxiliaryData {
-    fn as_ref(&self) -> &cml_chain::auxdata::AuxiliaryData {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum AuxiliaryDataKind {
     Shelley,
@@ -215,34 +136,12 @@ pub type ShelleyAuxData = Metadata;
 #[wasm_bindgen]
 pub struct ShelleyMaAuxData(cml_chain::auxdata::ShelleyMaAuxData);
 
+impl_wasm_cbor_json_api!(ShelleyMaAuxData);
+
+impl_wasm_conversions!(cml_chain::auxdata::ShelleyMaAuxData, ShelleyMaAuxData);
+
 #[wasm_bindgen]
 impl ShelleyMaAuxData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyMaAuxData, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyMaAuxData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn transaction_metadata(&self) -> Metadata {
         self.0.transaction_metadata.clone().into()
     }
@@ -259,20 +158,3 @@ impl ShelleyMaAuxData {
     }
 }
 
-impl From<cml_chain::auxdata::ShelleyMaAuxData> for ShelleyMaAuxData {
-    fn from(native: cml_chain::auxdata::ShelleyMaAuxData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyMaAuxData> for cml_chain::auxdata::ShelleyMaAuxData {
-    fn from(wasm: ShelleyMaAuxData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::auxdata::ShelleyMaAuxData> for ShelleyMaAuxData {
-    fn as_ref(&self) -> &cml_chain::auxdata::ShelleyMaAuxData {
-        &self.0
-    }
-}

--- a/chain/wasm/src/block/mod.rs
+++ b/chain/wasm/src/block/mod.rs
@@ -7,40 +7,19 @@ use super::{
 };
 use crate::crypto::{KESSignature, VRFCert, Vkey};
 use cml_crypto_wasm::{BlockBodyHash, BlockHeaderHash, Ed25519Signature, KESVkey, VRFVkey};
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Block(cml_chain::block::Block);
 
+impl_wasm_cbor_json_api!(Block);
+
+impl_wasm_conversions!(cml_chain::block::Block, Block);
+
 #[wasm_bindgen]
 impl Block {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Block, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Block, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header(&self) -> Header {
         self.0.header.clone().into()
     }
@@ -78,56 +57,16 @@ impl Block {
     }
 }
 
-impl From<cml_chain::block::Block> for Block {
-    fn from(native: cml_chain::block::Block) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Block> for cml_chain::block::Block {
-    fn from(wasm: Block) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::block::Block> for Block {
-    fn as_ref(&self) -> &cml_chain::block::Block {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Header(cml_chain::block::Header);
 
+impl_wasm_cbor_json_api!(Header);
+
+impl_wasm_conversions!(cml_chain::block::Header, Header);
+
 #[wasm_bindgen]
 impl Header {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Header, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Header, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header_body(&self) -> HeaderBody {
         self.0.header_body.clone().into()
     }
@@ -144,56 +83,16 @@ impl Header {
     }
 }
 
-impl From<cml_chain::block::Header> for Header {
-    fn from(native: cml_chain::block::Header) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Header> for cml_chain::block::Header {
-    fn from(wasm: Header) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::block::Header> for Header {
-    fn as_ref(&self) -> &cml_chain::block::Header {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct HeaderBody(cml_chain::block::HeaderBody);
 
+impl_wasm_cbor_json_api!(HeaderBody);
+
+impl_wasm_conversions!(cml_chain::block::HeaderBody, HeaderBody);
+
 #[wasm_bindgen]
 impl HeaderBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<HeaderBody, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<HeaderBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn block_number(&self) -> u64 {
         self.0.block_number
     }
@@ -261,56 +160,16 @@ impl HeaderBody {
     }
 }
 
-impl From<cml_chain::block::HeaderBody> for HeaderBody {
-    fn from(native: cml_chain::block::HeaderBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<HeaderBody> for cml_chain::block::HeaderBody {
-    fn from(wasm: HeaderBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::block::HeaderBody> for HeaderBody {
-    fn as_ref(&self) -> &cml_chain::block::HeaderBody {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct OperationalCert(cml_chain::block::OperationalCert);
 
+impl_wasm_cbor_json_api!(OperationalCert);
+
+impl_wasm_conversions!(cml_chain::block::OperationalCert, OperationalCert);
+
 #[wasm_bindgen]
 impl OperationalCert {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<OperationalCert, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<OperationalCert, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn hot_vkey(&self) -> KESVkey {
         self.0.hot_vkey.clone().into()
     }
@@ -342,56 +201,16 @@ impl OperationalCert {
     }
 }
 
-impl From<cml_chain::block::OperationalCert> for OperationalCert {
-    fn from(native: cml_chain::block::OperationalCert) -> Self {
-        Self(native)
-    }
-}
-
-impl From<OperationalCert> for cml_chain::block::OperationalCert {
-    fn from(wasm: OperationalCert) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::block::OperationalCert> for OperationalCert {
-    fn as_ref(&self) -> &cml_chain::block::OperationalCert {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ProtocolVersion(cml_chain::block::ProtocolVersion);
 
+impl_wasm_cbor_json_api!(ProtocolVersion);
+
+impl_wasm_conversions!(cml_chain::block::ProtocolVersion, ProtocolVersion);
+
 #[wasm_bindgen]
 impl ProtocolVersion {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ProtocolVersion, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ProtocolVersion, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn major(&self) -> u64 {
         self.0.major
     }
@@ -402,23 +221,5 @@ impl ProtocolVersion {
 
     pub fn new(major: u64, minor: u64) -> Self {
         Self(cml_chain::block::ProtocolVersion::new(major, minor))
-    }
-}
-
-impl From<cml_chain::block::ProtocolVersion> for ProtocolVersion {
-    fn from(native: cml_chain::block::ProtocolVersion) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ProtocolVersion> for cml_chain::block::ProtocolVersion {
-    fn from(wasm: ProtocolVersion) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::block::ProtocolVersion> for ProtocolVersion {
-    fn as_ref(&self) -> &cml_chain::block::ProtocolVersion {
-        &self.0
     }
 }

--- a/chain/wasm/src/certs/mod.rs
+++ b/chain/wasm/src/certs/mod.rs
@@ -9,40 +9,19 @@ pub use cml_chain::certs::MIRPot;
 use cml_crypto_wasm::{
     Ed25519KeyHash, GenesisDelegateHash, GenesisHash, PoolMetadataHash, ScriptHash, VRFKeyHash,
 };
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Certificate(cml_chain::certs::Certificate);
 
+impl_wasm_cbor_json_api!(Certificate);
+
+impl_wasm_conversions!(cml_chain::certs::Certificate, Certificate);
+
 #[wasm_bindgen]
 impl Certificate {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Certificate, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Certificate, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_stake_registration(stake_credential: &StakeCredential) -> Self {
         Self(cml_chain::certs::Certificate::new_stake_registration(
             stake_credential.clone().into(),
@@ -184,24 +163,6 @@ impl Certificate {
     }
 }
 
-impl From<cml_chain::certs::Certificate> for Certificate {
-    fn from(native: cml_chain::certs::Certificate) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Certificate> for cml_chain::certs::Certificate {
-    fn from(wasm: Certificate) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::Certificate> for Certificate {
-    fn as_ref(&self) -> &cml_chain::certs::Certificate {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum CertificateKind {
     StakeRegistration,
@@ -217,54 +178,14 @@ pub enum CertificateKind {
 #[wasm_bindgen]
 pub struct DnsName(cml_chain::certs::DnsName);
 
+impl_wasm_cbor_json_api!(DnsName);
+
+impl_wasm_conversions!(cml_chain::certs::DnsName, DnsName);
+
 #[wasm_bindgen]
 impl DnsName {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<DnsName, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<DnsName, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> String {
         self.0.get().clone()
-    }
-}
-
-impl From<cml_chain::certs::DnsName> for DnsName {
-    fn from(native: cml_chain::certs::DnsName) -> Self {
-        Self(native)
-    }
-}
-
-impl From<DnsName> for cml_chain::certs::DnsName {
-    fn from(wasm: DnsName) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::DnsName> for DnsName {
-    fn as_ref(&self) -> &cml_chain::certs::DnsName {
-        &self.0
     }
 }
 
@@ -272,34 +193,12 @@ impl AsRef<cml_chain::certs::DnsName> for DnsName {
 #[wasm_bindgen]
 pub struct GenesisKeyDelegation(cml_chain::certs::GenesisKeyDelegation);
 
+impl_wasm_cbor_json_api!(GenesisKeyDelegation);
+
+impl_wasm_conversions!(cml_chain::certs::GenesisKeyDelegation, GenesisKeyDelegation);
+
 #[wasm_bindgen]
 impl GenesisKeyDelegation {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<GenesisKeyDelegation, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<GenesisKeyDelegation, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn genesis_hash(&self) -> GenesisHash {
         self.0.genesis_hash.clone().into()
     }
@@ -325,76 +224,18 @@ impl GenesisKeyDelegation {
     }
 }
 
-impl From<cml_chain::certs::GenesisKeyDelegation> for GenesisKeyDelegation {
-    fn from(native: cml_chain::certs::GenesisKeyDelegation) -> Self {
-        Self(native)
-    }
-}
-
-impl From<GenesisKeyDelegation> for cml_chain::certs::GenesisKeyDelegation {
-    fn from(wasm: GenesisKeyDelegation) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::GenesisKeyDelegation> for GenesisKeyDelegation {
-    fn as_ref(&self) -> &cml_chain::certs::GenesisKeyDelegation {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Ipv4(cml_chain::certs::Ipv4);
 
+impl_wasm_cbor_json_api!(Ipv4);
+
+impl_wasm_conversions!(cml_chain::certs::Ipv4, Ipv4);
+
 #[wasm_bindgen]
 impl Ipv4 {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Ipv4, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Ipv4, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> Vec<u8> {
         self.0.get().clone()
-    }
-}
-
-impl From<cml_chain::certs::Ipv4> for Ipv4 {
-    fn from(native: cml_chain::certs::Ipv4) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Ipv4> for cml_chain::certs::Ipv4 {
-    fn from(wasm: Ipv4) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::Ipv4> for Ipv4 {
-    fn as_ref(&self) -> &cml_chain::certs::Ipv4 {
-        &self.0
     }
 }
 
@@ -402,54 +243,14 @@ impl AsRef<cml_chain::certs::Ipv4> for Ipv4 {
 #[wasm_bindgen]
 pub struct Ipv6(cml_chain::certs::Ipv6);
 
+impl_wasm_cbor_json_api!(Ipv6);
+
+impl_wasm_conversions!(cml_chain::certs::Ipv6, Ipv6);
+
 #[wasm_bindgen]
 impl Ipv6 {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Ipv6, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Ipv6, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> Vec<u8> {
         self.0.get().clone()
-    }
-}
-
-impl From<cml_chain::certs::Ipv6> for Ipv6 {
-    fn from(native: cml_chain::certs::Ipv6) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Ipv6> for cml_chain::certs::Ipv6 {
-    fn from(wasm: Ipv6) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::Ipv6> for Ipv6 {
-    fn as_ref(&self) -> &cml_chain::certs::Ipv6 {
-        &self.0
     }
 }
 
@@ -457,34 +258,12 @@ impl AsRef<cml_chain::certs::Ipv6> for Ipv6 {
 #[wasm_bindgen]
 pub struct MIRAction(cml_chain::certs::MIRAction);
 
+impl_wasm_cbor_json_api!(MIRAction);
+
+impl_wasm_conversions!(cml_chain::certs::MIRAction, MIRAction);
+
 #[wasm_bindgen]
 impl MIRAction {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MIRAction, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MIRAction, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_to_stake_credentials(to_stake_credentials: &MapStakeCredentialToDeltaCoin) -> Self {
         Self(cml_chain::certs::MIRAction::new_to_stake_credentials(
             to_stake_credentials.clone().into(),
@@ -522,24 +301,6 @@ impl MIRAction {
     }
 }
 
-impl From<cml_chain::certs::MIRAction> for MIRAction {
-    fn from(native: cml_chain::certs::MIRAction) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MIRAction> for cml_chain::certs::MIRAction {
-    fn from(wasm: MIRAction) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::MIRAction> for MIRAction {
-    fn as_ref(&self) -> &cml_chain::certs::MIRAction {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum MIRActionKind {
     ToStakeCredentials,
@@ -550,34 +311,15 @@ pub enum MIRActionKind {
 #[wasm_bindgen]
 pub struct MoveInstantaneousReward(cml_chain::certs::MoveInstantaneousReward);
 
+impl_wasm_cbor_json_api!(MoveInstantaneousReward);
+
+impl_wasm_conversions!(
+    cml_chain::certs::MoveInstantaneousReward,
+    MoveInstantaneousReward
+);
+
 #[wasm_bindgen]
 impl MoveInstantaneousReward {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MoveInstantaneousReward, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MoveInstantaneousReward, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn pot(&self) -> MIRPot {
         self.0.pot
     }
@@ -594,56 +336,19 @@ impl MoveInstantaneousReward {
     }
 }
 
-impl From<cml_chain::certs::MoveInstantaneousReward> for MoveInstantaneousReward {
-    fn from(native: cml_chain::certs::MoveInstantaneousReward) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MoveInstantaneousReward> for cml_chain::certs::MoveInstantaneousReward {
-    fn from(wasm: MoveInstantaneousReward) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::MoveInstantaneousReward> for MoveInstantaneousReward {
-    fn as_ref(&self) -> &cml_chain::certs::MoveInstantaneousReward {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MoveInstantaneousRewardsCert(cml_chain::certs::MoveInstantaneousRewardsCert);
 
+impl_wasm_cbor_json_api!(MoveInstantaneousRewardsCert);
+
+impl_wasm_conversions!(
+    cml_chain::certs::MoveInstantaneousRewardsCert,
+    MoveInstantaneousRewardsCert
+);
+
 #[wasm_bindgen]
 impl MoveInstantaneousRewardsCert {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MoveInstantaneousRewardsCert, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MoveInstantaneousRewardsCert, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn move_instantaneous_reward(&self) -> MoveInstantaneousReward {
         self.0.move_instantaneous_reward.clone().into()
     }
@@ -655,56 +360,16 @@ impl MoveInstantaneousRewardsCert {
     }
 }
 
-impl From<cml_chain::certs::MoveInstantaneousRewardsCert> for MoveInstantaneousRewardsCert {
-    fn from(native: cml_chain::certs::MoveInstantaneousRewardsCert) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MoveInstantaneousRewardsCert> for cml_chain::certs::MoveInstantaneousRewardsCert {
-    fn from(wasm: MoveInstantaneousRewardsCert) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::MoveInstantaneousRewardsCert> for MoveInstantaneousRewardsCert {
-    fn as_ref(&self) -> &cml_chain::certs::MoveInstantaneousRewardsCert {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MultiHostName(cml_chain::certs::MultiHostName);
 
+impl_wasm_cbor_json_api!(MultiHostName);
+
+impl_wasm_conversions!(cml_chain::certs::MultiHostName, MultiHostName);
+
 #[wasm_bindgen]
 impl MultiHostName {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultiHostName, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MultiHostName, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn dns_name(&self) -> DnsName {
         self.0.dns_name.clone().into()
     }
@@ -716,56 +381,16 @@ impl MultiHostName {
     }
 }
 
-impl From<cml_chain::certs::MultiHostName> for MultiHostName {
-    fn from(native: cml_chain::certs::MultiHostName) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MultiHostName> for cml_chain::certs::MultiHostName {
-    fn from(wasm: MultiHostName) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::MultiHostName> for MultiHostName {
-    fn as_ref(&self) -> &cml_chain::certs::MultiHostName {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PoolMetadata(cml_chain::certs::PoolMetadata);
 
+impl_wasm_cbor_json_api!(PoolMetadata);
+
+impl_wasm_conversions!(cml_chain::certs::PoolMetadata, PoolMetadata);
+
 #[wasm_bindgen]
 impl PoolMetadata {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PoolMetadata, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PoolMetadata, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn url(&self) -> Url {
         self.0.url.clone().into()
     }
@@ -782,56 +407,16 @@ impl PoolMetadata {
     }
 }
 
-impl From<cml_chain::certs::PoolMetadata> for PoolMetadata {
-    fn from(native: cml_chain::certs::PoolMetadata) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PoolMetadata> for cml_chain::certs::PoolMetadata {
-    fn from(wasm: PoolMetadata) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::PoolMetadata> for PoolMetadata {
-    fn as_ref(&self) -> &cml_chain::certs::PoolMetadata {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PoolParams(cml_chain::certs::PoolParams);
 
+impl_wasm_cbor_json_api!(PoolParams);
+
+impl_wasm_conversions!(cml_chain::certs::PoolParams, PoolParams);
+
 #[wasm_bindgen]
 impl PoolParams {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PoolParams, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PoolParams, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn operator(&self) -> Ed25519KeyHash {
         self.0.operator.clone().into()
     }
@@ -893,56 +478,16 @@ impl PoolParams {
     }
 }
 
-impl From<cml_chain::certs::PoolParams> for PoolParams {
-    fn from(native: cml_chain::certs::PoolParams) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PoolParams> for cml_chain::certs::PoolParams {
-    fn from(wasm: PoolParams) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::PoolParams> for PoolParams {
-    fn as_ref(&self) -> &cml_chain::certs::PoolParams {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PoolRegistration(cml_chain::certs::PoolRegistration);
 
+impl_wasm_cbor_json_api!(PoolRegistration);
+
+impl_wasm_conversions!(cml_chain::certs::PoolRegistration, PoolRegistration);
+
 #[wasm_bindgen]
 impl PoolRegistration {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PoolRegistration, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PoolRegistration, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn pool_params(&self) -> PoolParams {
         self.0.pool_params.clone().into()
     }
@@ -954,56 +499,16 @@ impl PoolRegistration {
     }
 }
 
-impl From<cml_chain::certs::PoolRegistration> for PoolRegistration {
-    fn from(native: cml_chain::certs::PoolRegistration) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PoolRegistration> for cml_chain::certs::PoolRegistration {
-    fn from(wasm: PoolRegistration) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::PoolRegistration> for PoolRegistration {
-    fn as_ref(&self) -> &cml_chain::certs::PoolRegistration {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PoolRetirement(cml_chain::certs::PoolRetirement);
 
+impl_wasm_cbor_json_api!(PoolRetirement);
+
+impl_wasm_conversions!(cml_chain::certs::PoolRetirement, PoolRetirement);
+
 #[wasm_bindgen]
 impl PoolRetirement {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PoolRetirement, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PoolRetirement, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn ed25519_key_hash(&self) -> Ed25519KeyHash {
         self.0.ed25519_key_hash.clone().into()
     }
@@ -1020,56 +525,16 @@ impl PoolRetirement {
     }
 }
 
-impl From<cml_chain::certs::PoolRetirement> for PoolRetirement {
-    fn from(native: cml_chain::certs::PoolRetirement) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PoolRetirement> for cml_chain::certs::PoolRetirement {
-    fn from(wasm: PoolRetirement) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::PoolRetirement> for PoolRetirement {
-    fn as_ref(&self) -> &cml_chain::certs::PoolRetirement {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Relay(cml_chain::certs::Relay);
 
+impl_wasm_cbor_json_api!(Relay);
+
+impl_wasm_conversions!(cml_chain::certs::Relay, Relay);
+
 #[wasm_bindgen]
 impl Relay {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Relay, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Relay, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_single_host_addr(
         port: Option<Port>,
         ipv4: Option<Ipv4>,
@@ -1131,24 +596,6 @@ impl Relay {
     }
 }
 
-impl From<cml_chain::certs::Relay> for Relay {
-    fn from(native: cml_chain::certs::Relay) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Relay> for cml_chain::certs::Relay {
-    fn from(wasm: Relay) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::Relay> for Relay {
-    fn as_ref(&self) -> &cml_chain::certs::Relay {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum RelayKind {
     SingleHostAddr,
@@ -1160,34 +607,12 @@ pub enum RelayKind {
 #[wasm_bindgen]
 pub struct SingleHostAddr(cml_chain::certs::SingleHostAddr);
 
+impl_wasm_cbor_json_api!(SingleHostAddr);
+
+impl_wasm_conversions!(cml_chain::certs::SingleHostAddr, SingleHostAddr);
+
 #[wasm_bindgen]
 impl SingleHostAddr {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SingleHostAddr, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SingleHostAddr, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn port(&self) -> Option<Port> {
         self.0.port
     }
@@ -1209,56 +634,16 @@ impl SingleHostAddr {
     }
 }
 
-impl From<cml_chain::certs::SingleHostAddr> for SingleHostAddr {
-    fn from(native: cml_chain::certs::SingleHostAddr) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SingleHostAddr> for cml_chain::certs::SingleHostAddr {
-    fn from(wasm: SingleHostAddr) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::SingleHostAddr> for SingleHostAddr {
-    fn as_ref(&self) -> &cml_chain::certs::SingleHostAddr {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SingleHostName(cml_chain::certs::SingleHostName);
 
+impl_wasm_cbor_json_api!(SingleHostName);
+
+impl_wasm_conversions!(cml_chain::certs::SingleHostName, SingleHostName);
+
 #[wasm_bindgen]
 impl SingleHostName {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SingleHostName, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SingleHostName, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn port(&self) -> Option<Port> {
         self.0.port
     }
@@ -1275,56 +660,16 @@ impl SingleHostName {
     }
 }
 
-impl From<cml_chain::certs::SingleHostName> for SingleHostName {
-    fn from(native: cml_chain::certs::SingleHostName) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SingleHostName> for cml_chain::certs::SingleHostName {
-    fn from(wasm: SingleHostName) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::SingleHostName> for SingleHostName {
-    fn as_ref(&self) -> &cml_chain::certs::SingleHostName {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct StakeCredential(cml_chain::certs::StakeCredential);
 
+impl_wasm_cbor_json_api!(StakeCredential);
+
+impl_wasm_conversions!(cml_chain::certs::StakeCredential, StakeCredential);
+
 #[wasm_bindgen]
 impl StakeCredential {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<StakeCredential, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<StakeCredential, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_pub_key(hash: &Ed25519KeyHash) -> Self {
         Self(cml_chain::certs::StakeCredential::new_pub_key(
             hash.clone().into(),
@@ -1359,24 +704,6 @@ impl StakeCredential {
     }
 }
 
-impl From<cml_chain::certs::StakeCredential> for StakeCredential {
-    fn from(native: cml_chain::certs::StakeCredential) -> Self {
-        Self(native)
-    }
-}
-
-impl From<StakeCredential> for cml_chain::certs::StakeCredential {
-    fn from(wasm: StakeCredential) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::StakeCredential> for StakeCredential {
-    fn as_ref(&self) -> &cml_chain::certs::StakeCredential {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum StakeCredentialKind {
     PubKey,
@@ -1387,34 +714,12 @@ pub enum StakeCredentialKind {
 #[wasm_bindgen]
 pub struct StakeDelegation(cml_chain::certs::StakeDelegation);
 
+impl_wasm_cbor_json_api!(StakeDelegation);
+
+impl_wasm_conversions!(cml_chain::certs::StakeDelegation, StakeDelegation);
+
 #[wasm_bindgen]
 impl StakeDelegation {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<StakeDelegation, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<StakeDelegation, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn stake_credential(&self) -> StakeCredential {
         self.0.stake_credential.clone().into()
     }
@@ -1431,56 +736,16 @@ impl StakeDelegation {
     }
 }
 
-impl From<cml_chain::certs::StakeDelegation> for StakeDelegation {
-    fn from(native: cml_chain::certs::StakeDelegation) -> Self {
-        Self(native)
-    }
-}
-
-impl From<StakeDelegation> for cml_chain::certs::StakeDelegation {
-    fn from(wasm: StakeDelegation) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::StakeDelegation> for StakeDelegation {
-    fn as_ref(&self) -> &cml_chain::certs::StakeDelegation {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct StakeDeregistration(cml_chain::certs::StakeDeregistration);
 
+impl_wasm_cbor_json_api!(StakeDeregistration);
+
+impl_wasm_conversions!(cml_chain::certs::StakeDeregistration, StakeDeregistration);
+
 #[wasm_bindgen]
 impl StakeDeregistration {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<StakeDeregistration, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<StakeDeregistration, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn stake_credential(&self) -> StakeCredential {
         self.0.stake_credential.clone().into()
     }
@@ -1492,56 +757,16 @@ impl StakeDeregistration {
     }
 }
 
-impl From<cml_chain::certs::StakeDeregistration> for StakeDeregistration {
-    fn from(native: cml_chain::certs::StakeDeregistration) -> Self {
-        Self(native)
-    }
-}
-
-impl From<StakeDeregistration> for cml_chain::certs::StakeDeregistration {
-    fn from(wasm: StakeDeregistration) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::StakeDeregistration> for StakeDeregistration {
-    fn as_ref(&self) -> &cml_chain::certs::StakeDeregistration {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct StakeRegistration(cml_chain::certs::StakeRegistration);
 
+impl_wasm_cbor_json_api!(StakeRegistration);
+
+impl_wasm_conversions!(cml_chain::certs::StakeRegistration, StakeRegistration);
+
 #[wasm_bindgen]
 impl StakeRegistration {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<StakeRegistration, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<StakeRegistration, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn stake_credential(&self) -> StakeCredential {
         self.0.stake_credential.clone().into()
     }
@@ -1553,75 +778,17 @@ impl StakeRegistration {
     }
 }
 
-impl From<cml_chain::certs::StakeRegistration> for StakeRegistration {
-    fn from(native: cml_chain::certs::StakeRegistration) -> Self {
-        Self(native)
-    }
-}
-
-impl From<StakeRegistration> for cml_chain::certs::StakeRegistration {
-    fn from(wasm: StakeRegistration) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::StakeRegistration> for StakeRegistration {
-    fn as_ref(&self) -> &cml_chain::certs::StakeRegistration {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Url(cml_chain::certs::Url);
 
+impl_wasm_cbor_json_api!(Url);
+
+impl_wasm_conversions!(cml_chain::certs::Url, Url);
+
 #[wasm_bindgen]
 impl Url {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Url, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Url, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> String {
         self.0.get().clone()
-    }
-}
-
-impl From<cml_chain::certs::Url> for Url {
-    fn from(native: cml_chain::certs::Url) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Url> for cml_chain::certs::Url {
-    fn from(wasm: Url) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::certs::Url> for Url {
-    fn as_ref(&self) -> &cml_chain::certs::Url {
-        &self.0
     }
 }

--- a/chain/wasm/src/crypto/mod.rs
+++ b/chain/wasm/src/crypto/mod.rs
@@ -5,6 +5,8 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 use cml_crypto_wasm::{Ed25519Signature, NonceHash};
 
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
+
 use crate::byron::AddrAttributes;
 
 pub type Vkey = cml_crypto_wasm::PublicKey;
@@ -13,34 +15,12 @@ pub type Vkey = cml_crypto_wasm::PublicKey;
 #[wasm_bindgen]
 pub struct BootstrapWitness(cml_chain::crypto::BootstrapWitness);
 
+impl_wasm_cbor_json_api!(BootstrapWitness);
+
+impl_wasm_conversions!(cml_chain::crypto::BootstrapWitness, BootstrapWitness);
+
 #[wasm_bindgen]
 impl BootstrapWitness {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<BootstrapWitness, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<BootstrapWitness, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn public_key(&self) -> Vkey {
         self.0.public_key.clone().into()
     }
@@ -72,76 +52,18 @@ impl BootstrapWitness {
     }
 }
 
-impl From<cml_chain::crypto::BootstrapWitness> for BootstrapWitness {
-    fn from(native: cml_chain::crypto::BootstrapWitness) -> Self {
-        Self(native)
-    }
-}
-
-impl From<BootstrapWitness> for cml_chain::crypto::BootstrapWitness {
-    fn from(wasm: BootstrapWitness) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::crypto::BootstrapWitness> for BootstrapWitness {
-    fn as_ref(&self) -> &cml_chain::crypto::BootstrapWitness {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct KESSignature(cml_chain::crypto::KESSignature);
 
+impl_wasm_cbor_json_api!(KESSignature);
+
+impl_wasm_conversions!(cml_chain::crypto::KESSignature, KESSignature);
+
 #[wasm_bindgen]
 impl KESSignature {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<KESSignature, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<KESSignature, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> Vec<u8> {
         self.0.get().clone()
-    }
-}
-
-impl From<cml_chain::crypto::KESSignature> for KESSignature {
-    fn from(native: cml_chain::crypto::KESSignature) -> Self {
-        Self(native)
-    }
-}
-
-impl From<KESSignature> for cml_chain::crypto::KESSignature {
-    fn from(wasm: KESSignature) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::crypto::KESSignature> for KESSignature {
-    fn as_ref(&self) -> &cml_chain::crypto::KESSignature {
-        &self.0
     }
 }
 
@@ -149,34 +71,12 @@ impl AsRef<cml_chain::crypto::KESSignature> for KESSignature {
 #[wasm_bindgen]
 pub struct Nonce(cml_chain::crypto::Nonce);
 
+impl_wasm_cbor_json_api!(Nonce);
+
+impl_wasm_conversions!(cml_chain::crypto::Nonce, Nonce);
+
 #[wasm_bindgen]
 impl Nonce {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Nonce, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Nonce, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_identity() -> Self {
         Self(cml_chain::crypto::Nonce::new_identity())
     }
@@ -200,24 +100,6 @@ impl Nonce {
     }
 }
 
-impl From<cml_chain::crypto::Nonce> for Nonce {
-    fn from(native: cml_chain::crypto::Nonce) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Nonce> for cml_chain::crypto::Nonce {
-    fn from(wasm: Nonce) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::crypto::Nonce> for Nonce {
-    fn as_ref(&self) -> &cml_chain::crypto::Nonce {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum NonceKind {
     Identity,
@@ -228,34 +110,12 @@ pub enum NonceKind {
 #[wasm_bindgen]
 pub struct VRFCert(cml_chain::crypto::VRFCert);
 
+impl_wasm_cbor_json_api!(VRFCert);
+
+impl_wasm_conversions!(cml_chain::crypto::VRFCert, VRFCert);
+
 #[wasm_bindgen]
 impl VRFCert {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<VRFCert, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<VRFCert, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn output(&self) -> Vec<u8> {
         self.0.output.clone()
     }
@@ -269,56 +129,16 @@ impl VRFCert {
     }
 }
 
-impl From<cml_chain::crypto::VRFCert> for VRFCert {
-    fn from(native: cml_chain::crypto::VRFCert) -> Self {
-        Self(native)
-    }
-}
-
-impl From<VRFCert> for cml_chain::crypto::VRFCert {
-    fn from(wasm: VRFCert) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::crypto::VRFCert> for VRFCert {
-    fn as_ref(&self) -> &cml_chain::crypto::VRFCert {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Vkeywitness(cml_chain::crypto::Vkeywitness);
 
+impl_wasm_cbor_json_api!(Vkeywitness);
+
+impl_wasm_conversions!(cml_chain::crypto::Vkeywitness, Vkeywitness);
+
 #[wasm_bindgen]
 impl Vkeywitness {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Vkeywitness, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Vkeywitness, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn vkey(&self) -> Vkey {
         self.0.vkey.clone().into()
     }
@@ -332,23 +152,5 @@ impl Vkeywitness {
             vkey.clone().into(),
             ed25519_signature.clone().into(),
         ))
-    }
-}
-
-impl From<cml_chain::crypto::Vkeywitness> for Vkeywitness {
-    fn from(native: cml_chain::crypto::Vkeywitness) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Vkeywitness> for cml_chain::crypto::Vkeywitness {
-    fn from(wasm: Vkeywitness) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::crypto::Vkeywitness> for Vkeywitness {
-    fn as_ref(&self) -> &cml_chain::crypto::Vkeywitness {
-        &self.0
     }
 }

--- a/chain/wasm/src/lib.rs
+++ b/chain/wasm/src/lib.rs
@@ -4,6 +4,8 @@
     clippy::new_without_default
 )]
 
+use cml_core_wasm::metadata::TransactionMetadatumList;
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use ::wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
 
 pub use cml_core_wasm::Int;
@@ -35,7 +37,8 @@ use plutus::{
 use transaction::{
     NativeScript, TransactionBody, TransactionInput, TransactionOutput, TransactionWitnessSet,
 };
-pub use cml_chain::{Epoch, NetworkId};
+pub use cml_chain::{Epoch, NetworkId, Coin};
+pub use assets::Value;
 
 //extern crate serde_wasm_bindgen;
 // Code below here was code-generated using an experimental CDDL to rust tool:
@@ -44,6 +47,8 @@ pub use cml_chain::{Epoch, NetworkId};
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AssetNameList(Vec<cml_chain::assets::AssetName>);
+
+impl_wasm_conversions!(Vec<cml_chain::assets::AssetName>, AssetNameList);
 
 #[wasm_bindgen]
 impl AssetNameList {
@@ -64,27 +69,14 @@ impl AssetNameList {
     }
 }
 
-impl From<Vec<cml_chain::assets::AssetName>> for AssetNameList {
-    fn from(native: Vec<cml_chain::assets::AssetName>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AssetNameList> for Vec<cml_chain::assets::AssetName> {
-    fn from(wasm: AssetNameList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::assets::AssetName>> for AssetNameList {
-    fn as_ref(&self) -> &Vec<cml_chain::assets::AssetName> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct BootstrapWitnessList(Vec<cml_chain::crypto::BootstrapWitness>);
+
+impl_wasm_conversions!(
+    Vec<cml_chain::crypto::BootstrapWitness>,
+    BootstrapWitnessList
+);
 
 #[wasm_bindgen]
 impl BootstrapWitnessList {
@@ -105,27 +97,11 @@ impl BootstrapWitnessList {
     }
 }
 
-impl From<Vec<cml_chain::crypto::BootstrapWitness>> for BootstrapWitnessList {
-    fn from(native: Vec<cml_chain::crypto::BootstrapWitness>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<BootstrapWitnessList> for Vec<cml_chain::crypto::BootstrapWitness> {
-    fn from(wasm: BootstrapWitnessList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::crypto::BootstrapWitness>> for BootstrapWitnessList {
-    fn as_ref(&self) -> &Vec<cml_chain::crypto::BootstrapWitness> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct CertificateList(Vec<cml_chain::certs::Certificate>);
+
+impl_wasm_conversions!(Vec<cml_chain::certs::Certificate>, CertificateList);
 
 #[wasm_bindgen]
 impl CertificateList {
@@ -146,31 +122,13 @@ impl CertificateList {
     }
 }
 
-impl From<Vec<cml_chain::certs::Certificate>> for CertificateList {
-    fn from(native: Vec<cml_chain::certs::Certificate>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<CertificateList> for Vec<cml_chain::certs::Certificate> {
-    fn from(wasm: CertificateList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::certs::Certificate>> for CertificateList {
-    fn as_ref(&self) -> &Vec<cml_chain::certs::Certificate> {
-        &self.0
-    }
-}
-
-pub type Coin = u64;
-
 pub type DeltaCoin = Int;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Ed25519KeyHashList(Vec<cml_chain::crypto::Ed25519KeyHash>);
+
+impl_wasm_conversions!(Vec<cml_chain::crypto::Ed25519KeyHash>, Ed25519KeyHashList);
 
 #[wasm_bindgen]
 impl Ed25519KeyHashList {
@@ -191,27 +149,12 @@ impl Ed25519KeyHashList {
     }
 }
 
-impl From<Vec<cml_chain::crypto::Ed25519KeyHash>> for Ed25519KeyHashList {
-    fn from(native: Vec<cml_chain::crypto::Ed25519KeyHash>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Ed25519KeyHashList> for Vec<cml_chain::crypto::Ed25519KeyHash> {
-    fn from(wasm: Ed25519KeyHashList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::crypto::Ed25519KeyHash>> for Ed25519KeyHashList {
-    fn as_ref(&self) -> &Vec<cml_chain::crypto::Ed25519KeyHash> {
-        &self.0
-    }
-}
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct GenesisHashList(Vec<cml_chain::crypto::GenesisHash>);
+
+impl_wasm_conversions!(Vec<cml_chain::crypto::GenesisHash>, GenesisHashList);
 
 #[wasm_bindgen]
 impl GenesisHashList {
@@ -232,27 +175,13 @@ impl GenesisHashList {
     }
 }
 
-impl From<Vec<cml_chain::crypto::GenesisHash>> for GenesisHashList {
-    fn from(native: Vec<cml_chain::crypto::GenesisHash>) -> Self {
-        Self(native)
-    }
-}
 
-impl From<GenesisHashList> for Vec<cml_chain::crypto::GenesisHash> {
-    fn from(wasm: GenesisHashList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::crypto::GenesisHash>> for GenesisHashList {
-    fn as_ref(&self) -> &Vec<cml_chain::crypto::GenesisHash> {
-        &self.0
-    }
-}
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct IntList(Vec<cml_chain::Int>);
+
+impl_wasm_conversions!(Vec<cml_chain::Int>, IntList);
 
 #[wasm_bindgen]
 impl IntList {
@@ -273,27 +202,11 @@ impl IntList {
     }
 }
 
-impl From<Vec<cml_chain::Int>> for IntList {
-    fn from(native: Vec<cml_chain::Int>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<IntList> for Vec<cml_chain::Int> {
-    fn from(wasm: IntList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::Int>> for IntList {
-    fn as_ref(&self) -> &Vec<cml_chain::Int> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MapAssetNameToI64(OrderedHashMap<cml_chain::assets::AssetName, i64>);
+
+impl_wasm_conversions!(OrderedHashMap<cml_chain::assets::AssetName, i64>, MapAssetNameToI64);
 
 #[wasm_bindgen]
 impl MapAssetNameToI64 {
@@ -318,29 +231,14 @@ impl MapAssetNameToI64 {
     }
 }
 
-impl From<OrderedHashMap<cml_chain::assets::AssetName, i64>> for MapAssetNameToI64 {
-    fn from(native: OrderedHashMap<cml_chain::assets::AssetName, i64>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MapAssetNameToI64> for OrderedHashMap<cml_chain::assets::AssetName, i64> {
-    fn from(wasm: MapAssetNameToI64) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<OrderedHashMap<cml_chain::assets::AssetName, i64>> for MapAssetNameToI64 {
-    fn as_ref(&self) -> &OrderedHashMap<cml_chain::assets::AssetName, i64> {
-        &self.0
-    }
-}
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MapStakeCredentialToDeltaCoin(
     OrderedHashMap<cml_chain::certs::StakeCredential, cml_chain::DeltaCoin>,
 );
+
+impl_wasm_conversions!(OrderedHashMap<cml_chain::certs::StakeCredential, cml_chain::DeltaCoin>, MapStakeCredentialToDeltaCoin);
 
 #[wasm_bindgen]
 impl MapStakeCredentialToDeltaCoin {
@@ -367,37 +265,13 @@ impl MapStakeCredentialToDeltaCoin {
     }
 }
 
-impl From<OrderedHashMap<cml_chain::certs::StakeCredential, cml_chain::DeltaCoin>>
-    for MapStakeCredentialToDeltaCoin
-{
-    fn from(
-        native: OrderedHashMap<cml_chain::certs::StakeCredential, cml_chain::DeltaCoin>,
-    ) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MapStakeCredentialToDeltaCoin>
-    for OrderedHashMap<cml_chain::certs::StakeCredential, cml_chain::DeltaCoin>
-{
-    fn from(wasm: MapStakeCredentialToDeltaCoin) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<OrderedHashMap<cml_chain::certs::StakeCredential, cml_chain::DeltaCoin>>
-    for MapStakeCredentialToDeltaCoin
-{
-    fn as_ref(&self) -> &OrderedHashMap<cml_chain::certs::StakeCredential, cml_chain::DeltaCoin> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MapTransactionIndexToAuxiliaryData(
     OrderedHashMap<cml_chain::TransactionIndex, cml_chain::auxdata::AuxiliaryData>,
 );
+
+impl_wasm_conversions!(OrderedHashMap<cml_chain::TransactionIndex, cml_chain::auxdata::AuxiliaryData>, MapTransactionIndexToAuxiliaryData);
 
 #[wasm_bindgen]
 impl MapTransactionIndexToAuxiliaryData {
@@ -426,34 +300,6 @@ impl MapTransactionIndexToAuxiliaryData {
     }
 }
 
-impl From<OrderedHashMap<cml_chain::TransactionIndex, cml_chain::auxdata::AuxiliaryData>>
-    for MapTransactionIndexToAuxiliaryData
-{
-    fn from(
-        native: OrderedHashMap<cml_chain::TransactionIndex, cml_chain::auxdata::AuxiliaryData>,
-    ) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MapTransactionIndexToAuxiliaryData>
-    for OrderedHashMap<cml_chain::TransactionIndex, cml_chain::auxdata::AuxiliaryData>
-{
-    fn from(wasm: MapTransactionIndexToAuxiliaryData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<OrderedHashMap<cml_chain::TransactionIndex, cml_chain::auxdata::AuxiliaryData>>
-    for MapTransactionIndexToAuxiliaryData
-{
-    fn as_ref(
-        &self,
-    ) -> &OrderedHashMap<cml_chain::TransactionIndex, cml_chain::auxdata::AuxiliaryData> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MapTransactionMetadatumToTransactionMetadatum(
@@ -462,6 +308,8 @@ pub struct MapTransactionMetadatumToTransactionMetadatum(
         cml_chain::auxdata::TransactionMetadatum,
     >,
 );
+
+impl_wasm_conversions!(OrderedHashMap<cml_chain::auxdata::TransactionMetadatum, cml_chain::auxdata::TransactionMetadatum>, MapTransactionMetadatumToTransactionMetadatum);
 
 #[wasm_bindgen]
 impl MapTransactionMetadatumToTransactionMetadatum {
@@ -488,60 +336,15 @@ impl MapTransactionMetadatumToTransactionMetadatum {
     }
 
     pub fn keys(&self) -> TransactionMetadatumList {
-        TransactionMetadatumList(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
-    }
-}
-
-impl
-    From<
-        OrderedHashMap<
-            cml_chain::auxdata::TransactionMetadatum,
-            cml_chain::auxdata::TransactionMetadatum,
-        >,
-    > for MapTransactionMetadatumToTransactionMetadatum
-{
-    fn from(
-        native: OrderedHashMap<
-            cml_chain::auxdata::TransactionMetadatum,
-            cml_chain::auxdata::TransactionMetadatum,
-        >,
-    ) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MapTransactionMetadatumToTransactionMetadatum>
-    for OrderedHashMap<
-        cml_chain::auxdata::TransactionMetadatum,
-        cml_chain::auxdata::TransactionMetadatum,
-    >
-{
-    fn from(wasm: MapTransactionMetadatumToTransactionMetadatum) -> Self {
-        wasm.0
-    }
-}
-
-impl
-    AsRef<
-        OrderedHashMap<
-            cml_chain::auxdata::TransactionMetadatum,
-            cml_chain::auxdata::TransactionMetadatum,
-        >,
-    > for MapTransactionMetadatumToTransactionMetadatum
-{
-    fn as_ref(
-        &self,
-    ) -> &OrderedHashMap<
-        cml_chain::auxdata::TransactionMetadatum,
-        cml_chain::auxdata::TransactionMetadatum,
-    > {
-        &self.0
+        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>().into()
     }
 }
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct NativeScriptList(Vec<cml_chain::transaction::NativeScript>);
+
+impl_wasm_conversions!(Vec<cml_chain::transaction::NativeScript>, NativeScriptList);
 
 #[wasm_bindgen]
 impl NativeScriptList {
@@ -562,28 +365,11 @@ impl NativeScriptList {
     }
 }
 
-impl From<Vec<cml_chain::transaction::NativeScript>> for NativeScriptList {
-    fn from(native: Vec<cml_chain::transaction::NativeScript>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<NativeScriptList> for Vec<cml_chain::transaction::NativeScript> {
-    fn from(wasm: NativeScriptList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::transaction::NativeScript>> for NativeScriptList {
-    fn as_ref(&self) -> &Vec<cml_chain::transaction::NativeScript> {
-        &self.0
-    }
-}
-
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PlutusDataList(Vec<cml_chain::plutus::PlutusData>);
+
+impl_wasm_conversions!(Vec<cml_chain::plutus::PlutusData>, PlutusDataList);
 
 #[wasm_bindgen]
 impl PlutusDataList {
@@ -604,27 +390,11 @@ impl PlutusDataList {
     }
 }
 
-impl From<Vec<cml_chain::plutus::PlutusData>> for PlutusDataList {
-    fn from(native: Vec<cml_chain::plutus::PlutusData>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PlutusDataList> for Vec<cml_chain::plutus::PlutusData> {
-    fn from(wasm: PlutusDataList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::plutus::PlutusData>> for PlutusDataList {
-    fn as_ref(&self) -> &Vec<cml_chain::plutus::PlutusData> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PlutusV1ScriptList(Vec<cml_chain::plutus::PlutusV1Script>);
+
+impl_wasm_conversions!(Vec<cml_chain::plutus::PlutusV1Script>, PlutusV1ScriptList);
 
 #[wasm_bindgen]
 impl PlutusV1ScriptList {
@@ -645,27 +415,11 @@ impl PlutusV1ScriptList {
     }
 }
 
-impl From<Vec<cml_chain::plutus::PlutusV1Script>> for PlutusV1ScriptList {
-    fn from(native: Vec<cml_chain::plutus::PlutusV1Script>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PlutusV1ScriptList> for Vec<cml_chain::plutus::PlutusV1Script> {
-    fn from(wasm: PlutusV1ScriptList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::plutus::PlutusV1Script>> for PlutusV1ScriptList {
-    fn as_ref(&self) -> &Vec<cml_chain::plutus::PlutusV1Script> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PlutusV2ScriptList(Vec<cml_chain::plutus::PlutusV2Script>);
+
+impl_wasm_conversions!(Vec<cml_chain::plutus::PlutusV2Script>, PlutusV2ScriptList);
 
 #[wasm_bindgen]
 impl PlutusV2ScriptList {
@@ -686,29 +440,13 @@ impl PlutusV2ScriptList {
     }
 }
 
-impl From<Vec<cml_chain::plutus::PlutusV2Script>> for PlutusV2ScriptList {
-    fn from(native: Vec<cml_chain::plutus::PlutusV2Script>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PlutusV2ScriptList> for Vec<cml_chain::plutus::PlutusV2Script> {
-    fn from(wasm: PlutusV2ScriptList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::plutus::PlutusV2Script>> for PlutusV2ScriptList {
-    fn as_ref(&self) -> &Vec<cml_chain::plutus::PlutusV2Script> {
-        &self.0
-    }
-}
-
 pub type PolicyId = ScriptHash;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PolicyIdList(Vec<cml_chain::PolicyId>);
+
+impl_wasm_conversions!(Vec<cml_chain::PolicyId>, PolicyIdList);
 
 #[wasm_bindgen]
 impl PolicyIdList {
@@ -729,92 +467,16 @@ impl PolicyIdList {
     }
 }
 
-impl From<Vec<cml_chain::PolicyId>> for PolicyIdList {
-    fn from(native: Vec<cml_chain::PolicyId>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PolicyIdList> for Vec<cml_chain::PolicyId> {
-    fn from(wasm: PolicyIdList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::PolicyId>> for PolicyIdList {
-    fn as_ref(&self) -> &Vec<cml_chain::PolicyId> {
-        &self.0
-    }
-}
-
 pub type Port = u16;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
-pub struct PositiveInterval(cml_chain::PositiveInterval);
-
-#[wasm_bindgen]
-impl PositiveInterval {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PositiveInterval, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PositiveInterval, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
-    pub fn strart(&self) -> u64 {
-        self.0.strart
-    }
-
-    pub fn end(&self) -> u64 {
-        self.0.end
-    }
-
-    pub fn new(strart: u64, end: u64) -> Self {
-        Self(cml_chain::PositiveInterval::new(strart, end))
-    }
-}
-
-impl From<cml_chain::PositiveInterval> for PositiveInterval {
-    fn from(native: cml_chain::PositiveInterval) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PositiveInterval> for cml_chain::PositiveInterval {
-    fn from(wasm: PositiveInterval) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::PositiveInterval> for PositiveInterval {
-    fn as_ref(&self) -> &cml_chain::PositiveInterval {
-        &self.0
-    }
-}
-
-#[derive(Clone, Debug)]
-#[wasm_bindgen]
 pub struct ProposedProtocolParameterUpdates(cml_chain::ProposedProtocolParameterUpdates);
+
+impl_wasm_conversions!(
+    cml_chain::ProposedProtocolParameterUpdates,
+    ProposedProtocolParameterUpdates
+);
 
 #[wasm_bindgen]
 impl ProposedProtocolParameterUpdates {
@@ -845,56 +507,16 @@ impl ProposedProtocolParameterUpdates {
     }
 }
 
-impl From<cml_chain::ProposedProtocolParameterUpdates> for ProposedProtocolParameterUpdates {
-    fn from(native: cml_chain::ProposedProtocolParameterUpdates) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ProposedProtocolParameterUpdates> for cml_chain::ProposedProtocolParameterUpdates {
-    fn from(wasm: ProposedProtocolParameterUpdates) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::ProposedProtocolParameterUpdates> for ProposedProtocolParameterUpdates {
-    fn as_ref(&self) -> &cml_chain::ProposedProtocolParameterUpdates {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ProtocolParamUpdate(cml_chain::ProtocolParamUpdate);
 
+impl_wasm_cbor_json_api!(ProtocolParamUpdate);
+
+impl_wasm_conversions!(cml_chain::ProtocolParamUpdate, ProtocolParamUpdate);
+
 #[wasm_bindgen]
 impl ProtocolParamUpdate {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ProtocolParamUpdate, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ProtocolParamUpdate, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_minfee_a(&mut self, minfee_a: u64) {
         self.0.minfee_a = Some(minfee_a)
     }
@@ -1095,56 +717,16 @@ impl ProtocolParamUpdate {
     }
 }
 
-impl From<cml_chain::ProtocolParamUpdate> for ProtocolParamUpdate {
-    fn from(native: cml_chain::ProtocolParamUpdate) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ProtocolParamUpdate> for cml_chain::ProtocolParamUpdate {
-    fn from(wasm: ProtocolParamUpdate) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::ProtocolParamUpdate> for ProtocolParamUpdate {
-    fn as_ref(&self) -> &cml_chain::ProtocolParamUpdate {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ProtocolVersionStruct(cml_chain::ProtocolVersionStruct);
 
+impl_wasm_cbor_json_api!(ProtocolVersionStruct);
+
+impl_wasm_conversions!(cml_chain::ProtocolVersionStruct, ProtocolVersionStruct);
+
 #[wasm_bindgen]
 impl ProtocolVersionStruct {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ProtocolVersionStruct, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ProtocolVersionStruct, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn protocol_version(&self) -> ProtocolVersion {
         self.0.protocol_version.clone().into()
     }
@@ -1156,56 +738,16 @@ impl ProtocolVersionStruct {
     }
 }
 
-impl From<cml_chain::ProtocolVersionStruct> for ProtocolVersionStruct {
-    fn from(native: cml_chain::ProtocolVersionStruct) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ProtocolVersionStruct> for cml_chain::ProtocolVersionStruct {
-    fn from(wasm: ProtocolVersionStruct) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::ProtocolVersionStruct> for ProtocolVersionStruct {
-    fn as_ref(&self) -> &cml_chain::ProtocolVersionStruct {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Rational(cml_chain::Rational);
 
+impl_wasm_cbor_json_api!(Rational);
+
+impl_wasm_conversions!(cml_chain::Rational, Rational);
+
 #[wasm_bindgen]
 impl Rational {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Rational, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Rational, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn numerator(&self) -> u64 {
         self.0.numerator
     }
@@ -1219,27 +761,11 @@ impl Rational {
     }
 }
 
-impl From<cml_chain::Rational> for Rational {
-    fn from(native: cml_chain::Rational) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Rational> for cml_chain::Rational {
-    fn from(wasm: Rational) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::Rational> for Rational {
-    fn as_ref(&self) -> &cml_chain::Rational {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct RedeemerList(Vec<cml_chain::plutus::Redeemer>);
+
+impl_wasm_conversions!(Vec<cml_chain::plutus::Redeemer>, RedeemerList);
 
 #[wasm_bindgen]
 impl RedeemerList {
@@ -1260,27 +786,11 @@ impl RedeemerList {
     }
 }
 
-impl From<Vec<cml_chain::plutus::Redeemer>> for RedeemerList {
-    fn from(native: Vec<cml_chain::plutus::Redeemer>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<RedeemerList> for Vec<cml_chain::plutus::Redeemer> {
-    fn from(wasm: RedeemerList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::plutus::Redeemer>> for RedeemerList {
-    fn as_ref(&self) -> &Vec<cml_chain::plutus::Redeemer> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct RelayList(Vec<cml_chain::certs::Relay>);
+
+impl_wasm_conversions!(Vec<cml_chain::certs::Relay>, RelayList);
 
 #[wasm_bindgen]
 impl RelayList {
@@ -1301,27 +811,11 @@ impl RelayList {
     }
 }
 
-impl From<Vec<cml_chain::certs::Relay>> for RelayList {
-    fn from(native: Vec<cml_chain::certs::Relay>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<RelayList> for Vec<cml_chain::certs::Relay> {
-    fn from(wasm: RelayList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::certs::Relay>> for RelayList {
-    fn as_ref(&self) -> &Vec<cml_chain::certs::Relay> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct RewardAccountList(Vec<cml_chain::address::RewardAccount>);
+
+impl_wasm_conversions!(Vec<cml_chain::address::RewardAccount>, RewardAccountList);
 
 #[wasm_bindgen]
 impl RewardAccountList {
@@ -1342,56 +836,16 @@ impl RewardAccountList {
     }
 }
 
-impl From<Vec<cml_chain::address::RewardAccount>> for RewardAccountList {
-    fn from(native: Vec<cml_chain::address::RewardAccount>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<RewardAccountList> for Vec<cml_chain::address::RewardAccount> {
-    fn from(wasm: RewardAccountList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::address::RewardAccount>> for RewardAccountList {
-    fn as_ref(&self) -> &Vec<cml_chain::address::RewardAccount> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Script(cml_chain::Script);
 
+impl_wasm_cbor_json_api!(Script);
+
+impl_wasm_conversions!(cml_chain::Script, Script);
+
 #[wasm_bindgen]
 impl Script {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Script, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Script, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_native(script: &NativeScript) -> Self {
         Self(cml_chain::Script::new_native(script.clone().into()))
     }
@@ -1434,24 +888,6 @@ impl Script {
     }
 }
 
-impl From<cml_chain::Script> for Script {
-    fn from(native: cml_chain::Script) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Script> for cml_chain::Script {
-    fn from(wasm: Script) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::Script> for Script {
-    fn as_ref(&self) -> &cml_chain::Script {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum ScriptKind {
     Native,
@@ -1464,6 +900,8 @@ pub type Slot = u64;
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct StakeCredentialList(Vec<cml_chain::certs::StakeCredential>);
+
+impl_wasm_conversions!(Vec<cml_chain::certs::StakeCredential>, StakeCredentialList);
 
 #[wasm_bindgen]
 impl StakeCredentialList {
@@ -1484,29 +922,16 @@ impl StakeCredentialList {
     }
 }
 
-impl From<Vec<cml_chain::certs::StakeCredential>> for StakeCredentialList {
-    fn from(native: Vec<cml_chain::certs::StakeCredential>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<StakeCredentialList> for Vec<cml_chain::certs::StakeCredential> {
-    fn from(wasm: StakeCredentialList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::certs::StakeCredential>> for StakeCredentialList {
-    fn as_ref(&self) -> &Vec<cml_chain::certs::StakeCredential> {
-        &self.0
-    }
-}
-
 pub type SubCoin = Rational;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TransactionBodyList(Vec<cml_chain::transaction::TransactionBody>);
+
+impl_wasm_conversions!(
+    Vec<cml_chain::transaction::TransactionBody>,
+    TransactionBodyList
+);
 
 #[wasm_bindgen]
 impl TransactionBodyList {
@@ -1527,29 +952,16 @@ impl TransactionBodyList {
     }
 }
 
-impl From<Vec<cml_chain::transaction::TransactionBody>> for TransactionBodyList {
-    fn from(native: Vec<cml_chain::transaction::TransactionBody>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionBodyList> for Vec<cml_chain::transaction::TransactionBody> {
-    fn from(wasm: TransactionBodyList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::transaction::TransactionBody>> for TransactionBodyList {
-    fn as_ref(&self) -> &Vec<cml_chain::transaction::TransactionBody> {
-        &self.0
-    }
-}
-
 pub type TransactionIndex = u16;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TransactionInputList(Vec<cml_chain::transaction::TransactionInput>);
+
+impl_wasm_conversions!(
+    Vec<cml_chain::transaction::TransactionInput>,
+    TransactionInputList
+);
 
 #[wasm_bindgen]
 impl TransactionInputList {
@@ -1570,70 +982,15 @@ impl TransactionInputList {
     }
 }
 
-impl From<Vec<cml_chain::transaction::TransactionInput>> for TransactionInputList {
-    fn from(native: Vec<cml_chain::transaction::TransactionInput>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionInputList> for Vec<cml_chain::transaction::TransactionInput> {
-    fn from(wasm: TransactionInputList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::transaction::TransactionInput>> for TransactionInputList {
-    fn as_ref(&self) -> &Vec<cml_chain::transaction::TransactionInput> {
-        &self.0
-    }
-}
-
-pub type TransactionMetadatumLabel = u64;
-
-#[derive(Clone, Debug)]
-#[wasm_bindgen]
-pub struct TransactionMetadatumList(Vec<cml_chain::auxdata::TransactionMetadatum>);
-
-#[wasm_bindgen]
-impl TransactionMetadatumList {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn get(&self, index: usize) -> TransactionMetadatum {
-        self.0[index].clone().into()
-    }
-
-    pub fn add(&mut self, elem: &TransactionMetadatum) {
-        self.0.push(elem.clone().into());
-    }
-}
-
-impl From<Vec<cml_chain::auxdata::TransactionMetadatum>> for TransactionMetadatumList {
-    fn from(native: Vec<cml_chain::auxdata::TransactionMetadatum>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionMetadatumList> for Vec<cml_chain::auxdata::TransactionMetadatum> {
-    fn from(wasm: TransactionMetadatumList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::auxdata::TransactionMetadatum>> for TransactionMetadatumList {
-    fn as_ref(&self) -> &Vec<cml_chain::auxdata::TransactionMetadatum> {
-        &self.0
-    }
-}
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TransactionOutputList(Vec<cml_chain::transaction::TransactionOutput>);
+
+impl_wasm_conversions!(
+    Vec<cml_chain::transaction::TransactionOutput>,
+    TransactionOutputList
+);
 
 #[wasm_bindgen]
 impl TransactionOutputList {
@@ -1654,27 +1011,14 @@ impl TransactionOutputList {
     }
 }
 
-impl From<Vec<cml_chain::transaction::TransactionOutput>> for TransactionOutputList {
-    fn from(native: Vec<cml_chain::transaction::TransactionOutput>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionOutputList> for Vec<cml_chain::transaction::TransactionOutput> {
-    fn from(wasm: TransactionOutputList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::transaction::TransactionOutput>> for TransactionOutputList {
-    fn as_ref(&self) -> &Vec<cml_chain::transaction::TransactionOutput> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TransactionWitnessSetList(Vec<cml_chain::transaction::TransactionWitnessSet>);
+
+impl_wasm_conversions!(
+    Vec<cml_chain::transaction::TransactionWitnessSet>,
+    TransactionWitnessSetList
+);
 
 #[wasm_bindgen]
 impl TransactionWitnessSetList {
@@ -1695,56 +1039,16 @@ impl TransactionWitnessSetList {
     }
 }
 
-impl From<Vec<cml_chain::transaction::TransactionWitnessSet>> for TransactionWitnessSetList {
-    fn from(native: Vec<cml_chain::transaction::TransactionWitnessSet>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionWitnessSetList> for Vec<cml_chain::transaction::TransactionWitnessSet> {
-    fn from(wasm: TransactionWitnessSetList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::transaction::TransactionWitnessSet>> for TransactionWitnessSetList {
-    fn as_ref(&self) -> &Vec<cml_chain::transaction::TransactionWitnessSet> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct UnitInterval(cml_chain::UnitInterval);
 
+impl_wasm_cbor_json_api!(UnitInterval);
+
+impl_wasm_conversions!(cml_chain::UnitInterval, UnitInterval);
+
 #[wasm_bindgen]
 impl UnitInterval {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<UnitInterval, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<UnitInterval, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn start(&self) -> u64 {
         self.0.start
     }
@@ -1758,56 +1062,16 @@ impl UnitInterval {
     }
 }
 
-impl From<cml_chain::UnitInterval> for UnitInterval {
-    fn from(native: cml_chain::UnitInterval) -> Self {
-        Self(native)
-    }
-}
-
-impl From<UnitInterval> for cml_chain::UnitInterval {
-    fn from(wasm: UnitInterval) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::UnitInterval> for UnitInterval {
-    fn as_ref(&self) -> &cml_chain::UnitInterval {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Update(cml_chain::Update);
 
+impl_wasm_cbor_json_api!(Update);
+
+impl_wasm_conversions!(cml_chain::Update, Update);
+
 #[wasm_bindgen]
 impl Update {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Update, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Update, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn proposed_protocol_parameter_updates(&self) -> ProposedProtocolParameterUpdates {
         self.0.proposed_protocol_parameter_updates.clone().into()
     }
@@ -1827,54 +1091,11 @@ impl Update {
     }
 }
 
-impl From<cml_chain::Update> for Update {
-    fn from(native: cml_chain::Update) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Update> for cml_chain::Update {
-    fn from(wasm: Update) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::Update> for Update {
-    fn as_ref(&self) -> &cml_chain::Update {
-        &self.0
-    }
-}
-
-#[derive(Clone, Debug)]
-#[wasm_bindgen]
-pub struct Value(cml_chain::Value);
-
-#[wasm_bindgen]
-impl Value {
-    // TODO: API
-}
-
-impl From<cml_chain::Value> for Value {
-    fn from(native: cml_chain::Value) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Value> for cml_chain::Value {
-    fn from(wasm: Value) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::Value> for Value {
-    fn as_ref(&self) -> &cml_chain::Value {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct VkeywitnessList(Vec<cml_chain::crypto::Vkeywitness>);
+
+impl_wasm_conversions!(Vec<cml_chain::crypto::Vkeywitness>, VkeywitnessList);
 
 #[wasm_bindgen]
 impl VkeywitnessList {
@@ -1895,27 +1116,11 @@ impl VkeywitnessList {
     }
 }
 
-impl From<Vec<cml_chain::crypto::Vkeywitness>> for VkeywitnessList {
-    fn from(native: Vec<cml_chain::crypto::Vkeywitness>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<VkeywitnessList> for Vec<cml_chain::crypto::Vkeywitness> {
-    fn from(wasm: VkeywitnessList) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::crypto::Vkeywitness>> for VkeywitnessList {
-    fn as_ref(&self) -> &Vec<cml_chain::crypto::Vkeywitness> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Withdrawals(cml_chain::Withdrawals);
+
+impl_wasm_conversions!(cml_chain::Withdrawals, Withdrawals);
 
 #[wasm_bindgen]
 impl Withdrawals {
@@ -1937,23 +1142,5 @@ impl Withdrawals {
 
     pub fn keys(&self) -> RewardAccountList {
         RewardAccountList(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
-    }
-}
-
-impl From<cml_chain::Withdrawals> for Withdrawals {
-    fn from(native: cml_chain::Withdrawals) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Withdrawals> for cml_chain::Withdrawals {
-    fn from(wasm: Withdrawals) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::Withdrawals> for Withdrawals {
-    fn as_ref(&self) -> &cml_chain::Withdrawals {
-        &self.0
     }
 }

--- a/chain/wasm/src/plutus/mod.rs
+++ b/chain/wasm/src/plutus/mod.rs
@@ -7,6 +7,7 @@ use crate::utils::BigInt;
 
 use super::{IntList, PlutusDataList, SubCoin};
 pub use cml_chain::plutus::{Language, RedeemerTag};
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 pub use utils::{ConstrPlutusData, PlutusMap};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -14,34 +15,12 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[wasm_bindgen]
 pub struct CostModels(cml_chain::plutus::CostModels);
 
+impl_wasm_cbor_json_api!(CostModels);
+
+impl_wasm_conversions!(cml_chain::plutus::CostModels, CostModels);
+
 #[wasm_bindgen]
 impl CostModels {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<CostModels, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<CostModels, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_plutus_v1(&mut self, plutus_v1: &IntList) {
         self.0.plutus_v1 = Some(plutus_v1.clone().into())
     }
@@ -63,56 +42,16 @@ impl CostModels {
     }
 }
 
-impl From<cml_chain::plutus::CostModels> for CostModels {
-    fn from(native: cml_chain::plutus::CostModels) -> Self {
-        Self(native)
-    }
-}
-
-impl From<CostModels> for cml_chain::plutus::CostModels {
-    fn from(wasm: CostModels) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::plutus::CostModels> for CostModels {
-    fn as_ref(&self) -> &cml_chain::plutus::CostModels {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ExUnitPrices(cml_chain::plutus::ExUnitPrices);
 
+impl_wasm_cbor_json_api!(ExUnitPrices);
+
+impl_wasm_conversions!(cml_chain::plutus::ExUnitPrices, ExUnitPrices);
+
 #[wasm_bindgen]
 impl ExUnitPrices {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ExUnitPrices, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ExUnitPrices, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn mem_price(&self) -> SubCoin {
         self.0.mem_price.clone().into()
     }
@@ -129,56 +68,16 @@ impl ExUnitPrices {
     }
 }
 
-impl From<cml_chain::plutus::ExUnitPrices> for ExUnitPrices {
-    fn from(native: cml_chain::plutus::ExUnitPrices) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ExUnitPrices> for cml_chain::plutus::ExUnitPrices {
-    fn from(wasm: ExUnitPrices) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::plutus::ExUnitPrices> for ExUnitPrices {
-    fn as_ref(&self) -> &cml_chain::plutus::ExUnitPrices {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ExUnits(cml_chain::plutus::ExUnits);
 
+impl_wasm_cbor_json_api!(ExUnits);
+
+impl_wasm_conversions!(cml_chain::plutus::ExUnits, ExUnits);
+
 #[wasm_bindgen]
 impl ExUnits {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ExUnits, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ExUnits, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn mem(&self) -> u64 {
         self.0.mem
     }
@@ -192,56 +91,16 @@ impl ExUnits {
     }
 }
 
-impl From<cml_chain::plutus::ExUnits> for ExUnits {
-    fn from(native: cml_chain::plutus::ExUnits) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ExUnits> for cml_chain::plutus::ExUnits {
-    fn from(wasm: ExUnits) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::plutus::ExUnits> for ExUnits {
-    fn as_ref(&self) -> &cml_chain::plutus::ExUnits {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PlutusData(cml_chain::plutus::PlutusData);
 
+impl_wasm_cbor_json_api!(PlutusData);
+
+impl_wasm_conversions!(cml_chain::plutus::PlutusData, PlutusData);
+
 #[wasm_bindgen]
 impl PlutusData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PlutusData, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PlutusData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_constr_plutus_data(constr_plutus_data: &ConstrPlutusData) -> Self {
         Self(cml_chain::plutus::PlutusData::new_constr_plutus_data(
             constr_plutus_data.clone().into(),
@@ -314,24 +173,6 @@ impl PlutusData {
     }
 }
 
-impl From<cml_chain::plutus::PlutusData> for PlutusData {
-    fn from(native: cml_chain::plutus::PlutusData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PlutusData> for cml_chain::plutus::PlutusData {
-    fn from(wasm: PlutusData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::plutus::PlutusData> for PlutusData {
-    fn as_ref(&self) -> &cml_chain::plutus::PlutusData {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum PlutusDataKind {
     ConstrPlutusData,
@@ -345,54 +186,14 @@ pub enum PlutusDataKind {
 #[wasm_bindgen]
 pub struct PlutusV1Script(cml_chain::plutus::PlutusV1Script);
 
+impl_wasm_cbor_json_api!(PlutusV1Script);
+
+impl_wasm_conversions!(cml_chain::plutus::PlutusV1Script, PlutusV1Script);
+
 #[wasm_bindgen]
 impl PlutusV1Script {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PlutusV1Script, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PlutusV1Script, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> Vec<u8> {
         self.0.get().clone()
-    }
-}
-
-impl From<cml_chain::plutus::PlutusV1Script> for PlutusV1Script {
-    fn from(native: cml_chain::plutus::PlutusV1Script) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PlutusV1Script> for cml_chain::plutus::PlutusV1Script {
-    fn from(wasm: PlutusV1Script) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::plutus::PlutusV1Script> for PlutusV1Script {
-    fn as_ref(&self) -> &cml_chain::plutus::PlutusV1Script {
-        &self.0
     }
 }
 
@@ -400,54 +201,14 @@ impl AsRef<cml_chain::plutus::PlutusV1Script> for PlutusV1Script {
 #[wasm_bindgen]
 pub struct PlutusV2Script(cml_chain::plutus::PlutusV2Script);
 
+impl_wasm_cbor_json_api!(PlutusV2Script);
+
+impl_wasm_conversions!(cml_chain::plutus::PlutusV2Script, PlutusV2Script);
+
 #[wasm_bindgen]
 impl PlutusV2Script {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<PlutusV2Script, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<PlutusV2Script, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn get(&self) -> Vec<u8> {
         self.0.get().clone()
-    }
-}
-
-impl From<cml_chain::plutus::PlutusV2Script> for PlutusV2Script {
-    fn from(native: cml_chain::plutus::PlutusV2Script) -> Self {
-        Self(native)
-    }
-}
-
-impl From<PlutusV2Script> for cml_chain::plutus::PlutusV2Script {
-    fn from(wasm: PlutusV2Script) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::plutus::PlutusV2Script> for PlutusV2Script {
-    fn as_ref(&self) -> &cml_chain::plutus::PlutusV2Script {
-        &self.0
     }
 }
 
@@ -455,34 +216,12 @@ impl AsRef<cml_chain::plutus::PlutusV2Script> for PlutusV2Script {
 #[wasm_bindgen]
 pub struct Redeemer(cml_chain::plutus::Redeemer);
 
+impl_wasm_cbor_json_api!(Redeemer);
+
+impl_wasm_conversions!(cml_chain::plutus::Redeemer, Redeemer);
+
 #[wasm_bindgen]
 impl Redeemer {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Redeemer, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Redeemer, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn tag(&self) -> RedeemerTag {
         self.0.tag
     }
@@ -506,23 +245,5 @@ impl Redeemer {
             data.clone().into(),
             ex_units.clone().into(),
         ))
-    }
-}
-
-impl From<cml_chain::plutus::Redeemer> for Redeemer {
-    fn from(native: cml_chain::plutus::Redeemer) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Redeemer> for cml_chain::plutus::Redeemer {
-    fn from(wasm: Redeemer) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::plutus::Redeemer> for Redeemer {
-    fn as_ref(&self) -> &cml_chain::plutus::Redeemer {
-        &self.0
     }
 }

--- a/chain/wasm/src/transaction/mod.rs
+++ b/chain/wasm/src/transaction/mod.rs
@@ -13,6 +13,7 @@ use crate::auxdata::AuxiliaryData;
 use cml_crypto_wasm::{
     AuxiliaryDataHash, DatumHash, Ed25519KeyHash, ScriptDataHash, TransactionHash,
 };
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use crate::plutus::PlutusData;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -22,34 +23,12 @@ pub mod utils;
 #[wasm_bindgen]
 pub struct AlonzoTxOut(cml_chain::transaction::AlonzoTxOut);
 
+impl_wasm_cbor_json_api!(AlonzoTxOut);
+
+impl_wasm_conversions!(cml_chain::transaction::AlonzoTxOut, AlonzoTxOut);
+
 #[wasm_bindgen]
 impl AlonzoTxOut {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTxOut, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoTxOut, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn address(&self) -> Address {
         self.0.address.clone().into()
     }
@@ -71,56 +50,16 @@ impl AlonzoTxOut {
     }
 }
 
-impl From<cml_chain::transaction::AlonzoTxOut> for AlonzoTxOut {
-    fn from(native: cml_chain::transaction::AlonzoTxOut) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoTxOut> for cml_chain::transaction::AlonzoTxOut {
-    fn from(wasm: AlonzoTxOut) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::AlonzoTxOut> for AlonzoTxOut {
-    fn as_ref(&self) -> &cml_chain::transaction::AlonzoTxOut {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct BabbageTxOut(cml_chain::transaction::BabbageTxOut);
 
+impl_wasm_cbor_json_api!(BabbageTxOut);
+
+impl_wasm_conversions!(cml_chain::transaction::BabbageTxOut, BabbageTxOut);
+
 #[wasm_bindgen]
 impl BabbageTxOut {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<BabbageTxOut, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<BabbageTxOut, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn address(&self) -> Address {
         self.0.address.clone().into()
     }
@@ -156,56 +95,16 @@ impl BabbageTxOut {
     }
 }
 
-impl From<cml_chain::transaction::BabbageTxOut> for BabbageTxOut {
-    fn from(native: cml_chain::transaction::BabbageTxOut) -> Self {
-        Self(native)
-    }
-}
-
-impl From<BabbageTxOut> for cml_chain::transaction::BabbageTxOut {
-    fn from(wasm: BabbageTxOut) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::BabbageTxOut> for BabbageTxOut {
-    fn as_ref(&self) -> &cml_chain::transaction::BabbageTxOut {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct DatumOption(cml_chain::transaction::DatumOption);
 
+impl_wasm_cbor_json_api!(DatumOption);
+
+impl_wasm_conversions!(cml_chain::transaction::DatumOption, DatumOption);
+
 #[wasm_bindgen]
 impl DatumOption {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<DatumOption, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<DatumOption, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_hash(datum_hash: &DatumHash) -> Self {
         Self(cml_chain::transaction::DatumOption::new_hash(
             datum_hash.clone().into(),
@@ -242,24 +141,6 @@ impl DatumOption {
     }
 }
 
-impl From<cml_chain::transaction::DatumOption> for DatumOption {
-    fn from(native: cml_chain::transaction::DatumOption) -> Self {
-        Self(native)
-    }
-}
-
-impl From<DatumOption> for cml_chain::transaction::DatumOption {
-    fn from(wasm: DatumOption) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::DatumOption> for DatumOption {
-    fn as_ref(&self) -> &cml_chain::transaction::DatumOption {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum DatumOptionKind {
     Hash,
@@ -270,34 +151,12 @@ pub enum DatumOptionKind {
 #[wasm_bindgen]
 pub struct NativeScript(cml_chain::transaction::NativeScript);
 
+impl_wasm_cbor_json_api!(NativeScript);
+
+impl_wasm_conversions!(cml_chain::transaction::NativeScript, NativeScript);
+
 #[wasm_bindgen]
 impl NativeScript {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<NativeScript, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<NativeScript, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_script_pubkey(ed25519_key_hash: &Ed25519KeyHash) -> Self {
         Self(cml_chain::transaction::NativeScript::new_script_pubkey(
             ed25519_key_hash.clone().into(),
@@ -401,24 +260,6 @@ impl NativeScript {
     }
 }
 
-impl From<cml_chain::transaction::NativeScript> for NativeScript {
-    fn from(native: cml_chain::transaction::NativeScript) -> Self {
-        Self(native)
-    }
-}
-
-impl From<NativeScript> for cml_chain::transaction::NativeScript {
-    fn from(wasm: NativeScript) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::NativeScript> for NativeScript {
-    fn as_ref(&self) -> &cml_chain::transaction::NativeScript {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum NativeScriptKind {
     ScriptPubkey,
@@ -432,6 +273,8 @@ pub enum NativeScriptKind {
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct RequiredSigners(Vec<cml_chain::crypto::Ed25519KeyHash>);
+
+impl_wasm_conversions!(Vec<cml_chain::crypto::Ed25519KeyHash>, RequiredSigners);
 
 #[wasm_bindgen]
 impl RequiredSigners {
@@ -452,56 +295,16 @@ impl RequiredSigners {
     }
 }
 
-impl From<Vec<cml_chain::crypto::Ed25519KeyHash>> for RequiredSigners {
-    fn from(native: Vec<cml_chain::crypto::Ed25519KeyHash>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<RequiredSigners> for Vec<cml_chain::crypto::Ed25519KeyHash> {
-    fn from(wasm: RequiredSigners) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_chain::crypto::Ed25519KeyHash>> for RequiredSigners {
-    fn as_ref(&self) -> &Vec<cml_chain::crypto::Ed25519KeyHash> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ScriptAll(cml_chain::transaction::ScriptAll);
 
+impl_wasm_cbor_json_api!(ScriptAll);
+
+impl_wasm_conversions!(cml_chain::transaction::ScriptAll, ScriptAll);
+
 #[wasm_bindgen]
 impl ScriptAll {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ScriptAll, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ScriptAll, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn native_scripts(&self) -> NativeScriptList {
         self.0.native_scripts.clone().into()
     }
@@ -513,56 +316,16 @@ impl ScriptAll {
     }
 }
 
-impl From<cml_chain::transaction::ScriptAll> for ScriptAll {
-    fn from(native: cml_chain::transaction::ScriptAll) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ScriptAll> for cml_chain::transaction::ScriptAll {
-    fn from(wasm: ScriptAll) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::ScriptAll> for ScriptAll {
-    fn as_ref(&self) -> &cml_chain::transaction::ScriptAll {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ScriptAny(cml_chain::transaction::ScriptAny);
 
+impl_wasm_cbor_json_api!(ScriptAny);
+
+impl_wasm_conversions!(cml_chain::transaction::ScriptAny, ScriptAny);
+
 #[wasm_bindgen]
 impl ScriptAny {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ScriptAny, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ScriptAny, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn native_scripts(&self) -> NativeScriptList {
         self.0.native_scripts.clone().into()
     }
@@ -574,56 +337,19 @@ impl ScriptAny {
     }
 }
 
-impl From<cml_chain::transaction::ScriptAny> for ScriptAny {
-    fn from(native: cml_chain::transaction::ScriptAny) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ScriptAny> for cml_chain::transaction::ScriptAny {
-    fn from(wasm: ScriptAny) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::ScriptAny> for ScriptAny {
-    fn as_ref(&self) -> &cml_chain::transaction::ScriptAny {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ScriptInvalidBefore(cml_chain::transaction::ScriptInvalidBefore);
 
+impl_wasm_cbor_json_api!(ScriptInvalidBefore);
+
+impl_wasm_conversions!(
+    cml_chain::transaction::ScriptInvalidBefore,
+    ScriptInvalidBefore
+);
+
 #[wasm_bindgen]
 impl ScriptInvalidBefore {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ScriptInvalidBefore, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ScriptInvalidBefore, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn before(&self) -> Slot {
         self.0.before
     }
@@ -633,56 +359,19 @@ impl ScriptInvalidBefore {
     }
 }
 
-impl From<cml_chain::transaction::ScriptInvalidBefore> for ScriptInvalidBefore {
-    fn from(native: cml_chain::transaction::ScriptInvalidBefore) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ScriptInvalidBefore> for cml_chain::transaction::ScriptInvalidBefore {
-    fn from(wasm: ScriptInvalidBefore) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::ScriptInvalidBefore> for ScriptInvalidBefore {
-    fn as_ref(&self) -> &cml_chain::transaction::ScriptInvalidBefore {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ScriptInvalidHereafter(cml_chain::transaction::ScriptInvalidHereafter);
 
+impl_wasm_cbor_json_api!(ScriptInvalidHereafter);
+
+impl_wasm_conversions!(
+    cml_chain::transaction::ScriptInvalidHereafter,
+    ScriptInvalidHereafter
+);
+
 #[wasm_bindgen]
 impl ScriptInvalidHereafter {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ScriptInvalidHereafter, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ScriptInvalidHereafter, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn after(&self) -> Slot {
         self.0.after
     }
@@ -692,56 +381,16 @@ impl ScriptInvalidHereafter {
     }
 }
 
-impl From<cml_chain::transaction::ScriptInvalidHereafter> for ScriptInvalidHereafter {
-    fn from(native: cml_chain::transaction::ScriptInvalidHereafter) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ScriptInvalidHereafter> for cml_chain::transaction::ScriptInvalidHereafter {
-    fn from(wasm: ScriptInvalidHereafter) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::ScriptInvalidHereafter> for ScriptInvalidHereafter {
-    fn as_ref(&self) -> &cml_chain::transaction::ScriptInvalidHereafter {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ScriptNOfK(cml_chain::transaction::ScriptNOfK);
 
+impl_wasm_cbor_json_api!(ScriptNOfK);
+
+impl_wasm_conversions!(cml_chain::transaction::ScriptNOfK, ScriptNOfK);
+
 #[wasm_bindgen]
 impl ScriptNOfK {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ScriptNOfK, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ScriptNOfK, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn n(&self) -> u64 {
         self.0.n
     }
@@ -758,56 +407,16 @@ impl ScriptNOfK {
     }
 }
 
-impl From<cml_chain::transaction::ScriptNOfK> for ScriptNOfK {
-    fn from(native: cml_chain::transaction::ScriptNOfK) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ScriptNOfK> for cml_chain::transaction::ScriptNOfK {
-    fn from(wasm: ScriptNOfK) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::ScriptNOfK> for ScriptNOfK {
-    fn as_ref(&self) -> &cml_chain::transaction::ScriptNOfK {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ScriptPubkey(cml_chain::transaction::ScriptPubkey);
 
+impl_wasm_cbor_json_api!(ScriptPubkey);
+
+impl_wasm_conversions!(cml_chain::transaction::ScriptPubkey, ScriptPubkey);
+
 #[wasm_bindgen]
 impl ScriptPubkey {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ScriptPubkey, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ScriptPubkey, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn ed25519_key_hash(&self) -> Ed25519KeyHash {
         self.0.ed25519_key_hash.clone().into()
     }
@@ -819,58 +428,18 @@ impl ScriptPubkey {
     }
 }
 
-impl From<cml_chain::transaction::ScriptPubkey> for ScriptPubkey {
-    fn from(native: cml_chain::transaction::ScriptPubkey) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ScriptPubkey> for cml_chain::transaction::ScriptPubkey {
-    fn from(wasm: ScriptPubkey) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::ScriptPubkey> for ScriptPubkey {
-    fn as_ref(&self) -> &cml_chain::transaction::ScriptPubkey {
-        &self.0
-    }
-}
-
 pub type ScriptRef = Script;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyTxOut(cml_chain::transaction::ShelleyTxOut);
 
+impl_wasm_cbor_json_api!(ShelleyTxOut);
+
+impl_wasm_conversions!(cml_chain::transaction::ShelleyTxOut, ShelleyTxOut);
+
 #[wasm_bindgen]
 impl ShelleyTxOut {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTxOut, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyTxOut, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn address(&self) -> Address {
         self.0.address.clone().into()
     }
@@ -887,56 +456,16 @@ impl ShelleyTxOut {
     }
 }
 
-impl From<cml_chain::transaction::ShelleyTxOut> for ShelleyTxOut {
-    fn from(native: cml_chain::transaction::ShelleyTxOut) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyTxOut> for cml_chain::transaction::ShelleyTxOut {
-    fn from(wasm: ShelleyTxOut) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::ShelleyTxOut> for ShelleyTxOut {
-    fn as_ref(&self) -> &cml_chain::transaction::ShelleyTxOut {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct Transaction(cml_chain::transaction::Transaction);
 
+impl_wasm_cbor_json_api!(Transaction);
+
+impl_wasm_conversions!(cml_chain::transaction::Transaction, Transaction);
+
 #[wasm_bindgen]
 impl Transaction {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Transaction, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Transaction, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn body(&self) -> TransactionBody {
         self.0.body.clone().into()
     }
@@ -968,56 +497,16 @@ impl Transaction {
     }
 }
 
-impl From<cml_chain::transaction::Transaction> for Transaction {
-    fn from(native: cml_chain::transaction::Transaction) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Transaction> for cml_chain::transaction::Transaction {
-    fn from(wasm: Transaction) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::Transaction> for Transaction {
-    fn as_ref(&self) -> &cml_chain::transaction::Transaction {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TransactionBody(cml_chain::transaction::TransactionBody);
 
+impl_wasm_cbor_json_api!(TransactionBody);
+
+impl_wasm_conversions!(cml_chain::transaction::TransactionBody, TransactionBody);
+
 #[wasm_bindgen]
 impl TransactionBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<TransactionBody, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<TransactionBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn inputs(&self) -> TransactionInputList {
         self.0.inputs.clone().into()
     }
@@ -1169,56 +658,16 @@ impl TransactionBody {
     }
 }
 
-impl From<cml_chain::transaction::TransactionBody> for TransactionBody {
-    fn from(native: cml_chain::transaction::TransactionBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionBody> for cml_chain::transaction::TransactionBody {
-    fn from(wasm: TransactionBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::TransactionBody> for TransactionBody {
-    fn as_ref(&self) -> &cml_chain::transaction::TransactionBody {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TransactionInput(cml_chain::transaction::TransactionInput);
 
+impl_wasm_cbor_json_api!(TransactionInput);
+
+impl_wasm_conversions!(cml_chain::transaction::TransactionInput, TransactionInput);
+
 #[wasm_bindgen]
 impl TransactionInput {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<TransactionInput, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<TransactionInput, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn transaction_id(&self) -> TransactionHash {
         self.0.transaction_id.clone().into()
     }
@@ -1235,56 +684,16 @@ impl TransactionInput {
     }
 }
 
-impl From<cml_chain::transaction::TransactionInput> for TransactionInput {
-    fn from(native: cml_chain::transaction::TransactionInput) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionInput> for cml_chain::transaction::TransactionInput {
-    fn from(wasm: TransactionInput) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::TransactionInput> for TransactionInput {
-    fn as_ref(&self) -> &cml_chain::transaction::TransactionInput {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TransactionOutput(cml_chain::transaction::TransactionOutput);
 
+impl_wasm_cbor_json_api!(TransactionOutput);
+
+impl_wasm_conversions!(cml_chain::transaction::TransactionOutput, TransactionOutput);
+
 #[wasm_bindgen]
 impl TransactionOutput {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<TransactionOutput, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<TransactionOutput, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_shelley_tx_out(shelley_tx_out: &ShelleyTxOut) -> Self {
         Self(
             cml_chain::transaction::TransactionOutput::new_shelley_tx_out(
@@ -1351,24 +760,6 @@ impl TransactionOutput {
     }
 }
 
-impl From<cml_chain::transaction::TransactionOutput> for TransactionOutput {
-    fn from(native: cml_chain::transaction::TransactionOutput) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionOutput> for cml_chain::transaction::TransactionOutput {
-    fn from(wasm: TransactionOutput) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::TransactionOutput> for TransactionOutput {
-    fn as_ref(&self) -> &cml_chain::transaction::TransactionOutput {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum TransactionOutputKind {
     ShelleyTxOut,
@@ -1380,34 +771,15 @@ pub enum TransactionOutputKind {
 #[wasm_bindgen]
 pub struct TransactionWitnessSet(cml_chain::transaction::TransactionWitnessSet);
 
+impl_wasm_cbor_json_api!(TransactionWitnessSet);
+
+impl_wasm_conversions!(
+    cml_chain::transaction::TransactionWitnessSet,
+    TransactionWitnessSet
+);
+
 #[wasm_bindgen]
 impl TransactionWitnessSet {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_chain::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<TransactionWitnessSet, JsValue> {
-        cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<TransactionWitnessSet, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_vkeywitnesses(&mut self, vkeywitnesses: &VkeywitnessList) {
         self.0.vkeywitnesses = Some(vkeywitnesses.clone().into())
     }
@@ -1475,23 +847,5 @@ impl TransactionWitnessSet {
 
     pub fn new() -> Self {
         Self(cml_chain::transaction::TransactionWitnessSet::new())
-    }
-}
-
-impl From<cml_chain::transaction::TransactionWitnessSet> for TransactionWitnessSet {
-    fn from(native: cml_chain::transaction::TransactionWitnessSet) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TransactionWitnessSet> for cml_chain::transaction::TransactionWitnessSet {
-    fn from(wasm: TransactionWitnessSet) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_chain::transaction::TransactionWitnessSet> for TransactionWitnessSet {
-    fn as_ref(&self) -> &cml_chain::transaction::TransactionWitnessSet {
-        &self.0
     }
 }

--- a/chain/wasm/src/utils.rs
+++ b/chain/wasm/src/utils.rs
@@ -22,7 +22,7 @@ impl BigInt {
             .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
     }
 
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
+    pub fn to_js_value(&self) -> Result<JsValue, JsValue> {
         serde_wasm_bindgen::to_value(&self.0)
             .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
     }

--- a/cip25/rust/src/utils.rs
+++ b/cip25/rust/src/utils.rs
@@ -140,22 +140,22 @@ impl MiniMetadataDetails {
     ///       however, since this is a lot of work, we use this temporary solution instead
     pub fn loose_parse(metadatum: &TransactionMetadatum) -> Result<Self, DeserializeError> {
         match metadatum {
-            TransactionMetadatum::Map { entries, .. } => {
-                let name: Option<String64> = entries
+            TransactionMetadatum::Map(map) => {
+                let name: Option<String64> = map
                 .get(&TransactionMetadatum::new_text("name".to_owned()))
                 // for some reason, 1% of NFTs seem to use the wrong case
-                .or_else(|| entries.get(&TransactionMetadatum::new_text("Name".to_owned())))
+                .or_else(|| map.get(&TransactionMetadatum::new_text("Name".to_owned())))
                 // for some reason, 0.5% of NFTs use "title" instead of name
-                .or_else(|| entries.get(&TransactionMetadatum::new_text("title".to_owned())))
+                .or_else(|| map.get(&TransactionMetadatum::new_text("title".to_owned())))
                 // for some reason, 0.3% of NFTs use "id" instead of name
-                .or_else(|| entries.get(&TransactionMetadatum::new_text("id".to_owned())))
+                .or_else(|| map.get(&TransactionMetadatum::new_text("id".to_owned())))
                 .map(|result| match result {
                     TransactionMetadatum::Text { text, .. } => String64::new_str(&text).ok(),
                     _ => None,
                 })
                 .flatten();
     
-                let image_base = entries
+                let image_base = map
                 .get(&TransactionMetadatum::new_text("image".to_owned()));
                 let image = match image_base {
                     None => None,
@@ -724,7 +724,7 @@ mod tests {
         //     TransactionMetadatum::new_bytes(vec![0xBA, 0xAD, 0xF0, 0x0D]),
         // ]));
         // let label_metadatum_entries: &mut _ = match as_metadata.get_mut(&721).unwrap() {
-        //     TransactionMetadatum::Map { entries, .. } => entries,
+        //     TransactionMetadatum::Map(map) => map.entries,
         //     _ => panic!(),
         // };
         // let mut filler_map = OrderedHashMap::new();
@@ -734,12 +734,12 @@ mod tests {
         // );
         // label_metadatum_entries.insert(TransactionMetadatum::new_map(filler_map.clone()), TransactionMetadatum::new_map(filler_map.clone()));
         // let data_entries: &mut _ = match label_metadatum_entries.get_mut(&TransactionMetadatum::new_text("data".to_owned())).unwrap() {
-        //     TransactionMetadatum::Map{ entries, .. } => entries,
+        //     TransactionMetadatum::Map{ map.entries, .. } => map.entries,
         //     _ => panic!(),
         // };
         // data_entries.insert(TransactionMetadatum::new_map(filler_map.clone()), TransactionMetadatum::new_map(filler_map.clone()));
         // let policy_entries: &mut _ = match data_entries.get_mut(&TransactionMetadatum::new_bytes(policy_id_bytes.to_vec())).unwrap() {
-        //     TransactionMetadatum::Map{ entries, .. } => entries,
+        //     TransactionMetadatum::Map{ map.entries, .. } => map.entries,
         //     _ => panic!(),
         // };
         // policy_entries.insert(TransactionMetadatum::new_map(filler_map.clone()), TransactionMetadatum::new_map(filler_map.clone()));
@@ -748,7 +748,7 @@ mod tests {
         //     TransactionMetadatum::new_list(vec![TransactionMetadatum::new_text("dskjfaks".to_owned())])
         // );
         // let details: &mut _ = match policy_entries.get_mut(&TransactionMetadatum::new_bytes(vec![0xCA, 0xFE, 0xD0, 0x0D])).unwrap() {
-        //     TransactionMetadatum::Map { entries, .. } => entries,
+        //     TransactionMetadatum::Map(map) => map.entries,
         //     _ => panic!(),
         // };
         // details.insert(
@@ -757,7 +757,7 @@ mod tests {
         // );
         // let file_details: &mut _ = match details.get_mut(&TransactionMetadatum::new_text("files".to_owned())).unwrap() {
         //     TransactionMetadatum::List{ elements, .. } => match elements.get_mut(0).unwrap() {
-        //         TransactionMetadatum::Map{ entries, .. } => entries,
+        //         TransactionMetadatum::Map{ map.entries, .. } => map.entries,
         //         _ => panic!(),
         //     },
         //     _ => panic!(),

--- a/cip25/wasm/json-gen/src/main.rs
+++ b/cip25/wasm/json-gen/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
         std::fs::create_dir(schema_path).unwrap();
     }    
     gen_json_schema!(CIP25Metadata);
+    gen_json_schema!(CIP25Version);
     gen_json_schema!(ChunkableString);
     gen_json_schema!(FilesDetails);
     gen_json_schema!(LabelMetadata);

--- a/cip25/wasm/package.json
+++ b/cip25/wasm/package.json
@@ -22,8 +22,7 @@
     "js:publish-browser:beta": "npm run rust:build-browser && npm run js:prepublish && node ../../scripts/publish-helper cip25 -browser && cd publish && npm publish --tag beta --access public",
     "js:publish-asm:prod": "npm run rust:build-asm && npm run js:prepublish && node ../../scripts/publish-helper cip25 -asmjs && cd publish && npm publish --access public",
     "js:publish-asm:beta": "npm run rust:build-asm && npm run js:prepublish && node ../../scripts/publish-helper cip25 -asmjs && cd publish && npm publish --tag beta --access public",
-    "js:ts-json-gen": "cd json-gen && cargo +stable run && cd .. && node ../../scripts/run-json2ts.js && node ../../scripts/json-ts-types.js cip25",
-    "postinstall": "git submodule update --init --recursive && cd binaryen; cmake . && make"
+    "js:ts-json-gen": "cd json-gen && cargo +stable run && cd .. && node ../../scripts/run-json2ts.js && node ../../scripts/json-ts-types.js cip25"
   },
   "husky": {
     "hooks": {

--- a/multi-era/rust/src/byron/utils.rs
+++ b/multi-era/rust/src/byron/utils.rs
@@ -6,7 +6,6 @@ use cml_crypto::impl_hash_type;
 use cml_core::error::{DeserializeError, DeserializeFailure};
 use cml_core::serialization::Deserialize;
 use cml_crypto::{CryptoError, RawBytesEncoding};
-use bech32::ToBase32;
 use schemars::JsonSchema;
 use cml_crypto::chain_crypto as chain_crypto;
 

--- a/multi-era/wasm/json-gen/src/main.rs
+++ b/multi-era/wasm/json-gen/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
     gen_json_schema!(cml_multi_era::byron::mpc::VssEncryptedShare);
     gen_json_schema!(cml_multi_era::byron::mpc::VssProof);
     // byron::transaction.rs
-    gen_json_schema!(cml_multi_era::byron::transaction::ByronAny);
+    gen_json_schema!(cml_multi_era::byron::utils::ByronAny);
     gen_json_schema!(cml_multi_era::byron::transaction::ByronPkWitness);
     gen_json_schema!(cml_multi_era::byron::transaction::ByronPkWitnessEntry);
     gen_json_schema!(cml_multi_era::byron::transaction::ByronRedeemWitness);

--- a/multi-era/wasm/src/allegra/mod.rs
+++ b/multi-era/wasm/src/allegra/mod.rs
@@ -9,6 +9,7 @@ use crate::shelley::{ShelleyHeader, ShelleyUpdate};
 use cml_chain_wasm::{
     BootstrapWitnessList, NativeScriptList, VkeywitnessList, TransactionInputList, CertificateList, 
 };
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use crate::{
     AllegraTransactionBodyList, AllegraTransactionWitnessSetList,
     MapTransactionIndexToAllegraAuxiliaryData, ShelleyTransactionOutputList,
@@ -19,34 +20,15 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[wasm_bindgen]
 pub struct AllegraAuxiliaryData(cml_multi_era::allegra::AllegraAuxiliaryData);
 
+impl_wasm_cbor_json_api!(AllegraAuxiliaryData);
+
+impl_wasm_conversions!(
+    cml_multi_era::allegra::AllegraAuxiliaryData,
+    AllegraAuxiliaryData
+);
+
 #[wasm_bindgen]
 impl AllegraAuxiliaryData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraAuxiliaryData, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AllegraAuxiliaryData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_shelley_aux_data(shelley_aux_data: &ShelleyAuxData) -> Self {
         Self(
             cml_multi_era::allegra::AllegraAuxiliaryData::new_shelley_aux_data(
@@ -93,24 +75,6 @@ impl AllegraAuxiliaryData {
     }
 }
 
-impl From<cml_multi_era::allegra::AllegraAuxiliaryData> for AllegraAuxiliaryData {
-    fn from(native: cml_multi_era::allegra::AllegraAuxiliaryData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AllegraAuxiliaryData> for cml_multi_era::allegra::AllegraAuxiliaryData {
-    fn from(wasm: AllegraAuxiliaryData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::allegra::AllegraAuxiliaryData> for AllegraAuxiliaryData {
-    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraAuxiliaryData {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum AllegraAuxiliaryDataKind {
     ShelleyAuxData,
@@ -121,34 +85,12 @@ pub enum AllegraAuxiliaryDataKind {
 #[wasm_bindgen]
 pub struct AllegraBlock(cml_multi_era::allegra::AllegraBlock);
 
+impl_wasm_cbor_json_api!(AllegraBlock);
+
+impl_wasm_conversions!(cml_multi_era::allegra::AllegraBlock, AllegraBlock);
+
 #[wasm_bindgen]
 impl AllegraBlock {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraBlock, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AllegraBlock, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header(&self) -> ShelleyHeader {
         self.0.header.clone().into()
     }
@@ -180,56 +122,19 @@ impl AllegraBlock {
     }
 }
 
-impl From<cml_multi_era::allegra::AllegraBlock> for AllegraBlock {
-    fn from(native: cml_multi_era::allegra::AllegraBlock) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AllegraBlock> for cml_multi_era::allegra::AllegraBlock {
-    fn from(wasm: AllegraBlock) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::allegra::AllegraBlock> for AllegraBlock {
-    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraBlock {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AllegraTransaction(cml_multi_era::allegra::AllegraTransaction);
 
+impl_wasm_cbor_json_api!(AllegraTransaction);
+
+impl_wasm_conversions!(
+    cml_multi_era::allegra::AllegraTransaction,
+    AllegraTransaction
+);
+
 #[wasm_bindgen]
 impl AllegraTransaction {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraTransaction, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AllegraTransaction, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn body(&self) -> AllegraTransactionBody {
         self.0.body.clone().into()
     }
@@ -255,56 +160,19 @@ impl AllegraTransaction {
     }
 }
 
-impl From<cml_multi_era::allegra::AllegraTransaction> for AllegraTransaction {
-    fn from(native: cml_multi_era::allegra::AllegraTransaction) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AllegraTransaction> for cml_multi_era::allegra::AllegraTransaction {
-    fn from(wasm: AllegraTransaction) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::allegra::AllegraTransaction> for AllegraTransaction {
-    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraTransaction {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AllegraTransactionBody(cml_multi_era::allegra::AllegraTransactionBody);
 
+impl_wasm_cbor_json_api!(AllegraTransactionBody);
+
+impl_wasm_conversions!(
+    cml_multi_era::allegra::AllegraTransactionBody,
+    AllegraTransactionBody
+);
+
 #[wasm_bindgen]
 impl AllegraTransactionBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraTransactionBody, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AllegraTransactionBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn inputs(&self) -> TransactionInputList {
         self.0.inputs.clone().into()
     }
@@ -381,56 +249,19 @@ impl AllegraTransactionBody {
     }
 }
 
-impl From<cml_multi_era::allegra::AllegraTransactionBody> for AllegraTransactionBody {
-    fn from(native: cml_multi_era::allegra::AllegraTransactionBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AllegraTransactionBody> for cml_multi_era::allegra::AllegraTransactionBody {
-    fn from(wasm: AllegraTransactionBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::allegra::AllegraTransactionBody> for AllegraTransactionBody {
-    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraTransactionBody {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AllegraTransactionWitnessSet(cml_multi_era::allegra::AllegraTransactionWitnessSet);
 
+impl_wasm_cbor_json_api!(AllegraTransactionWitnessSet);
+
+impl_wasm_conversions!(
+    cml_multi_era::allegra::AllegraTransactionWitnessSet,
+    AllegraTransactionWitnessSet
+);
+
 #[wasm_bindgen]
 impl AllegraTransactionWitnessSet {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AllegraTransactionWitnessSet, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AllegraTransactionWitnessSet, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_vkeywitnesses(&mut self, vkeywitnesses: &VkeywitnessList) {
         self.0.vkeywitnesses = Some(vkeywitnesses.clone().into())
     }
@@ -460,23 +291,5 @@ impl AllegraTransactionWitnessSet {
 
     pub fn new() -> Self {
         Self(cml_multi_era::allegra::AllegraTransactionWitnessSet::new())
-    }
-}
-
-impl From<cml_multi_era::allegra::AllegraTransactionWitnessSet> for AllegraTransactionWitnessSet {
-    fn from(native: cml_multi_era::allegra::AllegraTransactionWitnessSet) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AllegraTransactionWitnessSet> for cml_multi_era::allegra::AllegraTransactionWitnessSet {
-    fn from(wasm: AllegraTransactionWitnessSet) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::allegra::AllegraTransactionWitnessSet> for AllegraTransactionWitnessSet {
-    fn as_ref(&self) -> &cml_multi_era::allegra::AllegraTransactionWitnessSet {
-        &self.0
     }
 }

--- a/multi-era/wasm/src/alonzo/mod.rs
+++ b/multi-era/wasm/src/alonzo/mod.rs
@@ -17,6 +17,7 @@ use cml_chain_wasm::{
     CertificateList, IntList, NativeScriptList, PlutusDataList, PlutusV1ScriptList,
     RedeemerList, TransactionInputList, VkeywitnessList, BootstrapWitnessList
 };
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use cml_crypto_wasm::{AuxiliaryDataHash, GenesisHash, ScriptDataHash};
 use crate::{
     AlonzoTransactionBodyList, AlonzoTransactionWitnessSetList, AlonzoTransactionOutputList, MapTransactionIndexToAlonzoAuxiliaryData,
@@ -28,34 +29,15 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[wasm_bindgen]
 pub struct AlonzoAuxiliaryData(cml_multi_era::alonzo::AlonzoAuxiliaryData);
 
+impl_wasm_cbor_json_api!(AlonzoAuxiliaryData);
+
+impl_wasm_conversions!(
+    cml_multi_era::alonzo::AlonzoAuxiliaryData,
+    AlonzoAuxiliaryData
+);
+
 #[wasm_bindgen]
 impl AlonzoAuxiliaryData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoAuxiliaryData, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoAuxiliaryData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_shelley(shelley: &ShelleyAuxData) -> Self {
         Self(cml_multi_era::alonzo::AlonzoAuxiliaryData::new_shelley(
             shelley.clone().into(),
@@ -116,24 +98,6 @@ impl AlonzoAuxiliaryData {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoAuxiliaryData> for AlonzoAuxiliaryData {
-    fn from(native: cml_multi_era::alonzo::AlonzoAuxiliaryData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoAuxiliaryData> for cml_multi_era::alonzo::AlonzoAuxiliaryData {
-    fn from(wasm: AlonzoAuxiliaryData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoAuxiliaryData> for AlonzoAuxiliaryData {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoAuxiliaryData {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum AlonzoAuxiliaryDataKind {
     Shelley,
@@ -145,34 +109,12 @@ pub enum AlonzoAuxiliaryDataKind {
 #[wasm_bindgen]
 pub struct AlonzoBlock(cml_multi_era::alonzo::AlonzoBlock);
 
+impl_wasm_cbor_json_api!(AlonzoBlock);
+
+impl_wasm_conversions!(cml_multi_era::alonzo::AlonzoBlock, AlonzoBlock);
+
 #[wasm_bindgen]
 impl AlonzoBlock {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoBlock, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoBlock, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header(&self) -> ShelleyHeader {
         self.0.header.clone().into()
     }
@@ -210,56 +152,16 @@ impl AlonzoBlock {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoBlock> for AlonzoBlock {
-    fn from(native: cml_multi_era::alonzo::AlonzoBlock) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoBlock> for cml_multi_era::alonzo::AlonzoBlock {
-    fn from(wasm: AlonzoBlock) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoBlock> for AlonzoBlock {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoBlock {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoCostmdls(cml_multi_era::alonzo::AlonzoCostmdls);
 
+impl_wasm_cbor_json_api!(AlonzoCostmdls);
+
+impl_wasm_conversions!(cml_multi_era::alonzo::AlonzoCostmdls, AlonzoCostmdls);
+
 #[wasm_bindgen]
 impl AlonzoCostmdls {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoCostmdls, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoCostmdls, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn plutus_v1(&self) -> IntList {
         self.0.plutus_v1.clone().into()
     }
@@ -271,56 +173,16 @@ impl AlonzoCostmdls {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoCostmdls> for AlonzoCostmdls {
-    fn from(native: cml_multi_era::alonzo::AlonzoCostmdls) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoCostmdls> for cml_multi_era::alonzo::AlonzoCostmdls {
-    fn from(wasm: AlonzoCostmdls) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoCostmdls> for AlonzoCostmdls {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoCostmdls {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoOnlyAuxData(cml_multi_era::alonzo::AlonzoOnlyAuxData);
 
+impl_wasm_cbor_json_api!(AlonzoOnlyAuxData);
+
+impl_wasm_conversions!(cml_multi_era::alonzo::AlonzoOnlyAuxData, AlonzoOnlyAuxData);
+
 #[wasm_bindgen]
 impl AlonzoOnlyAuxData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoOnlyAuxData, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoOnlyAuxData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_metadata(&mut self, metadata: &Metadata) {
         self.0.metadata = Some(metadata.clone().into())
     }
@@ -353,28 +215,15 @@ impl AlonzoOnlyAuxData {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoOnlyAuxData> for AlonzoOnlyAuxData {
-    fn from(native: cml_multi_era::alonzo::AlonzoOnlyAuxData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoOnlyAuxData> for cml_multi_era::alonzo::AlonzoOnlyAuxData {
-    fn from(wasm: AlonzoOnlyAuxData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoOnlyAuxData> for AlonzoOnlyAuxData {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoOnlyAuxData {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoProposedProtocolParameterUpdates(
     cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates,
+);
+
+impl_wasm_conversions!(
+    cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates,
+    AlonzoProposedProtocolParameterUpdates
 );
 
 #[wasm_bindgen]
@@ -406,62 +255,19 @@ impl AlonzoProposedProtocolParameterUpdates {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates>
-    for AlonzoProposedProtocolParameterUpdates
-{
-    fn from(native: cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoProposedProtocolParameterUpdates>
-    for cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates
-{
-    fn from(wasm: AlonzoProposedProtocolParameterUpdates) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates>
-    for AlonzoProposedProtocolParameterUpdates
-{
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoProposedProtocolParameterUpdates {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoProtocolParamUpdate(cml_multi_era::alonzo::AlonzoProtocolParamUpdate);
 
+impl_wasm_cbor_json_api!(AlonzoProtocolParamUpdate);
+
+impl_wasm_conversions!(
+    cml_multi_era::alonzo::AlonzoProtocolParamUpdate,
+    AlonzoProtocolParamUpdate
+);
+
 #[wasm_bindgen]
 impl AlonzoProtocolParamUpdate {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoProtocolParamUpdate, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoProtocolParamUpdate, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_minfee_a(&mut self, minfee_a: u64) {
         self.0.minfee_a = Some(minfee_a)
     }
@@ -681,56 +487,16 @@ impl AlonzoProtocolParamUpdate {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoProtocolParamUpdate> for AlonzoProtocolParamUpdate {
-    fn from(native: cml_multi_era::alonzo::AlonzoProtocolParamUpdate) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoProtocolParamUpdate> for cml_multi_era::alonzo::AlonzoProtocolParamUpdate {
-    fn from(wasm: AlonzoProtocolParamUpdate) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoProtocolParamUpdate> for AlonzoProtocolParamUpdate {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoProtocolParamUpdate {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoTransaction(cml_multi_era::alonzo::AlonzoTransaction);
 
+impl_wasm_cbor_json_api!(AlonzoTransaction);
+
+impl_wasm_conversions!(cml_multi_era::alonzo::AlonzoTransaction, AlonzoTransaction);
+
 #[wasm_bindgen]
 impl AlonzoTransaction {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransaction, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoTransaction, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn body(&self) -> AlonzoTransactionBody {
         self.0.body.clone().into()
     }
@@ -762,56 +528,19 @@ impl AlonzoTransaction {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoTransaction> for AlonzoTransaction {
-    fn from(native: cml_multi_era::alonzo::AlonzoTransaction) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoTransaction> for cml_multi_era::alonzo::AlonzoTransaction {
-    fn from(wasm: AlonzoTransaction) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoTransaction> for AlonzoTransaction {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransaction {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoTransactionBody(cml_multi_era::alonzo::AlonzoTransactionBody);
 
+impl_wasm_cbor_json_api!(AlonzoTransactionBody);
+
+impl_wasm_conversions!(
+    cml_multi_era::alonzo::AlonzoTransactionBody,
+    AlonzoTransactionBody
+);
+
 #[wasm_bindgen]
 impl AlonzoTransactionBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransactionBody, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoTransactionBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn inputs(&self) -> TransactionInputList {
         self.0.inputs.clone().into()
     }
@@ -937,56 +666,19 @@ impl AlonzoTransactionBody {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoTransactionBody> for AlonzoTransactionBody {
-    fn from(native: cml_multi_era::alonzo::AlonzoTransactionBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoTransactionBody> for cml_multi_era::alonzo::AlonzoTransactionBody {
-    fn from(wasm: AlonzoTransactionBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoTransactionBody> for AlonzoTransactionBody {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransactionBody {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoTransactionOutput(cml_multi_era::alonzo::AlonzoTransactionOutput);
 
+impl_wasm_cbor_json_api!(AlonzoTransactionOutput);
+
+impl_wasm_conversions!(
+    cml_multi_era::alonzo::AlonzoTransactionOutput,
+    AlonzoTransactionOutput
+);
+
 #[wasm_bindgen]
 impl AlonzoTransactionOutput {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransactionOutput, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoTransactionOutput, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_shelley_tx_out(shelley_tx_out: &ShelleyTxOut) -> Self {
         Self(
             cml_multi_era::alonzo::AlonzoTransactionOutput::new_shelley_tx_out(
@@ -1033,24 +725,6 @@ impl AlonzoTransactionOutput {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoTransactionOutput> for AlonzoTransactionOutput {
-    fn from(native: cml_multi_era::alonzo::AlonzoTransactionOutput) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoTransactionOutput> for cml_multi_era::alonzo::AlonzoTransactionOutput {
-    fn from(wasm: AlonzoTransactionOutput) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoTransactionOutput> for AlonzoTransactionOutput {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransactionOutput {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum AlonzoTransactionOutputKind {
     ShelleyTxOut,
@@ -1061,34 +735,15 @@ pub enum AlonzoTransactionOutputKind {
 #[wasm_bindgen]
 pub struct AlonzoTransactionWitnessSet(cml_multi_era::alonzo::AlonzoTransactionWitnessSet);
 
+impl_wasm_cbor_json_api!(AlonzoTransactionWitnessSet);
+
+impl_wasm_conversions!(
+    cml_multi_era::alonzo::AlonzoTransactionWitnessSet,
+    AlonzoTransactionWitnessSet
+);
+
 #[wasm_bindgen]
 impl AlonzoTransactionWitnessSet {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoTransactionWitnessSet, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoTransactionWitnessSet, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_vkeywitnesses(&mut self, vkeywitnesses: &VkeywitnessList) {
         self.0.vkeywitnesses = Some(vkeywitnesses.clone().into())
     }
@@ -1148,56 +803,16 @@ impl AlonzoTransactionWitnessSet {
     }
 }
 
-impl From<cml_multi_era::alonzo::AlonzoTransactionWitnessSet> for AlonzoTransactionWitnessSet {
-    fn from(native: cml_multi_era::alonzo::AlonzoTransactionWitnessSet) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoTransactionWitnessSet> for cml_multi_era::alonzo::AlonzoTransactionWitnessSet {
-    fn from(wasm: AlonzoTransactionWitnessSet) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoTransactionWitnessSet> for AlonzoTransactionWitnessSet {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoTransactionWitnessSet {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct AlonzoUpdate(cml_multi_era::alonzo::AlonzoUpdate);
 
+impl_wasm_cbor_json_api!(AlonzoUpdate);
+
+impl_wasm_conversions!(cml_multi_era::alonzo::AlonzoUpdate, AlonzoUpdate);
+
 #[wasm_bindgen]
 impl AlonzoUpdate {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<AlonzoUpdate, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<AlonzoUpdate, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn proposed_protocol_parameter_updates(&self) -> AlonzoProposedProtocolParameterUpdates {
         self.0.proposed_protocol_parameter_updates.clone().into()
     }
@@ -1214,23 +829,5 @@ impl AlonzoUpdate {
             proposed_protocol_parameter_updates.clone().into(),
             epoch,
         ))
-    }
-}
-
-impl From<cml_multi_era::alonzo::AlonzoUpdate> for AlonzoUpdate {
-    fn from(native: cml_multi_era::alonzo::AlonzoUpdate) -> Self {
-        Self(native)
-    }
-}
-
-impl From<AlonzoUpdate> for cml_multi_era::alonzo::AlonzoUpdate {
-    fn from(wasm: AlonzoUpdate) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::alonzo::AlonzoUpdate> for AlonzoUpdate {
-    fn as_ref(&self) -> &cml_multi_era::alonzo::AlonzoUpdate {
-        &self.0
     }
 }

--- a/multi-era/wasm/src/byron/block/mod.rs
+++ b/multi-era/wasm/src/byron/block/mod.rs
@@ -5,42 +5,25 @@ use crate::byron::delegation::{ByronDelegationSignature, LightWeightDelegationSi
 use crate::byron::mpc::{Ssc, SscProof};
 use crate::byron::transaction::{ByronAttributes, ByronTx, ByronTxProof};
 use crate::byron::update::{ByronBlockVersion, ByronSoftwareVersion, ByronUpdate};
+use crate::impl_wasm_cbor_json_api_byron;
 use crate::byron::{Blake2b256, ByronBlockId, ByronPubKey, ByronSignature, ByronSlotId, EpochId};
 use crate::byron::{ByronAttributesList, ByronDelegationList, ByronTxWitnessList, StakeholderIdList};
+use cml_core_wasm::impl_wasm_conversions;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct BlockHeaderExtraData(cml_multi_era::byron::block::BlockHeaderExtraData);
 
+impl_wasm_cbor_json_api_byron!(BlockHeaderExtraData);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::BlockHeaderExtraData,
+    BlockHeaderExtraData
+);
+
 #[wasm_bindgen]
 impl BlockHeaderExtraData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<BlockHeaderExtraData, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<BlockHeaderExtraData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn block_version(&self) -> ByronBlockVersion {
         self.0.block_version.clone().into()
     }
@@ -72,56 +55,16 @@ impl BlockHeaderExtraData {
     }
 }
 
-impl From<cml_multi_era::byron::block::BlockHeaderExtraData> for BlockHeaderExtraData {
-    fn from(native: cml_multi_era::byron::block::BlockHeaderExtraData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<BlockHeaderExtraData> for cml_multi_era::byron::block::BlockHeaderExtraData {
-    fn from(wasm: BlockHeaderExtraData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::BlockHeaderExtraData> for BlockHeaderExtraData {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::BlockHeaderExtraData {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBlock(cml_multi_era::byron::block::ByronBlock);
 
+impl_wasm_cbor_json_api_byron!(ByronBlock);
+
+impl_wasm_conversions!(cml_multi_era::byron::block::ByronBlock, ByronBlock);
+
 #[wasm_bindgen]
 impl ByronBlock {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlock, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlock, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_epoch_boundary(epoch_boundary: &ByronEbBlock) -> Self {
         Self(cml_multi_era::byron::block::ByronBlock::new_epoch_boundary(
             epoch_boundary.clone().into(),
@@ -160,56 +103,16 @@ impl ByronBlock {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlock> for ByronBlock {
-    fn from(native: cml_multi_era::byron::block::ByronBlock) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlock> for cml_multi_era::byron::block::ByronBlock {
-    fn from(wasm: ByronBlock) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlock> for ByronBlock {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlock {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBlockBody(cml_multi_era::byron::block::ByronBlockBody);
 
+impl_wasm_cbor_json_api_byron!(ByronBlockBody);
+
+impl_wasm_conversions!(cml_multi_era::byron::block::ByronBlockBody, ByronBlockBody);
+
 #[wasm_bindgen]
 impl ByronBlockBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockBody, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn tx_payload(&self) -> TxPayload {
         self.0.tx_payload.clone().into()
     }
@@ -241,56 +144,19 @@ impl ByronBlockBody {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlockBody> for ByronBlockBody {
-    fn from(native: cml_multi_era::byron::block::ByronBlockBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockBody> for cml_multi_era::byron::block::ByronBlockBody {
-    fn from(wasm: ByronBlockBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlockBody> for ByronBlockBody {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlockBody {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBlockConsensusData(cml_multi_era::byron::block::ByronBlockConsensusData);
 
+impl_wasm_cbor_json_api_byron!(ByronBlockConsensusData);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::ByronBlockConsensusData,
+    ByronBlockConsensusData
+);
+
 #[wasm_bindgen]
 impl ByronBlockConsensusData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockConsensusData, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockConsensusData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_slot_id(&self) -> ByronSlotId {
         self.0.byron_slot_id.clone().into()
     }
@@ -322,56 +188,19 @@ impl ByronBlockConsensusData {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlockConsensusData> for ByronBlockConsensusData {
-    fn from(native: cml_multi_era::byron::block::ByronBlockConsensusData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockConsensusData> for cml_multi_era::byron::block::ByronBlockConsensusData {
-    fn from(wasm: ByronBlockConsensusData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlockConsensusData> for ByronBlockConsensusData {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlockConsensusData {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBlockHeader(cml_multi_era::byron::block::ByronBlockHeader);
 
+impl_wasm_cbor_json_api_byron!(ByronBlockHeader);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::ByronBlockHeader,
+    ByronBlockHeader
+);
+
 #[wasm_bindgen]
 impl ByronBlockHeader {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockHeader, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockHeader, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn protocol_magic(&self) -> u32 {
         self.0.protocol_magic
     }
@@ -409,24 +238,6 @@ impl ByronBlockHeader {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlockHeader> for ByronBlockHeader {
-    fn from(native: cml_multi_era::byron::block::ByronBlockHeader) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockHeader> for cml_multi_era::byron::block::ByronBlockHeader {
-    fn from(wasm: ByronBlockHeader) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlockHeader> for ByronBlockHeader {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlockHeader {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum ByronBlockKind {
     EpochBoundary,
@@ -437,34 +248,15 @@ pub enum ByronBlockKind {
 #[wasm_bindgen]
 pub struct ByronBlockSignature(cml_multi_era::byron::block::ByronBlockSignature);
 
+impl_wasm_cbor_json_api_byron!(ByronBlockSignature);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::ByronBlockSignature,
+    ByronBlockSignature
+);
+
 #[wasm_bindgen]
 impl ByronBlockSignature {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockSignature, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockSignature, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_signature(signature: &ByronBlockSignatureNormal) -> Self {
         Self(
             cml_multi_era::byron::block::ByronBlockSignature::new_signature(
@@ -531,24 +323,6 @@ impl ByronBlockSignature {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlockSignature> for ByronBlockSignature {
-    fn from(native: cml_multi_era::byron::block::ByronBlockSignature) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockSignature> for cml_multi_era::byron::block::ByronBlockSignature {
-    fn from(wasm: ByronBlockSignature) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlockSignature> for ByronBlockSignature {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlockSignature {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum ByronBlockSignatureKind {
     Signature,
@@ -560,34 +334,15 @@ pub enum ByronBlockSignatureKind {
 #[wasm_bindgen]
 pub struct ByronBlockSignatureNormal(cml_multi_era::byron::block::ByronBlockSignatureNormal);
 
+impl_wasm_cbor_json_api_byron!(ByronBlockSignatureNormal);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::ByronBlockSignatureNormal,
+    ByronBlockSignatureNormal
+);
+
 #[wasm_bindgen]
 impl ByronBlockSignatureNormal {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockSignatureNormal, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockSignatureNormal, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn signature(&self) -> ByronSignature {
         self.0.signature.clone()
     }
@@ -599,58 +354,21 @@ impl ByronBlockSignatureNormal {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlockSignatureNormal> for ByronBlockSignatureNormal {
-    fn from(native: cml_multi_era::byron::block::ByronBlockSignatureNormal) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockSignatureNormal> for cml_multi_era::byron::block::ByronBlockSignatureNormal {
-    fn from(wasm: ByronBlockSignatureNormal) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlockSignatureNormal> for ByronBlockSignatureNormal {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlockSignatureNormal {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBlockSignatureProxyHeavy(
     cml_multi_era::byron::block::ByronBlockSignatureProxyHeavy,
 );
 
+impl_wasm_cbor_json_api_byron!(ByronBlockSignatureProxyHeavy);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::ByronBlockSignatureProxyHeavy,
+    ByronBlockSignatureProxyHeavy
+);
+
 #[wasm_bindgen]
 impl ByronBlockSignatureProxyHeavy {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockSignatureProxyHeavy, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockSignatureProxyHeavy, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn signature(&self) -> ByronDelegationSignature {
         self.0.signature.clone().into()
     }
@@ -664,64 +382,21 @@ impl ByronBlockSignatureProxyHeavy {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlockSignatureProxyHeavy>
-    for ByronBlockSignatureProxyHeavy
-{
-    fn from(native: cml_multi_era::byron::block::ByronBlockSignatureProxyHeavy) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockSignatureProxyHeavy>
-    for cml_multi_era::byron::block::ByronBlockSignatureProxyHeavy
-{
-    fn from(wasm: ByronBlockSignatureProxyHeavy) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlockSignatureProxyHeavy>
-    for ByronBlockSignatureProxyHeavy
-{
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlockSignatureProxyHeavy {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBlockSignatureProxyLight(
     cml_multi_era::byron::block::ByronBlockSignatureProxyLight,
 );
 
+impl_wasm_cbor_json_api_byron!(ByronBlockSignatureProxyLight);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::ByronBlockSignatureProxyLight,
+    ByronBlockSignatureProxyLight
+);
+
 #[wasm_bindgen]
 impl ByronBlockSignatureProxyLight {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockSignatureProxyLight, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockSignatureProxyLight, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn signature(&self) -> LightWeightDelegationSignature {
         self.0.signature.clone().into()
     }
@@ -735,62 +410,16 @@ impl ByronBlockSignatureProxyLight {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBlockSignatureProxyLight>
-    for ByronBlockSignatureProxyLight
-{
-    fn from(native: cml_multi_era::byron::block::ByronBlockSignatureProxyLight) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockSignatureProxyLight>
-    for cml_multi_era::byron::block::ByronBlockSignatureProxyLight
-{
-    fn from(wasm: ByronBlockSignatureProxyLight) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBlockSignatureProxyLight>
-    for ByronBlockSignatureProxyLight
-{
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBlockSignatureProxyLight {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBodyProof(cml_multi_era::byron::block::ByronBodyProof);
 
+impl_wasm_cbor_json_api_byron!(ByronBodyProof);
+
+impl_wasm_conversions!(cml_multi_era::byron::block::ByronBodyProof, ByronBodyProof);
+
 #[wasm_bindgen]
 impl ByronBodyProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBodyProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBodyProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn tx_proof(&self) -> ByronTxProof {
         self.0.tx_proof.clone().into()
     }
@@ -822,56 +451,19 @@ impl ByronBodyProof {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronBodyProof> for ByronBodyProof {
-    fn from(native: cml_multi_era::byron::block::ByronBodyProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBodyProof> for cml_multi_era::byron::block::ByronBodyProof {
-    fn from(wasm: ByronBodyProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronBodyProof> for ByronBodyProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronBodyProof {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronDifficulty(cml_multi_era::byron::block::ByronDifficulty);
 
+impl_wasm_cbor_json_api_byron!(ByronDifficulty);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::ByronDifficulty,
+    ByronDifficulty
+);
+
 #[wasm_bindgen]
 impl ByronDifficulty {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronDifficulty, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronDifficulty, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn u64(&self) -> u64 {
         self.0.u64
     }
@@ -881,56 +473,16 @@ impl ByronDifficulty {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronDifficulty> for ByronDifficulty {
-    fn from(native: cml_multi_era::byron::block::ByronDifficulty) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronDifficulty> for cml_multi_era::byron::block::ByronDifficulty {
-    fn from(wasm: ByronDifficulty) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronDifficulty> for ByronDifficulty {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronDifficulty {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronEbBlock(cml_multi_era::byron::block::ByronEbBlock);
 
+impl_wasm_cbor_json_api_byron!(ByronEbBlock);
+
+impl_wasm_conversions!(cml_multi_era::byron::block::ByronEbBlock, ByronEbBlock);
+
 #[wasm_bindgen]
 impl ByronEbBlock {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronEbBlock, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronEbBlock, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header(&self) -> EbbHead {
         self.0.header.clone().into()
     }
@@ -952,56 +504,16 @@ impl ByronEbBlock {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronEbBlock> for ByronEbBlock {
-    fn from(native: cml_multi_era::byron::block::ByronEbBlock) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronEbBlock> for cml_multi_era::byron::block::ByronEbBlock {
-    fn from(wasm: ByronEbBlock) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronEbBlock> for ByronEbBlock {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronEbBlock {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronMainBlock(cml_multi_era::byron::block::ByronMainBlock);
 
+impl_wasm_cbor_json_api_byron!(ByronMainBlock);
+
+impl_wasm_conversions!(cml_multi_era::byron::block::ByronMainBlock, ByronMainBlock);
+
 #[wasm_bindgen]
 impl ByronMainBlock {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronMainBlock, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronMainBlock, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header(&self) -> ByronBlockHeader {
         self.0.header.clone().into()
     }
@@ -1027,56 +539,19 @@ impl ByronMainBlock {
     }
 }
 
-impl From<cml_multi_era::byron::block::ByronMainBlock> for ByronMainBlock {
-    fn from(native: cml_multi_era::byron::block::ByronMainBlock) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronMainBlock> for cml_multi_era::byron::block::ByronMainBlock {
-    fn from(wasm: ByronMainBlock) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::ByronMainBlock> for ByronMainBlock {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::ByronMainBlock {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct EbbConsensusData(cml_multi_era::byron::block::EbbConsensusData);
 
+impl_wasm_cbor_json_api_byron!(EbbConsensusData);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::block::EbbConsensusData,
+    EbbConsensusData
+);
+
 #[wasm_bindgen]
 impl EbbConsensusData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<EbbConsensusData, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<EbbConsensusData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn epoch_id(&self) -> EpochId {
         self.0.epoch_id
     }
@@ -1093,56 +568,16 @@ impl EbbConsensusData {
     }
 }
 
-impl From<cml_multi_era::byron::block::EbbConsensusData> for EbbConsensusData {
-    fn from(native: cml_multi_era::byron::block::EbbConsensusData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<EbbConsensusData> for cml_multi_era::byron::block::EbbConsensusData {
-    fn from(wasm: EbbConsensusData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::EbbConsensusData> for EbbConsensusData {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::EbbConsensusData {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct EbbHead(cml_multi_era::byron::block::EbbHead);
 
+impl_wasm_cbor_json_api_byron!(EbbHead);
+
+impl_wasm_conversions!(cml_multi_era::byron::block::EbbHead, EbbHead);
+
 #[wasm_bindgen]
 impl EbbHead {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<EbbHead, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<EbbHead, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn protocol_magic(&self) -> u32 {
         self.0.protocol_magic
     }
@@ -1180,56 +615,16 @@ impl EbbHead {
     }
 }
 
-impl From<cml_multi_era::byron::block::EbbHead> for EbbHead {
-    fn from(native: cml_multi_era::byron::block::EbbHead) -> Self {
-        Self(native)
-    }
-}
-
-impl From<EbbHead> for cml_multi_era::byron::block::EbbHead {
-    fn from(wasm: EbbHead) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::EbbHead> for EbbHead {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::EbbHead {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TxAux(cml_multi_era::byron::block::TxAux);
 
+impl_wasm_cbor_json_api_byron!(TxAux);
+
+impl_wasm_conversions!(cml_multi_era::byron::block::TxAux, TxAux);
+
 #[wasm_bindgen]
 impl TxAux {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<TxAux, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<TxAux, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_tx(&self) -> ByronTx {
         self.0.byron_tx.clone().into()
     }
@@ -1246,27 +641,11 @@ impl TxAux {
     }
 }
 
-impl From<cml_multi_era::byron::block::TxAux> for TxAux {
-    fn from(native: cml_multi_era::byron::block::TxAux) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TxAux> for cml_multi_era::byron::block::TxAux {
-    fn from(wasm: TxAux) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::block::TxAux> for TxAux {
-    fn as_ref(&self) -> &cml_multi_era::byron::block::TxAux {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct TxPayload(Vec<cml_multi_era::byron::block::TxAux>);
+
+impl_wasm_conversions!(Vec<cml_multi_era::byron::block::TxAux>, TxPayload);
 
 #[wasm_bindgen]
 impl TxPayload {
@@ -1284,23 +663,5 @@ impl TxPayload {
 
     pub fn add(&mut self, elem: &TxAux) {
         self.0.push(elem.clone().into());
-    }
-}
-
-impl From<Vec<cml_multi_era::byron::block::TxAux>> for TxPayload {
-    fn from(native: Vec<cml_multi_era::byron::block::TxAux>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<TxPayload> for Vec<cml_multi_era::byron::block::TxAux> {
-    fn from(wasm: TxPayload) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_multi_era::byron::block::TxAux>> for TxPayload {
-    fn as_ref(&self) -> &Vec<cml_multi_era::byron::block::TxAux> {
-        &self.0
     }
 }

--- a/multi-era/wasm/src/byron/delegation/mod.rs
+++ b/multi-era/wasm/src/byron/delegation/mod.rs
@@ -1,41 +1,24 @@
 // This file was code-generated using an experimental CDDL to rust tool:
 // https://github.com/dcSpark/cddl-codegen
 
+use crate::impl_wasm_cbor_json_api_byron;
 use crate::byron::{ByronPubKey, ByronSignature, EpochId};
+use cml_core_wasm::impl_wasm_conversions;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronDelegation(cml_multi_era::byron::delegation::ByronDelegation);
 
+impl_wasm_cbor_json_api_byron!(ByronDelegation);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::delegation::ByronDelegation,
+    ByronDelegation
+);
+
 #[wasm_bindgen]
 impl ByronDelegation {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronDelegation, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronDelegation, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn epoch(&self) -> EpochId {
         self.0.epoch
     }
@@ -67,56 +50,19 @@ impl ByronDelegation {
     }
 }
 
-impl From<cml_multi_era::byron::delegation::ByronDelegation> for ByronDelegation {
-    fn from(native: cml_multi_era::byron::delegation::ByronDelegation) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronDelegation> for cml_multi_era::byron::delegation::ByronDelegation {
-    fn from(wasm: ByronDelegation) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::delegation::ByronDelegation> for ByronDelegation {
-    fn as_ref(&self) -> &cml_multi_era::byron::delegation::ByronDelegation {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronDelegationSignature(cml_multi_era::byron::delegation::ByronDelegationSignature);
 
+impl_wasm_cbor_json_api_byron!(ByronDelegationSignature);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::delegation::ByronDelegationSignature,
+    ByronDelegationSignature
+);
+
 #[wasm_bindgen]
 impl ByronDelegationSignature {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronDelegationSignature, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronDelegationSignature, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_delegation(&self) -> ByronDelegation {
         self.0.byron_delegation.clone().into()
     }
@@ -135,58 +81,16 @@ impl ByronDelegationSignature {
     }
 }
 
-impl From<cml_multi_era::byron::delegation::ByronDelegationSignature> for ByronDelegationSignature {
-    fn from(native: cml_multi_era::byron::delegation::ByronDelegationSignature) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronDelegationSignature> for cml_multi_era::byron::delegation::ByronDelegationSignature {
-    fn from(wasm: ByronDelegationSignature) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::delegation::ByronDelegationSignature>
-    for ByronDelegationSignature
-{
-    fn as_ref(&self) -> &cml_multi_era::byron::delegation::ByronDelegationSignature {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct EpochRange(cml_multi_era::byron::delegation::EpochRange);
 
+impl_wasm_cbor_json_api_byron!(EpochRange);
+
+impl_wasm_conversions!(cml_multi_era::byron::delegation::EpochRange, EpochRange);
+
 #[wasm_bindgen]
 impl EpochRange {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<EpochRange, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<EpochRange, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn epoch_id(&self) -> EpochId {
         self.0.epoch_id
     }
@@ -202,58 +106,21 @@ impl EpochRange {
     }
 }
 
-impl From<cml_multi_era::byron::delegation::EpochRange> for EpochRange {
-    fn from(native: cml_multi_era::byron::delegation::EpochRange) -> Self {
-        Self(native)
-    }
-}
-
-impl From<EpochRange> for cml_multi_era::byron::delegation::EpochRange {
-    fn from(wasm: EpochRange) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::delegation::EpochRange> for EpochRange {
-    fn as_ref(&self) -> &cml_multi_era::byron::delegation::EpochRange {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct LightWeightDelegationSignature(
     cml_multi_era::byron::delegation::LightWeightDelegationSignature,
 );
 
+impl_wasm_cbor_json_api_byron!(LightWeightDelegationSignature);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::delegation::LightWeightDelegationSignature,
+    LightWeightDelegationSignature
+);
+
 #[wasm_bindgen]
 impl LightWeightDelegationSignature {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<LightWeightDelegationSignature, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<LightWeightDelegationSignature, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn light_weight_dlg(&self) -> LightWeightDlg {
         self.0.light_weight_dlg.clone().into()
     }
@@ -272,62 +139,19 @@ impl LightWeightDelegationSignature {
     }
 }
 
-impl From<cml_multi_era::byron::delegation::LightWeightDelegationSignature>
-    for LightWeightDelegationSignature
-{
-    fn from(native: cml_multi_era::byron::delegation::LightWeightDelegationSignature) -> Self {
-        Self(native)
-    }
-}
-
-impl From<LightWeightDelegationSignature>
-    for cml_multi_era::byron::delegation::LightWeightDelegationSignature
-{
-    fn from(wasm: LightWeightDelegationSignature) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::delegation::LightWeightDelegationSignature>
-    for LightWeightDelegationSignature
-{
-    fn as_ref(&self) -> &cml_multi_era::byron::delegation::LightWeightDelegationSignature {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct LightWeightDlg(cml_multi_era::byron::delegation::LightWeightDlg);
 
+impl_wasm_cbor_json_api_byron!(LightWeightDlg);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::delegation::LightWeightDlg,
+    LightWeightDlg
+);
+
 #[wasm_bindgen]
 impl LightWeightDlg {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<LightWeightDlg, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<LightWeightDlg, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn epoch_range(&self) -> EpochRange {
         self.0.epoch_range.clone().into()
     }
@@ -356,23 +180,5 @@ impl LightWeightDlg {
             delegate,
             certificate,
         ))
-    }
-}
-
-impl From<cml_multi_era::byron::delegation::LightWeightDlg> for LightWeightDlg {
-    fn from(native: cml_multi_era::byron::delegation::LightWeightDlg) -> Self {
-        Self(native)
-    }
-}
-
-impl From<LightWeightDlg> for cml_multi_era::byron::delegation::LightWeightDlg {
-    fn from(wasm: LightWeightDlg) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::delegation::LightWeightDlg> for LightWeightDlg {
-    fn as_ref(&self) -> &cml_multi_era::byron::delegation::LightWeightDlg {
-        &self.0
     }
 }

--- a/multi-era/wasm/src/byron/mod.rs
+++ b/multi-era/wasm/src/byron/mod.rs
@@ -6,8 +6,11 @@ pub mod delegation;
 pub mod mpc;
 pub mod transaction;
 pub mod update;
+#[macro_use]
 pub mod utils;
 
+use crate::impl_wasm_cbor_json_api_byron;
+use cml_core_wasm::impl_wasm_conversions;
 use cml_chain_wasm::byron::ByronTxOut;
 pub use utils::{Blake2b224, Blake2b256, ByronAny};
 use cml_chain_wasm::utils::BigInt;
@@ -26,34 +29,12 @@ pub type ByronSignature = Vec<u8>;
 #[wasm_bindgen]
 pub struct ByronSlotId(cml_multi_era::byron::ByronSlotId);
 
+impl_wasm_cbor_json_api_byron!(ByronSlotId);
+
+impl_wasm_conversions!(cml_multi_era::byron::ByronSlotId, ByronSlotId);
+
 #[wasm_bindgen]
 impl ByronSlotId {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronSlotId, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronSlotId, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn epoch(&self) -> EpochId {
         self.0.epoch
     }
@@ -64,24 +45,6 @@ impl ByronSlotId {
 
     pub fn new(epoch: EpochId, slot: u64) -> Self {
         Self(cml_multi_era::byron::ByronSlotId::new(epoch, slot))
-    }
-}
-
-impl From<cml_multi_era::byron::ByronSlotId> for ByronSlotId {
-    fn from(native: cml_multi_era::byron::ByronSlotId) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronSlotId> for cml_multi_era::byron::ByronSlotId {
-    fn from(wasm: ByronSlotId) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::ByronSlotId> for ByronSlotId {
-    fn as_ref(&self) -> &cml_multi_era::byron::ByronSlotId {
-        &self.0
     }
 }
 

--- a/multi-era/wasm/src/byron/mpc/mod.rs
+++ b/multi-era/wasm/src/byron/mpc/mod.rs
@@ -5,6 +5,8 @@ use crate::byron::{
     Blake2b256, ByronPubKey, ByronSignature, EpochId, AddressIdList,
     StakeholderIdList, VssPubKeyList, BytesList, VssDecryptedShareList
 };
+use crate::impl_wasm_cbor_json_api_byron;
+use cml_core_wasm::impl_wasm_conversions;
 use cml_chain_wasm::byron::{AddressId, StakeholderId};
 use std::collections::BTreeMap;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
@@ -13,34 +15,12 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[wasm_bindgen]
 pub struct Ssc(cml_multi_era::byron::mpc::Ssc);
 
+impl_wasm_cbor_json_api_byron!(Ssc);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::Ssc, Ssc);
+
 #[wasm_bindgen]
 impl Ssc {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Ssc, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Ssc, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_ssc_commitments_payload(ssc_commitments_payload: &SscCommitmentsPayload) -> Self {
         Self(cml_multi_era::byron::mpc::Ssc::new_ssc_commitments_payload(
             ssc_commitments_payload.clone().into(),
@@ -117,56 +97,16 @@ impl Ssc {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::Ssc> for Ssc {
-    fn from(native: cml_multi_era::byron::mpc::Ssc) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Ssc> for cml_multi_era::byron::mpc::Ssc {
-    fn from(wasm: Ssc) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::Ssc> for Ssc {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::Ssc {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscCert(cml_multi_era::byron::mpc::SscCert);
 
+impl_wasm_cbor_json_api_byron!(SscCert);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::SscCert, SscCert);
+
 #[wasm_bindgen]
 impl SscCert {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscCert, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscCert, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn vss_pub_key(&self) -> VssPubKey {
         self.0.vss_pub_key.clone()
     }
@@ -198,56 +138,19 @@ impl SscCert {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscCert> for SscCert {
-    fn from(native: cml_multi_era::byron::mpc::SscCert) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscCert> for cml_multi_era::byron::mpc::SscCert {
-    fn from(wasm: SscCert) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscCert> for SscCert {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscCert {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscCertificatesPayload(cml_multi_era::byron::mpc::SscCertificatesPayload);
 
+impl_wasm_cbor_json_api_byron!(SscCertificatesPayload);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscCertificatesPayload,
+    SscCertificatesPayload
+);
+
 #[wasm_bindgen]
 impl SscCertificatesPayload {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscCertificatesPayload, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscCertificatesPayload, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn ssc_certs(&self) -> SscCerts {
         self.0.ssc_certs.clone().into()
     }
@@ -259,56 +162,19 @@ impl SscCertificatesPayload {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscCertificatesPayload> for SscCertificatesPayload {
-    fn from(native: cml_multi_era::byron::mpc::SscCertificatesPayload) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscCertificatesPayload> for cml_multi_era::byron::mpc::SscCertificatesPayload {
-    fn from(wasm: SscCertificatesPayload) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscCertificatesPayload> for SscCertificatesPayload {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscCertificatesPayload {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscCertificatesProof(cml_multi_era::byron::mpc::SscCertificatesProof);
 
+impl_wasm_cbor_json_api_byron!(SscCertificatesProof);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscCertificatesProof,
+    SscCertificatesProof
+);
+
 #[wasm_bindgen]
 impl SscCertificatesProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscCertificatesProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscCertificatesProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn blake2b256(&self) -> Blake2b256 {
         self.0.blake2b256.clone().into()
     }
@@ -320,27 +186,11 @@ impl SscCertificatesProof {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscCertificatesProof> for SscCertificatesProof {
-    fn from(native: cml_multi_era::byron::mpc::SscCertificatesProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscCertificatesProof> for cml_multi_era::byron::mpc::SscCertificatesProof {
-    fn from(wasm: SscCertificatesProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscCertificatesProof> for SscCertificatesProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscCertificatesProof {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscCerts(Vec<cml_multi_era::byron::mpc::SscCert>);
+
+impl_wasm_conversions!(Vec<cml_multi_era::byron::mpc::SscCert>, SscCerts);
 
 #[wasm_bindgen]
 impl SscCerts {
@@ -361,56 +211,16 @@ impl SscCerts {
     }
 }
 
-impl From<Vec<cml_multi_era::byron::mpc::SscCert>> for SscCerts {
-    fn from(native: Vec<cml_multi_era::byron::mpc::SscCert>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscCerts> for Vec<cml_multi_era::byron::mpc::SscCert> {
-    fn from(wasm: SscCerts) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_multi_era::byron::mpc::SscCert>> for SscCerts {
-    fn as_ref(&self) -> &Vec<cml_multi_era::byron::mpc::SscCert> {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscCommitment(cml_multi_era::byron::mpc::SscCommitment);
 
+impl_wasm_cbor_json_api_byron!(SscCommitment);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::SscCommitment, SscCommitment);
+
 #[wasm_bindgen]
 impl SscCommitment {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscCommitment, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscCommitment, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn vss_shares(&self) -> VssShares {
         self.0.vss_shares.clone().into()
     }
@@ -427,56 +237,19 @@ impl SscCommitment {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscCommitment> for SscCommitment {
-    fn from(native: cml_multi_era::byron::mpc::SscCommitment) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscCommitment> for cml_multi_era::byron::mpc::SscCommitment {
-    fn from(wasm: SscCommitment) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscCommitment> for SscCommitment {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscCommitment {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscCommitmentsPayload(cml_multi_era::byron::mpc::SscCommitmentsPayload);
 
+impl_wasm_cbor_json_api_byron!(SscCommitmentsPayload);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscCommitmentsPayload,
+    SscCommitmentsPayload
+);
+
 #[wasm_bindgen]
 impl SscCommitmentsPayload {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscCommitmentsPayload, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscCommitmentsPayload, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn ssc_signed_commitments(&self) -> SscSignedCommitments {
         self.0.ssc_signed_commitments.clone().into()
     }
@@ -493,56 +266,19 @@ impl SscCommitmentsPayload {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscCommitmentsPayload> for SscCommitmentsPayload {
-    fn from(native: cml_multi_era::byron::mpc::SscCommitmentsPayload) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscCommitmentsPayload> for cml_multi_era::byron::mpc::SscCommitmentsPayload {
-    fn from(wasm: SscCommitmentsPayload) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscCommitmentsPayload> for SscCommitmentsPayload {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscCommitmentsPayload {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscCommitmentsProof(cml_multi_era::byron::mpc::SscCommitmentsProof);
 
+impl_wasm_cbor_json_api_byron!(SscCommitmentsProof);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscCommitmentsProof,
+    SscCommitmentsProof
+);
+
 #[wasm_bindgen]
 impl SscCommitmentsProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscCommitmentsProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscCommitmentsProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn blake2b256(&self) -> Blake2b256 {
         self.0.blake2b256.clone().into()
     }
@@ -559,24 +295,6 @@ impl SscCommitmentsProof {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscCommitmentsProof> for SscCommitmentsProof {
-    fn from(native: cml_multi_era::byron::mpc::SscCommitmentsProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscCommitmentsProof> for cml_multi_era::byron::mpc::SscCommitmentsProof {
-    fn from(wasm: SscCommitmentsProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscCommitmentsProof> for SscCommitmentsProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscCommitmentsProof {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum SscKind {
     SscCommitmentsPayload,
@@ -589,34 +307,15 @@ pub enum SscKind {
 #[wasm_bindgen]
 pub struct SscOpeningsPayload(cml_multi_era::byron::mpc::SscOpeningsPayload);
 
+impl_wasm_cbor_json_api_byron!(SscOpeningsPayload);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscOpeningsPayload,
+    SscOpeningsPayload
+);
+
 #[wasm_bindgen]
 impl SscOpeningsPayload {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscOpeningsPayload, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscOpeningsPayload, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn ssc_opens(&self) -> SscOpens {
         self.0.ssc_opens.clone().into()
     }
@@ -633,56 +332,19 @@ impl SscOpeningsPayload {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscOpeningsPayload> for SscOpeningsPayload {
-    fn from(native: cml_multi_era::byron::mpc::SscOpeningsPayload) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscOpeningsPayload> for cml_multi_era::byron::mpc::SscOpeningsPayload {
-    fn from(wasm: SscOpeningsPayload) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscOpeningsPayload> for SscOpeningsPayload {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscOpeningsPayload {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscOpeningsProof(cml_multi_era::byron::mpc::SscOpeningsProof);
 
+impl_wasm_cbor_json_api_byron!(SscOpeningsProof);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscOpeningsProof,
+    SscOpeningsProof
+);
+
 #[wasm_bindgen]
 impl SscOpeningsProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscOpeningsProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscOpeningsProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn blake2b256(&self) -> Blake2b256 {
         self.0.blake2b256.clone().into()
     }
@@ -699,27 +361,11 @@ impl SscOpeningsProof {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscOpeningsProof> for SscOpeningsProof {
-    fn from(native: cml_multi_era::byron::mpc::SscOpeningsProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscOpeningsProof> for cml_multi_era::byron::mpc::SscOpeningsProof {
-    fn from(wasm: SscOpeningsProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscOpeningsProof> for SscOpeningsProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscOpeningsProof {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscOpens(cml_multi_era::byron::mpc::SscOpens);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::SscOpens, SscOpens);
 
 #[wasm_bindgen]
 impl SscOpens {
@@ -744,56 +390,16 @@ impl SscOpens {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscOpens> for SscOpens {
-    fn from(native: cml_multi_era::byron::mpc::SscOpens) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscOpens> for cml_multi_era::byron::mpc::SscOpens {
-    fn from(wasm: SscOpens) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscOpens> for SscOpens {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscOpens {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscProof(cml_multi_era::byron::mpc::SscProof);
 
+impl_wasm_cbor_json_api_byron!(SscProof);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::SscProof, SscProof);
+
 #[wasm_bindgen]
 impl SscProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_ssc_commitments_proof(ssc_commitments_proof: &SscCommitmentsProof) -> Self {
         Self(
             cml_multi_era::byron::mpc::SscProof::new_ssc_commitments_proof(
@@ -874,24 +480,6 @@ impl SscProof {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscProof> for SscProof {
-    fn from(native: cml_multi_era::byron::mpc::SscProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscProof> for cml_multi_era::byron::mpc::SscProof {
-    fn from(wasm: SscProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscProof> for SscProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscProof {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum SscProofKind {
     SscCommitmentsProof,
@@ -903,6 +491,8 @@ pub enum SscProofKind {
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscShares(cml_multi_era::byron::mpc::SscShares);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::SscShares, SscShares);
 
 #[wasm_bindgen]
 impl SscShares {
@@ -929,56 +519,19 @@ impl SscShares {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscShares> for SscShares {
-    fn from(native: cml_multi_era::byron::mpc::SscShares) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscShares> for cml_multi_era::byron::mpc::SscShares {
-    fn from(wasm: SscShares) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscShares> for SscShares {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscShares {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscSharesPayload(cml_multi_era::byron::mpc::SscSharesPayload);
 
+impl_wasm_cbor_json_api_byron!(SscSharesPayload);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscSharesPayload,
+    SscSharesPayload
+);
+
 #[wasm_bindgen]
 impl SscSharesPayload {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscSharesPayload, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscSharesPayload, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn ssc_shares(&self) -> SscShares {
         self.0.ssc_shares.clone().into()
     }
@@ -995,56 +548,16 @@ impl SscSharesPayload {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscSharesPayload> for SscSharesPayload {
-    fn from(native: cml_multi_era::byron::mpc::SscSharesPayload) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscSharesPayload> for cml_multi_era::byron::mpc::SscSharesPayload {
-    fn from(wasm: SscSharesPayload) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscSharesPayload> for SscSharesPayload {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscSharesPayload {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscSharesProof(cml_multi_era::byron::mpc::SscSharesProof);
 
+impl_wasm_cbor_json_api_byron!(SscSharesProof);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::SscSharesProof, SscSharesProof);
+
 #[wasm_bindgen]
 impl SscSharesProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscSharesProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscSharesProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn blake2b256(&self) -> Blake2b256 {
         self.0.blake2b256.clone().into()
     }
@@ -1061,27 +574,11 @@ impl SscSharesProof {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscSharesProof> for SscSharesProof {
-    fn from(native: cml_multi_era::byron::mpc::SscSharesProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscSharesProof> for cml_multi_era::byron::mpc::SscSharesProof {
-    fn from(wasm: SscSharesProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscSharesProof> for SscSharesProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscSharesProof {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscSharesSubmap(cml_multi_era::byron::mpc::SscSharesSubmap);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::SscSharesSubmap, SscSharesSubmap);
 
 #[wasm_bindgen]
 impl SscSharesSubmap {
@@ -1112,56 +609,19 @@ impl SscSharesSubmap {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscSharesSubmap> for SscSharesSubmap {
-    fn from(native: cml_multi_era::byron::mpc::SscSharesSubmap) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscSharesSubmap> for cml_multi_era::byron::mpc::SscSharesSubmap {
-    fn from(wasm: SscSharesSubmap) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscSharesSubmap> for SscSharesSubmap {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscSharesSubmap {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscSignedCommitment(cml_multi_era::byron::mpc::SscSignedCommitment);
 
+impl_wasm_cbor_json_api_byron!(SscSignedCommitment);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::SscSignedCommitment,
+    SscSignedCommitment
+);
+
 #[wasm_bindgen]
 impl SscSignedCommitment {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SscSignedCommitment, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SscSignedCommitment, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_pub_key(&self) -> ByronPubKey {
         self.0.byron_pub_key.clone()
     }
@@ -1187,27 +647,14 @@ impl SscSignedCommitment {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::SscSignedCommitment> for SscSignedCommitment {
-    fn from(native: cml_multi_era::byron::mpc::SscSignedCommitment) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscSignedCommitment> for cml_multi_era::byron::mpc::SscSignedCommitment {
-    fn from(wasm: SscSignedCommitment) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::SscSignedCommitment> for SscSignedCommitment {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::SscSignedCommitment {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SscSignedCommitments(Vec<cml_multi_era::byron::mpc::SscSignedCommitment>);
+
+impl_wasm_conversions!(
+    Vec<cml_multi_era::byron::mpc::SscSignedCommitment>,
+    SscSignedCommitments
+);
 
 #[wasm_bindgen]
 impl SscSignedCommitments {
@@ -1228,58 +675,21 @@ impl SscSignedCommitments {
     }
 }
 
-impl From<Vec<cml_multi_era::byron::mpc::SscSignedCommitment>> for SscSignedCommitments {
-    fn from(native: Vec<cml_multi_era::byron::mpc::SscSignedCommitment>) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SscSignedCommitments> for Vec<cml_multi_era::byron::mpc::SscSignedCommitment> {
-    fn from(wasm: SscSignedCommitments) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<Vec<cml_multi_era::byron::mpc::SscSignedCommitment>> for SscSignedCommitments {
-    fn as_ref(&self) -> &Vec<cml_multi_era::byron::mpc::SscSignedCommitment> {
-        &self.0
-    }
-}
-
 pub type VssDecryptedShare = Vec<u8>;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct VssEncryptedShare(cml_multi_era::byron::mpc::VssEncryptedShare);
 
+impl_wasm_cbor_json_api_byron!(VssEncryptedShare);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::mpc::VssEncryptedShare,
+    VssEncryptedShare
+);
+
 #[wasm_bindgen]
 impl VssEncryptedShare {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<VssEncryptedShare, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<VssEncryptedShare, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn index_0(&self) -> Vec<u8> {
         self.0.index_0.clone()
     }
@@ -1289,56 +699,16 @@ impl VssEncryptedShare {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::VssEncryptedShare> for VssEncryptedShare {
-    fn from(native: cml_multi_era::byron::mpc::VssEncryptedShare) -> Self {
-        Self(native)
-    }
-}
-
-impl From<VssEncryptedShare> for cml_multi_era::byron::mpc::VssEncryptedShare {
-    fn from(wasm: VssEncryptedShare) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::VssEncryptedShare> for VssEncryptedShare {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::VssEncryptedShare {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct VssProof(cml_multi_era::byron::mpc::VssProof);
 
+impl_wasm_cbor_json_api_byron!(VssProof);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::VssProof, VssProof);
+
 #[wasm_bindgen]
 impl VssProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<VssProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<VssProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn extra_gen(&self) -> Vec<u8> {
         self.0.extra_gen.clone()
     }
@@ -1370,29 +740,13 @@ impl VssProof {
     }
 }
 
-impl From<cml_multi_era::byron::mpc::VssProof> for VssProof {
-    fn from(native: cml_multi_era::byron::mpc::VssProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<VssProof> for cml_multi_era::byron::mpc::VssProof {
-    fn from(wasm: VssProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::VssProof> for VssProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::VssProof {
-        &self.0
-    }
-}
-
 pub type VssPubKey = Vec<u8>;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct VssShares(cml_multi_era::byron::mpc::VssShares);
+
+impl_wasm_conversions!(cml_multi_era::byron::mpc::VssShares, VssShares);
 
 #[wasm_bindgen]
 impl VssShares {
@@ -1418,24 +772,6 @@ impl VssShares {
 
     pub fn keys(&self) -> VssPubKeyList {
         VssPubKeyList(self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<_>>())
-    }
-}
-
-impl From<cml_multi_era::byron::mpc::VssShares> for VssShares {
-    fn from(native: cml_multi_era::byron::mpc::VssShares) -> Self {
-        Self(native)
-    }
-}
-
-impl From<VssShares> for cml_multi_era::byron::mpc::VssShares {
-    fn from(wasm: VssShares) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::mpc::VssShares> for VssShares {
-    fn as_ref(&self) -> &cml_multi_era::byron::mpc::VssShares {
-        &self.0
     }
 }
 

--- a/multi-era/wasm/src/byron/transaction/mod.rs
+++ b/multi-era/wasm/src/byron/transaction/mod.rs
@@ -1,6 +1,8 @@
 // This file was code-generated using an experimental CDDL to rust tool:
 // https://github.com/dcSpark/cddl-codegen
 
+use crate::impl_wasm_cbor_json_api_byron;
+use cml_core_wasm::impl_wasm_conversions;
 use crate::byron::{
     Blake2b256, ByronPubKey, ByronSignature, ByronTxId,
     ByronTxInList, ByronTxOutList, ByronAny, ByronAnyList,
@@ -11,6 +13,11 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronAttributes(cml_multi_era::byron::transaction::ByronAttributes);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronAttributes,
+    ByronAttributes
+);
 
 #[wasm_bindgen]
 impl ByronAttributes {
@@ -37,56 +44,19 @@ impl ByronAttributes {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronAttributes> for ByronAttributes {
-    fn from(native: cml_multi_era::byron::transaction::ByronAttributes) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronAttributes> for cml_multi_era::byron::transaction::ByronAttributes {
-    fn from(wasm: ByronAttributes) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronAttributes> for ByronAttributes {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronAttributes {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronPkWitness(cml_multi_era::byron::transaction::ByronPkWitness);
 
+impl_wasm_cbor_json_api_byron!(ByronPkWitness);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronPkWitness,
+    ByronPkWitness
+);
+
 #[wasm_bindgen]
 impl ByronPkWitness {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronPkWitness, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronPkWitness, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn index_1(&self) -> ByronPkWitnessEntry {
         self.0.index_1.clone().into()
     }
@@ -98,56 +68,19 @@ impl ByronPkWitness {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronPkWitness> for ByronPkWitness {
-    fn from(native: cml_multi_era::byron::transaction::ByronPkWitness) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronPkWitness> for cml_multi_era::byron::transaction::ByronPkWitness {
-    fn from(wasm: ByronPkWitness) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronPkWitness> for ByronPkWitness {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronPkWitness {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronPkWitnessEntry(cml_multi_era::byron::transaction::ByronPkWitnessEntry);
 
+impl_wasm_cbor_json_api_byron!(ByronPkWitnessEntry);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronPkWitnessEntry,
+    ByronPkWitnessEntry
+);
+
 #[wasm_bindgen]
 impl ByronPkWitnessEntry {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronPkWitnessEntry, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronPkWitnessEntry, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_pub_key(&self) -> ByronPubKey {
         self.0.byron_pub_key.clone()
     }
@@ -164,56 +97,19 @@ impl ByronPkWitnessEntry {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronPkWitnessEntry> for ByronPkWitnessEntry {
-    fn from(native: cml_multi_era::byron::transaction::ByronPkWitnessEntry) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronPkWitnessEntry> for cml_multi_era::byron::transaction::ByronPkWitnessEntry {
-    fn from(wasm: ByronPkWitnessEntry) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronPkWitnessEntry> for ByronPkWitnessEntry {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronPkWitnessEntry {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronRedeemWitness(cml_multi_era::byron::transaction::ByronRedeemWitness);
 
+impl_wasm_cbor_json_api_byron!(ByronRedeemWitness);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronRedeemWitness,
+    ByronRedeemWitness
+);
+
 #[wasm_bindgen]
 impl ByronRedeemWitness {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronRedeemWitness, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronRedeemWitness, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn index_1(&self) -> ByronRedeemerWitnessEntry {
         self.0.index_1.clone().into()
     }
@@ -225,56 +121,19 @@ impl ByronRedeemWitness {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronRedeemWitness> for ByronRedeemWitness {
-    fn from(native: cml_multi_era::byron::transaction::ByronRedeemWitness) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronRedeemWitness> for cml_multi_era::byron::transaction::ByronRedeemWitness {
-    fn from(wasm: ByronRedeemWitness) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronRedeemWitness> for ByronRedeemWitness {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronRedeemWitness {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronRedeemerScript(cml_multi_era::byron::transaction::ByronRedeemerScript);
 
+impl_wasm_cbor_json_api_byron!(ByronRedeemerScript);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronRedeemerScript,
+    ByronRedeemerScript
+);
+
 #[wasm_bindgen]
 impl ByronRedeemerScript {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronRedeemerScript, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronRedeemerScript, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn u16(&self) -> u16 {
         self.0.u16
     }
@@ -290,56 +149,19 @@ impl ByronRedeemerScript {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronRedeemerScript> for ByronRedeemerScript {
-    fn from(native: cml_multi_era::byron::transaction::ByronRedeemerScript) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronRedeemerScript> for cml_multi_era::byron::transaction::ByronRedeemerScript {
-    fn from(wasm: ByronRedeemerScript) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronRedeemerScript> for ByronRedeemerScript {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronRedeemerScript {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronRedeemerWitnessEntry(cml_multi_era::byron::transaction::ByronRedeemerWitnessEntry);
 
+impl_wasm_cbor_json_api_byron!(ByronRedeemerWitnessEntry);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronRedeemerWitnessEntry,
+    ByronRedeemerWitnessEntry
+);
+
 #[wasm_bindgen]
 impl ByronRedeemerWitnessEntry {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronRedeemerWitnessEntry, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronRedeemerWitnessEntry, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_pub_key(&self) -> ByronPubKey {
         self.0.byron_pub_key.clone()
     }
@@ -358,62 +180,19 @@ impl ByronRedeemerWitnessEntry {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronRedeemerWitnessEntry>
-    for ByronRedeemerWitnessEntry
-{
-    fn from(native: cml_multi_era::byron::transaction::ByronRedeemerWitnessEntry) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronRedeemerWitnessEntry>
-    for cml_multi_era::byron::transaction::ByronRedeemerWitnessEntry
-{
-    fn from(wasm: ByronRedeemerWitnessEntry) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronRedeemerWitnessEntry>
-    for ByronRedeemerWitnessEntry
-{
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronRedeemerWitnessEntry {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronScriptWitness(cml_multi_era::byron::transaction::ByronScriptWitness);
 
+impl_wasm_cbor_json_api_byron!(ByronScriptWitness);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronScriptWitness,
+    ByronScriptWitness
+);
+
 #[wasm_bindgen]
 impl ByronScriptWitness {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronScriptWitness, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronScriptWitness, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn index_1(&self) -> ByronScriptWitnessEntry {
         self.0.index_1.clone().into()
     }
@@ -425,56 +204,19 @@ impl ByronScriptWitness {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronScriptWitness> for ByronScriptWitness {
-    fn from(native: cml_multi_era::byron::transaction::ByronScriptWitness) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronScriptWitness> for cml_multi_era::byron::transaction::ByronScriptWitness {
-    fn from(wasm: ByronScriptWitness) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronScriptWitness> for ByronScriptWitness {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronScriptWitness {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronScriptWitnessEntry(cml_multi_era::byron::transaction::ByronScriptWitnessEntry);
 
+impl_wasm_cbor_json_api_byron!(ByronScriptWitnessEntry);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronScriptWitnessEntry,
+    ByronScriptWitnessEntry
+);
+
 #[wasm_bindgen]
 impl ByronScriptWitnessEntry {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronScriptWitnessEntry, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronScriptWitnessEntry, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_validator_script(&self) -> ByronValidatorScript {
         self.0.byron_validator_script.clone().into()
     }
@@ -496,56 +238,16 @@ impl ByronScriptWitnessEntry {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronScriptWitnessEntry> for ByronScriptWitnessEntry {
-    fn from(native: cml_multi_era::byron::transaction::ByronScriptWitnessEntry) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronScriptWitnessEntry> for cml_multi_era::byron::transaction::ByronScriptWitnessEntry {
-    fn from(wasm: ByronScriptWitnessEntry) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronScriptWitnessEntry> for ByronScriptWitnessEntry {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronScriptWitnessEntry {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronTx(cml_multi_era::byron::transaction::ByronTx);
 
+impl_wasm_cbor_json_api_byron!(ByronTx);
+
+impl_wasm_conversions!(cml_multi_era::byron::transaction::ByronTx, ByronTx);
+
 #[wasm_bindgen]
 impl ByronTx {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTx, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTx, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn inputs(&self) -> ByronTxInList {
         self.0.inputs.clone().into()
     }
@@ -567,56 +269,16 @@ impl ByronTx {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronTx> for ByronTx {
-    fn from(native: cml_multi_era::byron::transaction::ByronTx) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTx> for cml_multi_era::byron::transaction::ByronTx {
-    fn from(wasm: ByronTx) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronTx> for ByronTx {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronTx {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronTxIn(cml_multi_era::byron::transaction::ByronTxIn);
 
+impl_wasm_cbor_json_api_byron!(ByronTxIn);
+
+impl_wasm_conversions!(cml_multi_era::byron::transaction::ByronTxIn, ByronTxIn);
+
 #[wasm_bindgen]
 impl ByronTxIn {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTxIn, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTxIn, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_byron_tx_in_regular(byron_tx_in_regular: &ByronTxInRegular) -> Self {
         Self(
             cml_multi_era::byron::transaction::ByronTxIn::new_byron_tx_in_regular(
@@ -663,56 +325,19 @@ impl ByronTxIn {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronTxIn> for ByronTxIn {
-    fn from(native: cml_multi_era::byron::transaction::ByronTxIn) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTxIn> for cml_multi_era::byron::transaction::ByronTxIn {
-    fn from(wasm: ByronTxIn) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronTxIn> for ByronTxIn {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronTxIn {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronTxInGenesis(cml_multi_era::byron::transaction::ByronTxInGenesis);
 
+impl_wasm_cbor_json_api_byron!(ByronTxInGenesis);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronTxInGenesis,
+    ByronTxInGenesis
+);
+
 #[wasm_bindgen]
 impl ByronTxInGenesis {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTxInGenesis, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTxInGenesis, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn u8(&self) -> u8 {
         self.0.u8
     }
@@ -728,24 +353,6 @@ impl ByronTxInGenesis {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronTxInGenesis> for ByronTxInGenesis {
-    fn from(native: cml_multi_era::byron::transaction::ByronTxInGenesis) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTxInGenesis> for cml_multi_era::byron::transaction::ByronTxInGenesis {
-    fn from(wasm: ByronTxInGenesis) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronTxInGenesis> for ByronTxInGenesis {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronTxInGenesis {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum ByronTxInKind {
     ByronTxInRegular,
@@ -756,34 +363,15 @@ pub enum ByronTxInKind {
 #[wasm_bindgen]
 pub struct ByronTxInRegular(cml_multi_era::byron::transaction::ByronTxInRegular);
 
+impl_wasm_cbor_json_api_byron!(ByronTxInRegular);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronTxInRegular,
+    ByronTxInRegular
+);
+
 #[wasm_bindgen]
 impl ByronTxInRegular {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTxInRegular, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTxInRegular, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn index_1(&self) -> ByronTxOutPtr {
         self.0.index_1.clone().into()
     }
@@ -795,56 +383,19 @@ impl ByronTxInRegular {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronTxInRegular> for ByronTxInRegular {
-    fn from(native: cml_multi_era::byron::transaction::ByronTxInRegular) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTxInRegular> for cml_multi_era::byron::transaction::ByronTxInRegular {
-    fn from(wasm: ByronTxInRegular) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronTxInRegular> for ByronTxInRegular {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronTxInRegular {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronTxOutPtr(cml_multi_era::byron::transaction::ByronTxOutPtr);
 
+impl_wasm_cbor_json_api_byron!(ByronTxOutPtr);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronTxOutPtr,
+    ByronTxOutPtr
+);
+
 #[wasm_bindgen]
 impl ByronTxOutPtr {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTxOutPtr, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTxOutPtr, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn byron_tx_id(&self) -> ByronTxId {
         self.0.byron_tx_id.clone().into()
     }
@@ -861,56 +412,19 @@ impl ByronTxOutPtr {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronTxOutPtr> for ByronTxOutPtr {
-    fn from(native: cml_multi_era::byron::transaction::ByronTxOutPtr) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTxOutPtr> for cml_multi_era::byron::transaction::ByronTxOutPtr {
-    fn from(wasm: ByronTxOutPtr) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronTxOutPtr> for ByronTxOutPtr {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronTxOutPtr {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronTxProof(cml_multi_era::byron::transaction::ByronTxProof);
 
+impl_wasm_cbor_json_api_byron!(ByronTxProof);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronTxProof,
+    ByronTxProof
+);
+
 #[wasm_bindgen]
 impl ByronTxProof {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTxProof, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTxProof, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn u32(&self) -> u32 {
         self.0.u32
     }
@@ -932,56 +446,19 @@ impl ByronTxProof {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronTxProof> for ByronTxProof {
-    fn from(native: cml_multi_era::byron::transaction::ByronTxProof) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTxProof> for cml_multi_era::byron::transaction::ByronTxProof {
-    fn from(wasm: ByronTxProof) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronTxProof> for ByronTxProof {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronTxProof {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronTxWitness(cml_multi_era::byron::transaction::ByronTxWitness);
 
+impl_wasm_cbor_json_api_byron!(ByronTxWitness);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronTxWitness,
+    ByronTxWitness
+);
+
 #[wasm_bindgen]
 impl ByronTxWitness {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTxWitness, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTxWitness, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_byron_pk_witness(index_1: &ByronPkWitnessEntry) -> Self {
         Self(
             cml_multi_era::byron::transaction::ByronTxWitness::new_byron_pk_witness(
@@ -1048,24 +525,6 @@ impl ByronTxWitness {
     }
 }
 
-impl From<cml_multi_era::byron::transaction::ByronTxWitness> for ByronTxWitness {
-    fn from(native: cml_multi_era::byron::transaction::ByronTxWitness) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTxWitness> for cml_multi_era::byron::transaction::ByronTxWitness {
-    fn from(wasm: ByronTxWitness) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronTxWitness> for ByronTxWitness {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronTxWitness {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum ByronTxWitnessKind {
     ByronPkWitness,
@@ -1077,34 +536,15 @@ pub enum ByronTxWitnessKind {
 #[wasm_bindgen]
 pub struct ByronValidatorScript(cml_multi_era::byron::transaction::ByronValidatorScript);
 
+impl_wasm_cbor_json_api_byron!(ByronValidatorScript);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::transaction::ByronValidatorScript,
+    ByronValidatorScript
+);
+
 #[wasm_bindgen]
 impl ByronValidatorScript {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronValidatorScript, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronValidatorScript, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn u16(&self) -> u16 {
         self.0.u16
     }
@@ -1115,23 +555,5 @@ impl ByronValidatorScript {
 
     pub fn new(u16: u16, index_1: Vec<u8>) -> Self {
         Self(cml_multi_era::byron::transaction::ByronValidatorScript::new(u16, index_1))
-    }
-}
-
-impl From<cml_multi_era::byron::transaction::ByronValidatorScript> for ByronValidatorScript {
-    fn from(native: cml_multi_era::byron::transaction::ByronValidatorScript) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronValidatorScript> for cml_multi_era::byron::transaction::ByronValidatorScript {
-    fn from(wasm: ByronValidatorScript) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::transaction::ByronValidatorScript> for ByronValidatorScript {
-    fn as_ref(&self) -> &cml_multi_era::byron::transaction::ByronValidatorScript {
-        &self.0
     }
 }

--- a/multi-era/wasm/src/byron/update/mod.rs
+++ b/multi-era/wasm/src/byron/update/mod.rs
@@ -2,11 +2,13 @@
 // https://github.com/dcSpark/cddl-codegen
 
 use crate::byron::transaction::ByronAttributes;
+use crate::impl_wasm_cbor_json_api_byron;
 use crate::byron::{Blake2b256, ByronPubKey, ByronSignature, ByronUpdateId, EpochId};
 use crate::byron::{
     BigIntList, ByronTxFeePolicyList, ByronUpdateProposalList, ByronUpdateVoteList,
     MapSystemTagToByronUpdateData, SoftForkRuleList,
 };
+use cml_core_wasm::impl_wasm_conversions;
 use cml_chain_wasm::utils::BigInt;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -14,34 +16,12 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[wasm_bindgen]
 pub struct Bvermod(cml_multi_era::byron::update::Bvermod);
 
+impl_wasm_cbor_json_api_byron!(Bvermod);
+
+impl_wasm_conversions!(cml_multi_era::byron::update::Bvermod, Bvermod);
+
 #[wasm_bindgen]
 impl Bvermod {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<Bvermod, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<Bvermod, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn script_version(&self) -> Vec<u16> {
         self.0.script_version.clone()
     }
@@ -133,56 +113,19 @@ impl Bvermod {
     }
 }
 
-impl From<cml_multi_era::byron::update::Bvermod> for Bvermod {
-    fn from(native: cml_multi_era::byron::update::Bvermod) -> Self {
-        Self(native)
-    }
-}
-
-impl From<Bvermod> for cml_multi_era::byron::update::Bvermod {
-    fn from(wasm: Bvermod) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::Bvermod> for Bvermod {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::Bvermod {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronBlockVersion(cml_multi_era::byron::update::ByronBlockVersion);
 
+impl_wasm_cbor_json_api_byron!(ByronBlockVersion);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::update::ByronBlockVersion,
+    ByronBlockVersion
+);
+
 #[wasm_bindgen]
 impl ByronBlockVersion {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronBlockVersion, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronBlockVersion, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn u16(&self) -> u16 {
         self.0.u16
     }
@@ -202,56 +145,19 @@ impl ByronBlockVersion {
     }
 }
 
-impl From<cml_multi_era::byron::update::ByronBlockVersion> for ByronBlockVersion {
-    fn from(native: cml_multi_era::byron::update::ByronBlockVersion) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronBlockVersion> for cml_multi_era::byron::update::ByronBlockVersion {
-    fn from(wasm: ByronBlockVersion) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::ByronBlockVersion> for ByronBlockVersion {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::ByronBlockVersion {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronSoftwareVersion(cml_multi_era::byron::update::ByronSoftwareVersion);
 
+impl_wasm_cbor_json_api_byron!(ByronSoftwareVersion);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::update::ByronSoftwareVersion,
+    ByronSoftwareVersion
+);
+
 #[wasm_bindgen]
 impl ByronSoftwareVersion {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronSoftwareVersion, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronSoftwareVersion, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn application_name(&self) -> String {
         self.0.application_name.clone()
     }
@@ -268,56 +174,19 @@ impl ByronSoftwareVersion {
     }
 }
 
-impl From<cml_multi_era::byron::update::ByronSoftwareVersion> for ByronSoftwareVersion {
-    fn from(native: cml_multi_era::byron::update::ByronSoftwareVersion) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronSoftwareVersion> for cml_multi_era::byron::update::ByronSoftwareVersion {
-    fn from(wasm: ByronSoftwareVersion) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::ByronSoftwareVersion> for ByronSoftwareVersion {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::ByronSoftwareVersion {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronTxFeePolicy(cml_multi_era::byron::update::ByronTxFeePolicy);
 
+impl_wasm_cbor_json_api_byron!(ByronTxFeePolicy);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::update::ByronTxFeePolicy,
+    ByronTxFeePolicy
+);
+
 #[wasm_bindgen]
 impl ByronTxFeePolicy {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronTxFeePolicy, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronTxFeePolicy, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn index_1(&self) -> StdFeePolicy {
         self.0.index_1.clone().into()
     }
@@ -329,56 +198,16 @@ impl ByronTxFeePolicy {
     }
 }
 
-impl From<cml_multi_era::byron::update::ByronTxFeePolicy> for ByronTxFeePolicy {
-    fn from(native: cml_multi_era::byron::update::ByronTxFeePolicy) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronTxFeePolicy> for cml_multi_era::byron::update::ByronTxFeePolicy {
-    fn from(wasm: ByronTxFeePolicy) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::ByronTxFeePolicy> for ByronTxFeePolicy {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::ByronTxFeePolicy {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronUpdate(cml_multi_era::byron::update::ByronUpdate);
 
+impl_wasm_cbor_json_api_byron!(ByronUpdate);
+
+impl_wasm_conversions!(cml_multi_era::byron::update::ByronUpdate, ByronUpdate);
+
 #[wasm_bindgen]
 impl ByronUpdate {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronUpdate, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronUpdate, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn proposal(&self) -> ByronUpdateProposalList {
         self.0.proposal.clone().into()
     }
@@ -395,56 +224,19 @@ impl ByronUpdate {
     }
 }
 
-impl From<cml_multi_era::byron::update::ByronUpdate> for ByronUpdate {
-    fn from(native: cml_multi_era::byron::update::ByronUpdate) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronUpdate> for cml_multi_era::byron::update::ByronUpdate {
-    fn from(wasm: ByronUpdate) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::ByronUpdate> for ByronUpdate {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::ByronUpdate {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronUpdateData(cml_multi_era::byron::update::ByronUpdateData);
 
+impl_wasm_cbor_json_api_byron!(ByronUpdateData);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::update::ByronUpdateData,
+    ByronUpdateData
+);
+
 #[wasm_bindgen]
 impl ByronUpdateData {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronUpdateData, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronUpdateData, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn blake2b256(&self) -> Blake2b256 {
         self.0.blake2b256.clone().into()
     }
@@ -476,56 +268,19 @@ impl ByronUpdateData {
     }
 }
 
-impl From<cml_multi_era::byron::update::ByronUpdateData> for ByronUpdateData {
-    fn from(native: cml_multi_era::byron::update::ByronUpdateData) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronUpdateData> for cml_multi_era::byron::update::ByronUpdateData {
-    fn from(wasm: ByronUpdateData) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::ByronUpdateData> for ByronUpdateData {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::ByronUpdateData {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronUpdateProposal(cml_multi_era::byron::update::ByronUpdateProposal);
 
+impl_wasm_cbor_json_api_byron!(ByronUpdateProposal);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::update::ByronUpdateProposal,
+    ByronUpdateProposal
+);
+
 #[wasm_bindgen]
 impl ByronUpdateProposal {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronUpdateProposal, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronUpdateProposal, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn block_version(&self) -> ByronBlockVersion {
         self.0.block_version.clone().into()
     }
@@ -575,56 +330,19 @@ impl ByronUpdateProposal {
     }
 }
 
-impl From<cml_multi_era::byron::update::ByronUpdateProposal> for ByronUpdateProposal {
-    fn from(native: cml_multi_era::byron::update::ByronUpdateProposal) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronUpdateProposal> for cml_multi_era::byron::update::ByronUpdateProposal {
-    fn from(wasm: ByronUpdateProposal) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::ByronUpdateProposal> for ByronUpdateProposal {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::ByronUpdateProposal {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ByronUpdateVote(cml_multi_era::byron::update::ByronUpdateVote);
 
+impl_wasm_cbor_json_api_byron!(ByronUpdateVote);
+
+impl_wasm_conversions!(
+    cml_multi_era::byron::update::ByronUpdateVote,
+    ByronUpdateVote
+);
+
 #[wasm_bindgen]
 impl ByronUpdateVote {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ByronUpdateVote, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ByronUpdateVote, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn voter(&self) -> ByronPubKey {
         self.0.voter.clone()
     }
@@ -656,58 +374,18 @@ impl ByronUpdateVote {
     }
 }
 
-impl From<cml_multi_era::byron::update::ByronUpdateVote> for ByronUpdateVote {
-    fn from(native: cml_multi_era::byron::update::ByronUpdateVote) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ByronUpdateVote> for cml_multi_era::byron::update::ByronUpdateVote {
-    fn from(wasm: ByronUpdateVote) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::ByronUpdateVote> for ByronUpdateVote {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::ByronUpdateVote {
-        &self.0
-    }
-}
-
 pub type CoinPortion = u64;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct SoftForkRule(cml_multi_era::byron::update::SoftForkRule);
 
+impl_wasm_cbor_json_api_byron!(SoftForkRule);
+
+impl_wasm_conversions!(cml_multi_era::byron::update::SoftForkRule, SoftForkRule);
+
 #[wasm_bindgen]
 impl SoftForkRule {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<SoftForkRule, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<SoftForkRule, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn coin_portion(&self) -> CoinPortion {
         self.0.coin_portion
     }
@@ -733,56 +411,16 @@ impl SoftForkRule {
     }
 }
 
-impl From<cml_multi_era::byron::update::SoftForkRule> for SoftForkRule {
-    fn from(native: cml_multi_era::byron::update::SoftForkRule) -> Self {
-        Self(native)
-    }
-}
-
-impl From<SoftForkRule> for cml_multi_era::byron::update::SoftForkRule {
-    fn from(wasm: SoftForkRule) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::SoftForkRule> for SoftForkRule {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::SoftForkRule {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct StdFeePolicy(cml_multi_era::byron::update::StdFeePolicy);
 
+impl_wasm_cbor_json_api_byron!(StdFeePolicy);
+
+impl_wasm_conversions!(cml_multi_era::byron::update::StdFeePolicy, StdFeePolicy);
+
 #[wasm_bindgen]
 impl StdFeePolicy {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::ToBytes::to_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<StdFeePolicy, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<StdFeePolicy, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn big_int(&self) -> BigInt {
         self.0.big_int.clone().into()
     }
@@ -796,24 +434,6 @@ impl StdFeePolicy {
             big_int.clone().into(),
             big_int2.clone().into(),
         ))
-    }
-}
-
-impl From<cml_multi_era::byron::update::StdFeePolicy> for StdFeePolicy {
-    fn from(native: cml_multi_era::byron::update::StdFeePolicy) -> Self {
-        Self(native)
-    }
-}
-
-impl From<StdFeePolicy> for cml_multi_era::byron::update::StdFeePolicy {
-    fn from(wasm: StdFeePolicy) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::byron::update::StdFeePolicy> for StdFeePolicy {
-    fn as_ref(&self) -> &cml_multi_era::byron::update::StdFeePolicy {
-        &self.0
     }
 }
 

--- a/multi-era/wasm/src/byron/utils.rs
+++ b/multi-era/wasm/src/byron/utils.rs
@@ -20,3 +20,40 @@ pub struct ByronAny(cml_multi_era::byron::ByronAny);
 // useful on-chain for this. It's either not present or is an empty array
 
 impl_wasm_conversions!(cml_multi_era::byron::ByronAny, ByronAny);
+
+/// We use this instead of cml_core::impl_wasm_cbor_json_api due to not implementing
+/// cml's Serialize. Byron just does cbor_event's due to not supporting preserve-encodings=true
+/// All other methods are identical to cml_core's macro though.
+#[macro_export]
+macro_rules! impl_wasm_cbor_json_api_byron {
+    ($wasm_name:ident) => {
+        #[wasm_bindgen::prelude::wasm_bindgen]
+        impl $wasm_name {
+            pub fn to_cbor_bytes(&self) -> Vec<u8> {
+                cml_core::serialization::ToBytes::to_bytes(&self.0)
+            }
+
+            pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<$wasm_name, JsValue> {
+                cml_chain::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+                    .map(Self)
+                    .map_err(|e| JsValue::from_str(&format!(concat!(stringify!($wasm_name), "::from_cbor_bytes: {}"), e)))
+            }
+
+            pub fn to_json(&self) -> Result<String, JsValue> {
+                serde_json::to_string_pretty(&self.0)
+                    .map_err(|e| JsValue::from_str(&format!(concat!(stringify!($wasm_name), "::to_json: {}"), e)))
+            }
+
+            pub fn to_js_value(&self) -> Result<JsValue, JsValue> {
+                serde_wasm_bindgen::to_value(&self.0)
+                    .map_err(|e| JsValue::from_str(&format!(concat!(stringify!($wasm_name), "::to_js_value: {}"), e)))
+            }
+
+            pub fn from_json(json: &str) -> Result<$wasm_name, JsValue> {
+                serde_json::from_str(json)
+                    .map(Self)
+                    .map_err(|e| JsValue::from_str(&format!(concat!(stringify!($wasm_name), "::from_json: {}"), e)))
+            }
+        }
+    }
+}

--- a/multi-era/wasm/src/mary/mod.rs
+++ b/multi-era/wasm/src/mary/mod.rs
@@ -9,6 +9,7 @@ use cml_chain_wasm::{
     CertificateList, TransactionInputList
 };
 use cml_crypto_wasm::{AuxiliaryDataHash};
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use crate::{
     AllegraTransactionWitnessSetList, MapTransactionIndexToAllegraAuxiliaryData,
     MaryTransactionBodyList, ShelleyTxOutList,
@@ -19,34 +20,12 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[wasm_bindgen]
 pub struct MaryBlock(cml_multi_era::mary::MaryBlock);
 
+impl_wasm_cbor_json_api!(MaryBlock);
+
+impl_wasm_conversions!(cml_multi_era::mary::MaryBlock, MaryBlock);
+
 #[wasm_bindgen]
 impl MaryBlock {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MaryBlock, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MaryBlock, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header(&self) -> ShelleyHeader {
         self.0.header.clone().into()
     }
@@ -78,56 +57,16 @@ impl MaryBlock {
     }
 }
 
-impl From<cml_multi_era::mary::MaryBlock> for MaryBlock {
-    fn from(native: cml_multi_era::mary::MaryBlock) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MaryBlock> for cml_multi_era::mary::MaryBlock {
-    fn from(wasm: MaryBlock) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::mary::MaryBlock> for MaryBlock {
-    fn as_ref(&self) -> &cml_multi_era::mary::MaryBlock {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MaryTransaction(cml_multi_era::mary::MaryTransaction);
 
+impl_wasm_cbor_json_api!(MaryTransaction);
+
+impl_wasm_conversions!(cml_multi_era::mary::MaryTransaction, MaryTransaction);
+
 #[wasm_bindgen]
 impl MaryTransaction {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MaryTransaction, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MaryTransaction, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn body(&self) -> MaryTransactionBody {
         self.0.body.clone().into()
     }
@@ -153,56 +92,19 @@ impl MaryTransaction {
     }
 }
 
-impl From<cml_multi_era::mary::MaryTransaction> for MaryTransaction {
-    fn from(native: cml_multi_era::mary::MaryTransaction) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MaryTransaction> for cml_multi_era::mary::MaryTransaction {
-    fn from(wasm: MaryTransaction) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::mary::MaryTransaction> for MaryTransaction {
-    fn as_ref(&self) -> &cml_multi_era::mary::MaryTransaction {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MaryTransactionBody(cml_multi_era::mary::MaryTransactionBody);
 
+impl_wasm_cbor_json_api!(MaryTransactionBody);
+
+impl_wasm_conversions!(
+    cml_multi_era::mary::MaryTransactionBody,
+    MaryTransactionBody
+);
+
 #[wasm_bindgen]
 impl MaryTransactionBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MaryTransactionBody, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MaryTransactionBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn inputs(&self) -> TransactionInputList {
         self.0.inputs.clone().into()
     }
@@ -280,23 +182,5 @@ impl MaryTransactionBody {
             outputs.clone().into(),
             fee,
         ))
-    }
-}
-
-impl From<cml_multi_era::mary::MaryTransactionBody> for MaryTransactionBody {
-    fn from(native: cml_multi_era::mary::MaryTransactionBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MaryTransactionBody> for cml_multi_era::mary::MaryTransactionBody {
-    fn from(wasm: MaryTransactionBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::mary::MaryTransactionBody> for MaryTransactionBody {
-    fn as_ref(&self) -> &cml_multi_era::mary::MaryTransactionBody {
-        &self.0
     }
 }

--- a/multi-era/wasm/src/shelley/mod.rs
+++ b/multi-era/wasm/src/shelley/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     MapStakeCredentialToCoin, MultisigScriptList,
     ShelleyTransactionBodyList, ShelleyTransactionOutputList, ShelleyTransactionWitnessSetList,
 };
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use cml_core::ordered_hash_map::OrderedHashMap;
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -31,34 +32,15 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 #[wasm_bindgen]
 pub struct MoveInstantaneousReward(cml_multi_era::shelley::MoveInstantaneousReward);
 
+impl_wasm_cbor_json_api!(MoveInstantaneousReward);
+
+impl_wasm_conversions!(
+    cml_multi_era::shelley::MoveInstantaneousReward,
+    MoveInstantaneousReward
+);
+
 #[wasm_bindgen]
 impl MoveInstantaneousReward {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MoveInstantaneousReward, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MoveInstantaneousReward, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn pot(&self) -> MIRPot {
         self.0.pot
     }
@@ -75,56 +57,16 @@ impl MoveInstantaneousReward {
     }
 }
 
-impl From<cml_multi_era::shelley::MoveInstantaneousReward> for MoveInstantaneousReward {
-    fn from(native: cml_multi_era::shelley::MoveInstantaneousReward) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MoveInstantaneousReward> for cml_multi_era::shelley::MoveInstantaneousReward {
-    fn from(wasm: MoveInstantaneousReward) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::MoveInstantaneousReward> for MoveInstantaneousReward {
-    fn as_ref(&self) -> &cml_multi_era::shelley::MoveInstantaneousReward {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MultisigAll(cml_multi_era::shelley::MultisigAll);
 
+impl_wasm_cbor_json_api!(MultisigAll);
+
+impl_wasm_conversions!(cml_multi_era::shelley::MultisigAll, MultisigAll);
+
 #[wasm_bindgen]
 impl MultisigAll {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigAll, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MultisigAll, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn multisig_scripts(&self) -> MultisigScriptList {
         self.0.multisig_scripts.clone().into()
     }
@@ -136,56 +78,16 @@ impl MultisigAll {
     }
 }
 
-impl From<cml_multi_era::shelley::MultisigAll> for MultisigAll {
-    fn from(native: cml_multi_era::shelley::MultisigAll) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MultisigAll> for cml_multi_era::shelley::MultisigAll {
-    fn from(wasm: MultisigAll) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::MultisigAll> for MultisigAll {
-    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigAll {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MultisigAny(cml_multi_era::shelley::MultisigAny);
 
+impl_wasm_cbor_json_api!(MultisigAny);
+
+impl_wasm_conversions!(cml_multi_era::shelley::MultisigAny, MultisigAny);
+
 #[wasm_bindgen]
 impl MultisigAny {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigAny, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MultisigAny, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn multisig_scripts(&self) -> MultisigScriptList {
         self.0.multisig_scripts.clone().into()
     }
@@ -197,56 +99,16 @@ impl MultisigAny {
     }
 }
 
-impl From<cml_multi_era::shelley::MultisigAny> for MultisigAny {
-    fn from(native: cml_multi_era::shelley::MultisigAny) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MultisigAny> for cml_multi_era::shelley::MultisigAny {
-    fn from(wasm: MultisigAny) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::MultisigAny> for MultisigAny {
-    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigAny {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MultisigNOfK(cml_multi_era::shelley::MultisigNOfK);
 
+impl_wasm_cbor_json_api!(MultisigNOfK);
+
+impl_wasm_conversions!(cml_multi_era::shelley::MultisigNOfK, MultisigNOfK);
+
 #[wasm_bindgen]
 impl MultisigNOfK {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigNOfK, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MultisigNOfK, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn n(&self) -> u64 {
         self.0.n
     }
@@ -263,56 +125,16 @@ impl MultisigNOfK {
     }
 }
 
-impl From<cml_multi_era::shelley::MultisigNOfK> for MultisigNOfK {
-    fn from(native: cml_multi_era::shelley::MultisigNOfK) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MultisigNOfK> for cml_multi_era::shelley::MultisigNOfK {
-    fn from(wasm: MultisigNOfK) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::MultisigNOfK> for MultisigNOfK {
-    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigNOfK {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MultisigPubkey(cml_multi_era::shelley::MultisigPubkey);
 
+impl_wasm_cbor_json_api!(MultisigPubkey);
+
+impl_wasm_conversions!(cml_multi_era::shelley::MultisigPubkey, MultisigPubkey);
+
 #[wasm_bindgen]
 impl MultisigPubkey {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigPubkey, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MultisigPubkey, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn ed25519_key_hash(&self) -> Ed25519KeyHash {
         self.0.ed25519_key_hash.clone().into()
     }
@@ -324,56 +146,16 @@ impl MultisigPubkey {
     }
 }
 
-impl From<cml_multi_era::shelley::MultisigPubkey> for MultisigPubkey {
-    fn from(native: cml_multi_era::shelley::MultisigPubkey) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MultisigPubkey> for cml_multi_era::shelley::MultisigPubkey {
-    fn from(wasm: MultisigPubkey) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::MultisigPubkey> for MultisigPubkey {
-    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigPubkey {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct MultisigScript(cml_multi_era::shelley::MultisigScript);
 
+impl_wasm_cbor_json_api!(MultisigScript);
+
+impl_wasm_conversions!(cml_multi_era::shelley::MultisigScript, MultisigScript);
+
 #[wasm_bindgen]
 impl MultisigScript {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<MultisigScript, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<MultisigScript, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn new_multisig_pubkey(ed25519_key_hash: &Ed25519KeyHash) -> Self {
         Self(cml_multi_era::shelley::MultisigScript::new_multisig_pubkey(
             ed25519_key_hash.clone().into(),
@@ -453,24 +235,6 @@ impl MultisigScript {
     }
 }
 
-impl From<cml_multi_era::shelley::MultisigScript> for MultisigScript {
-    fn from(native: cml_multi_era::shelley::MultisigScript) -> Self {
-        Self(native)
-    }
-}
-
-impl From<MultisigScript> for cml_multi_era::shelley::MultisigScript {
-    fn from(wasm: MultisigScript) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::MultisigScript> for MultisigScript {
-    fn as_ref(&self) -> &cml_multi_era::shelley::MultisigScript {
-        &self.0
-    }
-}
-
 #[wasm_bindgen]
 pub enum MultisigScriptKind {
     MultisigPubkey,
@@ -483,34 +247,12 @@ pub enum MultisigScriptKind {
 #[wasm_bindgen]
 pub struct ShelleyBlock(cml_multi_era::shelley::ShelleyBlock);
 
+impl_wasm_cbor_json_api!(ShelleyBlock);
+
+impl_wasm_conversions!(cml_multi_era::shelley::ShelleyBlock, ShelleyBlock);
+
 #[wasm_bindgen]
 impl ShelleyBlock {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyBlock, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyBlock, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn header(&self) -> ShelleyHeader {
         self.0.header.clone().into()
     }
@@ -542,56 +284,16 @@ impl ShelleyBlock {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyBlock> for ShelleyBlock {
-    fn from(native: cml_multi_era::shelley::ShelleyBlock) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyBlock> for cml_multi_era::shelley::ShelleyBlock {
-    fn from(wasm: ShelleyBlock) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyBlock> for ShelleyBlock {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyBlock {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyHeader(cml_multi_era::shelley::ShelleyHeader);
 
+impl_wasm_cbor_json_api!(ShelleyHeader);
+
+impl_wasm_conversions!(cml_multi_era::shelley::ShelleyHeader, ShelleyHeader);
+
 #[wasm_bindgen]
 impl ShelleyHeader {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyHeader, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyHeader, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn body(&self) -> ShelleyHeaderBody {
         self.0.body.clone().into()
     }
@@ -608,56 +310,16 @@ impl ShelleyHeader {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyHeader> for ShelleyHeader {
-    fn from(native: cml_multi_era::shelley::ShelleyHeader) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyHeader> for cml_multi_era::shelley::ShelleyHeader {
-    fn from(wasm: ShelleyHeader) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyHeader> for ShelleyHeader {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyHeader {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyHeaderBody(cml_multi_era::shelley::ShelleyHeaderBody);
 
+impl_wasm_cbor_json_api!(ShelleyHeaderBody);
+
+impl_wasm_conversions!(cml_multi_era::shelley::ShelleyHeaderBody, ShelleyHeaderBody);
+
 #[wasm_bindgen]
 impl ShelleyHeaderBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyHeaderBody, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyHeaderBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn block_number(&self) -> u64 {
         self.0.block_number
     }
@@ -731,28 +393,15 @@ impl ShelleyHeaderBody {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyHeaderBody> for ShelleyHeaderBody {
-    fn from(native: cml_multi_era::shelley::ShelleyHeaderBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyHeaderBody> for cml_multi_era::shelley::ShelleyHeaderBody {
-    fn from(wasm: ShelleyHeaderBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyHeaderBody> for ShelleyHeaderBody {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyHeaderBody {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyProposedProtocolParameterUpdates(
     cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates,
+);
+
+impl_wasm_conversions!(
+    cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates,
+    ShelleyProposedProtocolParameterUpdates
 );
 
 #[wasm_bindgen]
@@ -784,62 +433,19 @@ impl ShelleyProposedProtocolParameterUpdates {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates>
-    for ShelleyProposedProtocolParameterUpdates
-{
-    fn from(native: cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyProposedProtocolParameterUpdates>
-    for cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates
-{
-    fn from(wasm: ShelleyProposedProtocolParameterUpdates) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates>
-    for ShelleyProposedProtocolParameterUpdates
-{
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyProposedProtocolParameterUpdates {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyProtocolParamUpdate(cml_multi_era::shelley::ShelleyProtocolParamUpdate);
 
+impl_wasm_cbor_json_api!(ShelleyProtocolParamUpdate);
+
+impl_wasm_conversions!(
+    cml_multi_era::shelley::ShelleyProtocolParamUpdate,
+    ShelleyProtocolParamUpdate
+);
+
 #[wasm_bindgen]
 impl ShelleyProtocolParamUpdate {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyProtocolParamUpdate, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyProtocolParamUpdate, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_minfee_a(&mut self, minfee_a: u64) {
         self.0.minfee_a = Some(minfee_a)
     }
@@ -985,56 +591,19 @@ impl ShelleyProtocolParamUpdate {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyProtocolParamUpdate> for ShelleyProtocolParamUpdate {
-    fn from(native: cml_multi_era::shelley::ShelleyProtocolParamUpdate) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyProtocolParamUpdate> for cml_multi_era::shelley::ShelleyProtocolParamUpdate {
-    fn from(wasm: ShelleyProtocolParamUpdate) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyProtocolParamUpdate> for ShelleyProtocolParamUpdate {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyProtocolParamUpdate {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyTransaction(cml_multi_era::shelley::ShelleyTransaction);
 
+impl_wasm_cbor_json_api!(ShelleyTransaction);
+
+impl_wasm_conversions!(
+    cml_multi_era::shelley::ShelleyTransaction,
+    ShelleyTransaction
+);
+
 #[wasm_bindgen]
 impl ShelleyTransaction {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransaction, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyTransaction, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn body(&self) -> ShelleyTransactionBody {
         self.0.body.clone().into()
     }
@@ -1060,56 +629,19 @@ impl ShelleyTransaction {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyTransaction> for ShelleyTransaction {
-    fn from(native: cml_multi_era::shelley::ShelleyTransaction) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyTransaction> for cml_multi_era::shelley::ShelleyTransaction {
-    fn from(wasm: ShelleyTransaction) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyTransaction> for ShelleyTransaction {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransaction {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyTransactionBody(cml_multi_era::shelley::ShelleyTransactionBody);
 
+impl_wasm_cbor_json_api!(ShelleyTransactionBody);
+
+impl_wasm_conversions!(
+    cml_multi_era::shelley::ShelleyTransactionBody,
+    ShelleyTransactionBody
+);
+
 #[wasm_bindgen]
 impl ShelleyTransactionBody {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransactionBody, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyTransactionBody, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn inputs(&self) -> TransactionInputList {
         self.0.inputs.clone().into()
     }
@@ -1176,58 +708,21 @@ impl ShelleyTransactionBody {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyTransactionBody> for ShelleyTransactionBody {
-    fn from(native: cml_multi_era::shelley::ShelleyTransactionBody) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyTransactionBody> for cml_multi_era::shelley::ShelleyTransactionBody {
-    fn from(wasm: ShelleyTransactionBody) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyTransactionBody> for ShelleyTransactionBody {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransactionBody {
-        &self.0
-    }
-}
-
 pub type ShelleyTransactionIndex = u16;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyTransactionOutput(cml_multi_era::shelley::ShelleyTransactionOutput);
 
+impl_wasm_cbor_json_api!(ShelleyTransactionOutput);
+
+impl_wasm_conversions!(
+    cml_multi_era::shelley::ShelleyTransactionOutput,
+    ShelleyTransactionOutput
+);
+
 #[wasm_bindgen]
 impl ShelleyTransactionOutput {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransactionOutput, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyTransactionOutput, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn address(&self) -> Address {
         self.0.address.clone().into()
     }
@@ -1244,56 +739,19 @@ impl ShelleyTransactionOutput {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyTransactionOutput> for ShelleyTransactionOutput {
-    fn from(native: cml_multi_era::shelley::ShelleyTransactionOutput) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyTransactionOutput> for cml_multi_era::shelley::ShelleyTransactionOutput {
-    fn from(wasm: ShelleyTransactionOutput) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyTransactionOutput> for ShelleyTransactionOutput {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransactionOutput {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyTransactionWitnessSet(cml_multi_era::shelley::ShelleyTransactionWitnessSet);
 
+impl_wasm_cbor_json_api!(ShelleyTransactionWitnessSet);
+
+impl_wasm_conversions!(
+    cml_multi_era::shelley::ShelleyTransactionWitnessSet,
+    ShelleyTransactionWitnessSet
+);
+
 #[wasm_bindgen]
 impl ShelleyTransactionWitnessSet {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyTransactionWitnessSet, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyTransactionWitnessSet, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn set_vkeywitnesses(&mut self, vkeywitnesses: &VkeywitnessList) {
         self.0.vkeywitnesses = Some(vkeywitnesses.clone().into())
     }
@@ -1326,56 +784,16 @@ impl ShelleyTransactionWitnessSet {
     }
 }
 
-impl From<cml_multi_era::shelley::ShelleyTransactionWitnessSet> for ShelleyTransactionWitnessSet {
-    fn from(native: cml_multi_era::shelley::ShelleyTransactionWitnessSet) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyTransactionWitnessSet> for cml_multi_era::shelley::ShelleyTransactionWitnessSet {
-    fn from(wasm: ShelleyTransactionWitnessSet) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyTransactionWitnessSet> for ShelleyTransactionWitnessSet {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyTransactionWitnessSet {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct ShelleyUpdate(cml_multi_era::shelley::ShelleyUpdate);
 
+impl_wasm_cbor_json_api!(ShelleyUpdate);
+
+impl_wasm_conversions!(cml_multi_era::shelley::ShelleyUpdate, ShelleyUpdate);
+
 #[wasm_bindgen]
 impl ShelleyUpdate {
-    pub fn to_cbor_bytes(&self) -> Vec<u8> {
-        cml_core::serialization::Serialize::to_cbor_bytes(&self.0)
-    }
-
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ShelleyUpdate, JsValue> {
-        cml_core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
-    }
-
-    pub fn to_json(&self) -> Result<String, JsValue> {
-        serde_json::to_string_pretty(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_json: {}", e)))
-    }
-
-    pub fn to_json_value(&self) -> Result<JsValue, JsValue> {
-        serde_wasm_bindgen::to_value(&self.0)
-            .map_err(|e| JsValue::from_str(&format!("to_js_value: {}", e)))
-    }
-
-    pub fn from_json(json: &str) -> Result<ShelleyUpdate, JsValue> {
-        serde_json::from_str(json)
-            .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_json: {}", e)))
-    }
-
     pub fn shelley_proposed_protocol_parameter_updates(
         &self,
     ) -> ShelleyProposedProtocolParameterUpdates {
@@ -1397,23 +815,5 @@ impl ShelleyUpdate {
             shelley_proposed_protocol_parameter_updates.clone().into(),
             epoch,
         ))
-    }
-}
-
-impl From<cml_multi_era::shelley::ShelleyUpdate> for ShelleyUpdate {
-    fn from(native: cml_multi_era::shelley::ShelleyUpdate) -> Self {
-        Self(native)
-    }
-}
-
-impl From<ShelleyUpdate> for cml_multi_era::shelley::ShelleyUpdate {
-    fn from(wasm: ShelleyUpdate) -> Self {
-        wasm.0
-    }
-}
-
-impl AsRef<cml_multi_era::shelley::ShelleyUpdate> for ShelleyUpdate {
-    fn as_ref(&self) -> &cml_multi_era::shelley::ShelleyUpdate {
-        &self.0
     }
 }

--- a/rust/json-gen/Cargo.lock
+++ b/rust/json-gen/Cargo.lock
@@ -10,15 +10,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bech32"
-version = "0.7.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitflags"
@@ -51,7 +51,7 @@ dependencies = [
  "cfg-if",
  "clear_on_drop",
  "cryptoxide",
- "digest 0.9.0",
+ "digest",
  "ed25519-bip32",
  "fraction",
  "hex",
@@ -59,7 +59,7 @@ dependencies = [
  "js-sys",
  "linked-hash-map",
  "noop_proc_macro",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "rand",
  "rand_os",
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "cbor_event"
-version = "2.1.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b6cda8a789815488ee290d106bc97dba47785dae73d63576fc42c126912a451"
+checksum = "089a0261d1bc59e54e8e11860031efd88593f0e61b921172c474f1f38c2f2d3c"
 
 [[package]]
 name = "cc"
@@ -137,18 +137,9 @@ dependencies = [
 
 [[package]]
 name = "cryptoxide"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129eabb7b0b78644a3a7e7cf220714aba47463bb281f69fa7a71ca5d12564cca"
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
+checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "digest"
@@ -183,9 +174,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fraction"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb65943183b6b3cbf00f64c181e8178217e30194381b150e4f87ec59864c803"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
@@ -226,9 +217,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -241,9 +232,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -283,26 +274,15 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "num"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
- "num-bigint 0.2.6",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -319,11 +299,10 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -350,21 +329,21 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint 0.2.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -476,9 +455,9 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "schemars"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -488,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -548,7 +527,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -570,9 +549,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-xid"

--- a/scripts/run-json2ts.js
+++ b/scripts/run-json2ts.js
@@ -102,7 +102,9 @@ Promise.all(schemaFiles.map(schemaFile => {
   // prepend 'JSON' to all identifiers here so they don't conflict with main .ts types
   for (let i = 0; i < dedupedDefs.length; ++i) {
     for (let id of added) {
-      dedupedDefs[i] = dedupedDefs[i].replace(new RegExp(`\\b${id}\\b`), id + 'JSON');
+      // 1) To avoid FooJSON: FooJSON instead of a more consistent Foo: FooJSON we don't replace if followed by :
+      // 2) For some reason we're getting recursive types having a 1 appended to the type so cover that too
+      dedupedDefs[i] = dedupedDefs[i].replaceAll(new RegExp(`\\b${id}1?(?!:)\\b`, 'g'), id + 'JSON');
     }
   }
   return fs.writeFileSync(path.join('json-gen', 'output', 'json-types.d.ts'), dedupedDefs.join('\n'));


### PR DESCRIPTION
* Some WASM list/map wrappers were redundant in cml-chain/multi-era resulting in duplicate JS types

* Mix of `to_js_value()` and `to_json_value()` depending when we generated the types, which breaks the JSON schema script.

* Regen WASM using dcSpark/cddl-codegen#200 to massively reduce boilerplate and unify the JSON/CBOR conversiosn so we only need to change one place (this fixes the above point)

* wasm/json-gen crates were broken (incorrect module resolution or referring to types we removed)

* JSON schema build script replaces correctly for enum cases now, and also
fixes the type names fore recursive types that had 1's appended to them.

* Added in exports for missing types in chain/cip25 json export crates