### PR TITLE
Clarify where data is used in a redeemer

### DIFF
--- a/chain/rust/src/builders/redeemer_builder.rs
+++ b/chain/rust/src/builders/redeemer_builder.rs
@@ -146,13 +146,13 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_spend(&mut self, result: &InputBuilderResult) {
-        let plutus_data = {
+        let redeemer_data = {
             result
                 .aggregate_witness
                 .as_ref()
                 .and_then(|data| data.redeemer_plutus_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.spend.insert(
                 result.input.clone(),
                 Some(UntaggedRedeemerPlaceholder::JustData(data.clone())),
@@ -163,13 +163,13 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_mint(&mut self, result: &MintBuilderResult) {
-        let plutus_data = {
+        let redeemer_data = {
             result
                 .aggregate_witness
                 .as_ref()
                 .and_then(|data| data.redeemer_plutus_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.mint.insert(
                 result.policy_id,
                 Some(UntaggedRedeemerPlaceholder::JustData(data.clone())),
@@ -180,13 +180,13 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_reward(&mut self, result: &WithdrawalBuilderResult) {
-        let plutus_data = {
+        let redeemer_data = {
             result
                 .aggregate_witness
                 .as_ref()
                 .and_then(|data| data.redeemer_plutus_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.reward.insert(
                 result.address.clone(),
                 Some(UntaggedRedeemerPlaceholder::JustData(data.clone())),
@@ -197,13 +197,13 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_cert(&mut self, result: &CertificateBuilderResult) {
-        let plutus_data = {
+        let redeemer_data = {
             result
                 .aggregate_witness
                 .as_ref()
                 .and_then(|data| data.redeemer_plutus_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.cert
                 .push(Some(UntaggedRedeemerPlaceholder::JustData(data.clone())));
         } else {

--- a/rust/src/builders/redeemer_builder.rs
+++ b/rust/src/builders/redeemer_builder.rs
@@ -93,7 +93,7 @@ pub struct RedeemerSetBuilder {
     // domain of the Value map in the mint field of the transaction.
     mint: BTreeMap<PolicyID, Option<UntaggedRedeemerPlaceholder>>,
 
-    // the index of a reward account ract in the reward withdrawals map is the index of ract as a key in the (unfiltered) map.
+    // the index of a reward account "ract" in the reward withdrawals map is the index of "ract" as a key in the (unfiltered) map.
     // The keys of the Wdrl map are arranged in the order defined on the RewardAcnt type, which is a lexicographical (abbrv. lex)
     // order on the pair of the Network and the Credential.
     reward: BTreeMap<RewardAddress, Option<UntaggedRedeemerPlaceholder>>,
@@ -139,10 +139,10 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_spend(&mut self, result: &InputBuilderResult) {
-        let plutus_data = {
-            result.aggregate_witness.as_ref().and_then(|data| data.plutus_data())
+        let redeemer_data = {
+            result.aggregate_witness.as_ref().and_then(|data| data.redeemer_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.spend.insert(result.input.clone(), Some(UntaggedRedeemerPlaceholder::JustData(data)));
         } else {
             self.spend.insert(result.input.clone(), None);
@@ -150,10 +150,10 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_mint(&mut self, result: &MintBuilderResult) {
-        let plutus_data = {
-            result.aggregate_witness.as_ref().and_then(|data| data.plutus_data())
+        let redeemer_data = {
+            result.aggregate_witness.as_ref().and_then(|data| data.redeemer_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.mint.insert(result.policy_id.clone(), Some(UntaggedRedeemerPlaceholder::JustData(data)));
         }
         else {
@@ -162,10 +162,10 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_reward(&mut self, result: &WithdrawalBuilderResult) {
-        let plutus_data = {
-            result.aggregate_witness.as_ref().and_then(|data| data.plutus_data())
+        let redeemer_data = {
+            result.aggregate_witness.as_ref().and_then(|data| data.redeemer_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.reward.insert(result.address.clone(), Some(UntaggedRedeemerPlaceholder::JustData(data)));
         } 
         else {
@@ -175,10 +175,10 @@ impl RedeemerSetBuilder {
     }
 
     pub fn add_cert(&mut self, result: &CertificateBuilderResult) {
-        let plutus_data = {
-            result.aggregate_witness.as_ref().and_then(|data| data.plutus_data())
+        let redeemer_data = {
+            result.aggregate_witness.as_ref().and_then(|data| data.redeemer_data())
         };
-        if let Some(data) = plutus_data {
+        if let Some(data) = redeemer_data {
             self.cert.push(Some(UntaggedRedeemerPlaceholder::JustData(data)));
         }
         else {

--- a/rust/src/builders/witness_builder.rs
+++ b/rust/src/builders/witness_builder.rs
@@ -48,18 +48,18 @@ impl PlutusScriptWitness {
 #[derive(Clone, Debug)]
 pub struct PartialPlutusWitness {
     pub(crate) script: PlutusScriptWitness,
-    pub(crate) data: PlutusData,
+    pub(crate) redeemer_data: PlutusData,
 }
 
 #[wasm_bindgen]
 impl PartialPlutusWitness {
     pub fn new(
         script: &PlutusScriptWitness,
-        data: &PlutusData
+        redeemer_data: &PlutusData
     ) -> Self {
         Self {
             script: script.clone(),
-            data: data.clone(),
+            redeemer_data: redeemer_data.clone(),
         }
     }
 
@@ -67,8 +67,8 @@ impl PartialPlutusWitness {
         self.script.clone()
     }
 
-    pub fn data(&self) -> PlutusData {
-        self.data.clone()
+    pub fn redeemer_data(&self) -> PlutusData {
+        self.redeemer_data.clone()
     }
 }
 
@@ -79,10 +79,10 @@ pub enum InputAggregateWitnessData {
 }
 
 impl InputAggregateWitnessData {
-    pub fn plutus_data(&self) -> Option<PlutusData> {
+    pub fn redeemer_data(&self) -> Option<PlutusData> {
         match self {
             InputAggregateWitnessData::PlutusScript(witness, _, _) => {
-                Some(witness.data())
+                Some(witness.redeemer_data())
             }
             _ => None
         }


### PR DESCRIPTION
In some places, we use the variable name `plutus_data`, but unless you have the context it's not clear that this is actually the data for the redeemer and not the datum

I changed the variable names to try and clarify this