### PR TITLE
Bounds check API update + Metadata aritrary bytes

### DIFF
--- a/chain/rust/src/assets/mod.rs
+++ b/chain/rust/src/assets/mod.rs
@@ -38,7 +38,7 @@ impl AssetName {
             return Err(DeserializeError::new(
                 "AssetName",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(32),
                 },

--- a/chain/rust/src/assets/serialization.rs
+++ b/chain/rust/src/assets/serialization.rs
@@ -35,7 +35,7 @@ impl Deserialize for AssetName {
             return Err(DeserializeError::new(
                 "AssetName",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(32),
                 },

--- a/chain/rust/src/builders/tx_builder.rs
+++ b/chain/rust/src/builders/tx_builder.rs
@@ -4218,7 +4218,7 @@ mod tests {
     fn create_metadatum() -> TransactionMetadatum {
         let mut entries = MetadatumMap::new();
         entries.set(
-            TransactionMetadatum::new_text("qwe".into()),
+            TransactionMetadatum::new_text("qwe".into()).unwrap(),
             TransactionMetadatum::new_int(123i64.into()),
         );
         TransactionMetadatum::new_map(entries)
@@ -4244,7 +4244,7 @@ mod tests {
         match dat {
             TransactionMetadatum::Map(map) => {
                 assert_eq!(map.len(), 1);
-                let key = TransactionMetadatum::new_text(String::from("qwe"));
+                let key = TransactionMetadatum::new_text(String::from("qwe")).unwrap();
                 let val = map.get(&key).unwrap();
                 match val {
                     TransactionMetadatum::Int(x) => assert_eq!(*x, 123u64.into()),
@@ -4401,7 +4401,7 @@ mod tests {
         let mut tx_builder = create_default_tx_builder();
 
         let key = 42;
-        let value = TransactionMetadatum::new_text("Hello World".to_string());
+        let value = TransactionMetadatum::new_text("Hello World".to_string()).unwrap();
         {
             let mut aux_data = AuxiliaryData::new();
             aux_data.metadata_mut().set(key, value.clone());
@@ -4445,7 +4445,7 @@ mod tests {
         tx_builder.add_auxiliary_data(create_aux_with_metadata(key1));
 
         let key2 = 84;
-        let val2 = TransactionMetadatum::new_text("Hello World".to_string());
+        let val2 = TransactionMetadatum::new_text("Hello World".to_string()).unwrap();
         {
             let mut aux_data = AuxiliaryData::new();
             aux_data.metadata_mut().set(key2, val2.clone());
@@ -5193,7 +5193,7 @@ mod tests {
             let mut map = MetadatumMap::new();
             map.set(
                 TransactionMetadatum::new_int(Int::from(0u64)),
-                TransactionMetadatum::new_bytes(hex::decode("d866820080").unwrap()),
+                TransactionMetadatum::new_bytes(hex::decode("d866820080").unwrap()).unwrap(),
             );
 
             let mut aux_data = AuxiliaryData::new();
@@ -5341,7 +5341,7 @@ mod tests {
             let mut map = MetadatumMap::new();
             map.set(
                 TransactionMetadatum::new_int(0u64.into()),
-                TransactionMetadatum::new_bytes(hex::decode("d866820080").unwrap()),
+                TransactionMetadatum::new_bytes(hex::decode("d866820080").unwrap()).unwrap(),
             );
 
             let mut aux_data = AuxiliaryData::new();
@@ -5519,7 +5519,7 @@ mod tests {
             let mut map = MetadatumMap::new();
             map.set(
                 TransactionMetadatum::new_int(0u64.into()),
-                TransactionMetadatum::new_bytes(hex::decode("d866820080").unwrap()),
+                TransactionMetadatum::new_bytes(hex::decode("d866820080").unwrap()).unwrap(),
             );
 
             let mut aux_data = AuxiliaryData::new();

--- a/chain/rust/src/builders/witness_builder.rs
+++ b/chain/rust/src/builders/witness_builder.rs
@@ -521,7 +521,8 @@ pub fn merge_fake_witness(
             fake_sig,
             fake_chaincode.to_vec(),
             address_content.addr_attributes.clone(),
-        );
+        )
+        .unwrap();
 
         // avoid accidentally overriding real witness
         if !builder.bootstraps.contains_key(&fake_witness.public_key) {

--- a/chain/rust/src/byron/utils.rs
+++ b/chain/rust/src/byron/utils.rs
@@ -276,7 +276,7 @@ pub fn make_daedalus_bootstrap_witness(
         Ed25519Signature::from_raw_bytes(key.as_ref().sign(&tx_body_hash.to_raw_bytes()).as_ref())
             .unwrap();
 
-    BootstrapWitness::new(vkey, signature, chain_code, addr.content.addr_attributes)
+    BootstrapWitness::new(vkey, signature, chain_code, addr.content.addr_attributes).unwrap()
 }
 
 pub fn make_icarus_bootstrap_witness(
@@ -290,7 +290,7 @@ pub fn make_icarus_bootstrap_witness(
     let vkey = raw_key.to_public();
     let signature = raw_key.sign(tx_body_hash.to_raw_bytes());
 
-    BootstrapWitness::new(vkey, signature, chain_code, addr.content.addr_attributes)
+    BootstrapWitness::new(vkey, signature, chain_code, addr.content.addr_attributes).unwrap()
 }
 
 #[cfg(test)]

--- a/chain/rust/src/certs/mod.rs
+++ b/chain/rust/src/certs/mod.rs
@@ -297,13 +297,13 @@ pub enum DRep {
     },
     AlwaysAbstain {
         #[serde(skip)]
-        i2_encoding: Option<cbor_event::Sz>,
+        always_abstain_encoding: Option<cbor_event::Sz>,
         #[serde(skip)]
         len_encoding: LenEncoding,
     },
     AlwaysNoConfidence {
         #[serde(skip)]
-        i3_encoding: Option<cbor_event::Sz>,
+        always_no_confidence_encoding: Option<cbor_event::Sz>,
         #[serde(skip)]
         len_encoding: LenEncoding,
     },
@@ -330,14 +330,14 @@ impl DRep {
 
     pub fn new_always_abstain() -> Self {
         Self::AlwaysAbstain {
-            i2_encoding: None,
+            always_abstain_encoding: None,
             len_encoding: LenEncoding::default(),
         }
     }
 
     pub fn new_always_no_confidence() -> Self {
         Self::AlwaysNoConfidence {
-            i3_encoding: None,
+            always_no_confidence_encoding: None,
             len_encoding: LenEncoding::default(),
         }
     }
@@ -360,7 +360,7 @@ impl DnsName {
             return Err(DeserializeError::new(
                 "DnsName",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(64),
                 },
@@ -400,7 +400,7 @@ impl Ipv4 {
             return Err(DeserializeError::new(
                 "Ipv4",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(4),
                     max: Some(4),
                 },
@@ -444,7 +444,7 @@ impl Ipv6 {
             return Err(DeserializeError::new(
                 "Ipv6",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(16),
                     max: Some(16),
                 },
@@ -909,7 +909,7 @@ impl Url {
             return Err(DeserializeError::new(
                 "Url",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(64),
                 },

--- a/chain/rust/src/certs/serialization.rs
+++ b/chain/rust/src/certs/serialization.rs
@@ -601,22 +601,26 @@ impl Serialize for DRep {
                 Ok(serializer)
             }
             DRep::AlwaysAbstain {
-                i2_encoding,
+                always_abstain_encoding,
                 len_encoding,
             } => {
                 serializer.write_array_sz(len_encoding.to_len_sz(1, force_canonical))?;
-                serializer
-                    .write_unsigned_integer_sz(2u64, fit_sz(2u64, *i2_encoding, force_canonical))?;
+                serializer.write_unsigned_integer_sz(
+                    2u64,
+                    fit_sz(2u64, *always_abstain_encoding, force_canonical),
+                )?;
                 len_encoding.end(serializer, force_canonical)?;
                 Ok(serializer)
             }
             DRep::AlwaysNoConfidence {
-                i3_encoding,
+                always_no_confidence_encoding,
                 len_encoding,
             } => {
                 serializer.write_array_sz(len_encoding.to_len_sz(1, force_canonical))?;
-                serializer
-                    .write_unsigned_integer_sz(3u64, fit_sz(3u64, *i3_encoding, force_canonical))?;
+                serializer.write_unsigned_integer_sz(
+                    3u64,
+                    fit_sz(3u64, *always_no_confidence_encoding, force_canonical),
+                )?;
                 len_encoding.end(serializer, force_canonical)?;
                 Ok(serializer)
             }
@@ -723,7 +727,7 @@ impl Deserialize for DRep {
                 }
             };
             match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                let (i2_value, i2_encoding) = raw.unsigned_integer_sz()?;
+                let (i2_value, always_abstain_encoding) = raw.unsigned_integer_sz()?;
                 if i2_value != 2 {
                     return Err(DeserializeFailure::FixedValueMismatch {
                         found: Key::Uint(i2_value),
@@ -731,12 +735,12 @@ impl Deserialize for DRep {
                     }
                     .into());
                 }
-                Ok(Some(i2_encoding))
+                Ok(Some(always_abstain_encoding))
             })(raw)
             {
-                Ok(i2_encoding) => {
+                Ok(always_abstain_encoding) => {
                     return Ok(Self::AlwaysAbstain {
-                        i2_encoding,
+                        always_abstain_encoding,
                         len_encoding,
                     })
                 }
@@ -748,7 +752,7 @@ impl Deserialize for DRep {
                 }
             };
             match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                let (i3_value, i3_encoding) = raw.unsigned_integer_sz()?;
+                let (i3_value, always_no_confidence_encoding) = raw.unsigned_integer_sz()?;
                 if i3_value != 3 {
                     return Err(DeserializeFailure::FixedValueMismatch {
                         found: Key::Uint(i3_value),
@@ -756,12 +760,12 @@ impl Deserialize for DRep {
                     }
                     .into());
                 }
-                Ok(Some(i3_encoding))
+                Ok(Some(always_no_confidence_encoding))
             })(raw)
             {
-                Ok(i3_encoding) => {
+                Ok(always_no_confidence_encoding) => {
                     return Ok(Self::AlwaysNoConfidence {
-                        i3_encoding,
+                        always_no_confidence_encoding,
                         len_encoding,
                     })
                 }
@@ -814,7 +818,7 @@ impl Deserialize for DnsName {
             return Err(DeserializeError::new(
                 "DnsName",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(64),
                 },
@@ -853,7 +857,7 @@ impl Deserialize for Ipv4 {
             return Err(DeserializeError::new(
                 "Ipv4",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(4),
                     max: Some(4),
                 },
@@ -892,7 +896,7 @@ impl Deserialize for Ipv6 {
             return Err(DeserializeError::new(
                 "Ipv6",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(16),
                     max: Some(16),
                 },
@@ -3339,7 +3343,7 @@ impl Deserialize for Url {
             return Err(DeserializeError::new(
                 "Url",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(64),
                 },

--- a/chain/rust/src/crypto/mod.rs
+++ b/chain/rust/src/crypto/mod.rs
@@ -38,14 +38,22 @@ impl BootstrapWitness {
         signature: Ed25519Signature,
         chain_code: Vec<u8>,
         attributes: AddrAttributes,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, DeserializeError> {
+        if chain_code.len() < 32 || chain_code.len() > 32 {
+            return Err(DeserializeFailure::RangeCheck {
+                found: chain_code.len() as isize,
+                min: Some(32),
+                max: Some(32),
+            }
+            .into());
+        }
+        Ok(Self {
             public_key,
             signature,
             chain_code,
             attributes,
             encodings: None,
-        }
+        })
     }
 }
 
@@ -66,7 +74,7 @@ impl KESSignature {
             return Err(DeserializeError::new(
                 "KESSignature",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(448),
                     max: Some(448),
                 },
@@ -139,12 +147,20 @@ pub struct VRFCert {
 }
 
 impl VRFCert {
-    pub fn new(output: Vec<u8>, proof: Vec<u8>) -> Self {
-        Self {
+    pub fn new(output: Vec<u8>, proof: Vec<u8>) -> Result<Self, DeserializeError> {
+        if proof.len() < 80 || proof.len() > 80 {
+            return Err(DeserializeFailure::RangeCheck {
+                found: proof.len() as isize,
+                min: Some(80),
+                max: Some(80),
+            }
+            .into());
+        }
+        Ok(Self {
             output,
             proof,
             encodings: None,
-        }
+        })
     }
 }
 

--- a/chain/rust/src/crypto/serialization.rs
+++ b/chain/rust/src/crypto/serialization.rs
@@ -158,7 +158,7 @@ impl Deserialize for KESSignature {
             return Err(DeserializeError::new(
                 "KESSignature",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(448),
                     max: Some(448),
                 },

--- a/chain/wasm/src/crypto/mod.rs
+++ b/chain/wasm/src/crypto/mod.rs
@@ -46,13 +46,15 @@ impl BootstrapWitness {
         signature: &Ed25519Signature,
         chain_code: Vec<u8>,
         attributes: &AddrAttributes,
-    ) -> Self {
-        Self(cml_chain::crypto::BootstrapWitness::new(
+    ) -> Result<BootstrapWitness, JsError> {
+        cml_chain::crypto::BootstrapWitness::new(
             public_key.clone().into(),
             signature.clone().into(),
             chain_code,
             attributes.clone().into(),
-        ))
+        )
+        .map(Into::into)
+        .map_err(Into::into)
     }
 }
 
@@ -128,8 +130,10 @@ impl VRFCert {
         self.0.proof.clone()
     }
 
-    pub fn new(output: Vec<u8>, proof: Vec<u8>) -> Self {
-        Self(cml_chain::crypto::VRFCert::new(output, proof))
+    pub fn new(output: Vec<u8>, proof: Vec<u8>) -> Result<VRFCert, JsError> {
+        cml_chain::crypto::VRFCert::new(output, proof)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 }
 

--- a/cip25/rust/src/lib.rs
+++ b/cip25/rust/src/lib.rs
@@ -118,7 +118,7 @@ impl CIP25String64 {
             return Err(DeserializeError::new(
                 "CIP25String64",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(64),
                 },

--- a/cip25/rust/src/serialization.rs
+++ b/cip25/rust/src/serialization.rs
@@ -433,7 +433,7 @@ impl Deserialize for CIP25String64 {
             return Err(DeserializeError::new(
                 "CIP25String64",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(64),
                 },

--- a/cip25/rust/src/utils.rs
+++ b/cip25/rust/src/utils.rs
@@ -65,7 +65,7 @@ impl CIP25String64 {
             return Err(DeserializeError::new(
                 "CIP25String64",
                 DeserializeFailure::RangeCheck {
-                    found: inner.len(),
+                    found: inner.len() as isize,
                     min: Some(0),
                     max: Some(64),
                 },
@@ -138,13 +138,17 @@ impl CIP25MiniMetadataDetails {
         match metadatum {
             TransactionMetadatum::Map(map) => {
                 let name: Option<CIP25String64> = map
-                    .get(&TransactionMetadatum::new_text("name".to_owned()))
+                    .get(&TransactionMetadatum::new_text("name".to_owned()).unwrap())
                     // for some reason, 1% of NFTs seem to use the wrong case
-                    .or_else(|| map.get(&TransactionMetadatum::new_text("Name".to_owned())))
+                    .or_else(|| {
+                        map.get(&TransactionMetadatum::new_text("Name".to_owned()).unwrap())
+                    })
                     // for some reason, 0.5% of NFTs use "title" instead of name
-                    .or_else(|| map.get(&TransactionMetadatum::new_text("title".to_owned())))
+                    .or_else(|| {
+                        map.get(&TransactionMetadatum::new_text("title".to_owned()).unwrap())
+                    })
                     // for some reason, 0.3% of NFTs use "id" instead of name
-                    .or_else(|| map.get(&TransactionMetadatum::new_text("id".to_owned())))
+                    .or_else(|| map.get(&TransactionMetadatum::new_text("id".to_owned()).unwrap()))
                     .and_then(|result| match result {
                         TransactionMetadatum::Text { text, .. } => {
                             CIP25String64::new_str(text).ok()
@@ -152,7 +156,8 @@ impl CIP25MiniMetadataDetails {
                         _ => None,
                     });
 
-                let image_base = map.get(&TransactionMetadatum::new_text("image".to_owned()));
+                let image_base =
+                    map.get(&TransactionMetadatum::new_text("image".to_owned()).unwrap());
                 let image = match image_base {
                     None => None,
                     Some(base) => match base {

--- a/core/rust/src/error.rs
+++ b/core/rust/src/error.rs
@@ -37,7 +37,7 @@ pub enum DeserializeFailure {
         found: usize,
     },
     RangeCheck {
-        found: usize,
+        found: isize,
         min: Option<isize>,
         max: Option<isize>,
     },


### PR DESCRIPTION
Update types' APIs that have bounds restrictions e.g. metadata text/bytes, crypto primitives, etc with new codegen update. Now these types (that aren't newtypes - this was always supported) will have checks on the constructors/setters, not just in deserialization.

Moved over the arbitrary byte chunking utils for metadatums from old CML to new.