### PR TITLE
Add in missing [package] fields to crates' Cargo.tomls.

### DIFF
--- a/chain/rust/Cargo.toml
+++ b/chain/rust/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cml-chain"
 version = "0.1.0"
 edition = "2018"
+authors = ["dcSpark"]
+license = "MIT"
+description = "Multiplatform SDK for main Cardano blockchain functionality"
+documentation = "https://github.com/dcSpark/cardano-multiplatform-lib/docs"
+repository = "https://github.com/dcSpark/cardano-multiplatform-lib"
+readme = "../../README.md"
 keywords = ["cardano"]
 
 [lib]

--- a/cip25/rust/Cargo.toml
+++ b/cip25/rust/Cargo.toml
@@ -2,7 +2,13 @@
 name = "cml-cip25"
 version = "1.1.0"
 edition = "2018"
-keywords = ["cardano"]
+authors = ["dcSpark"]
+license = "MIT"
+description = "Multiplatform SDK for CIP25 Cardano NFT Metadata functionality"
+documentation = "https://github.com/dcSpark/cardano-multiplatform-lib/docs"
+repository = "https://github.com/dcSpark/cardano-multiplatform-lib"
+readme = "../../README.md"
+keywords = ["cardano", "cip25"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/cip36/rust/Cargo.toml
+++ b/cip36/rust/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cml-cip36"
 version = "0.1.0"
 edition = "2018"
+authors = ["dcSpark"]
+license = "MIT"
+description = "Multiplatform SDK for CIP36 Catalyst voting functionality"
+documentation = "https://github.com/dcSpark/cardano-multiplatform-lib/docs"
+repository = "https://github.com/dcSpark/cardano-multiplatform-lib"
+readme = "../../README.md"
 keywords = ["cardano", "cip36"]
 
 [lib]

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cml-core"
 version = "0.1.0"
 edition = "2018"
+authors = ["dcSpark"]
+license = "MIT"
+description = "Multiplatform SDK for core Cardano blockchain functionality"
+documentation = "https://github.com/dcSpark/cardano-multiplatform-lib/docs"
+repository = "https://github.com/dcSpark/cardano-multiplatform-lib"
+readme = "../../README.md"
 keywords = ["cardano"]
 
 [lib]

--- a/crypto/rust/Cargo.toml
+++ b/crypto/rust/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cml-crypto"
 version = "0.1.0"
 edition = "2018"
+authors = ["dcSpark"]
+license = "MIT"
+description = "Multiplatform SDK for Cardano-related cryptographic functionality"
+documentation = "https://github.com/dcSpark/cardano-multiplatform-lib/docs"
+repository = "https://github.com/dcSpark/cardano-multiplatform-lib"
+readme = "../../README.md"
 keywords = ["cardano"]
 
 [lib]

--- a/multi-era/rust/Cargo.toml
+++ b/multi-era/rust/Cargo.toml
@@ -2,6 +2,13 @@
 name = "cml-multi-era"
 version = "0.1.0"
 edition = "2018"
+authors = ["dcSpark"]
+license = "MIT"
+description = "Multiplatform SDK for era-agnostic Cardano blockchain parsing"
+documentation = "https://github.com/dcSpark/cardano-multiplatform-lib/docs"
+repository = "https://github.com/dcSpark/cardano-multiplatform-lib"
+readme = "../../README.md"
+keywords = ["cardano"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This results in a warning upon `cargo package` / `cargo publish` and these were present in the old rust/Cargo.toml.

Points to the root readme/docs. We might want crate-specific ones later on but right now the crate-specific readmes for some of the crates are rather barebones on their own compared to the more helpful root readme.