### PR TITLE
Default byron address network_id to testnet if magic not matched

### DIFF
--- a/chain/rust/src/address.rs
+++ b/chain/rust/src/address.rs
@@ -495,7 +495,7 @@ impl Address {
             Self::Enterprise(a) => Ok(a.network),
             Self::Ptr(a) => Ok(a.network),
             Self::Reward(a) => Ok(a.network),
-            Self::Byron(a) => a.content.network_id().map_err(Into::into),
+            Self::Byron(a) => Ok(a.content.network_id()),
         }
     }
 
@@ -1199,7 +1199,7 @@ mod tests {
         assert!(ByronAddress::is_valid(
             "Ae2tdPwUPEZHtBmjZBF4YpMkK9tMSPTE2ADEZTPN97saNkhG78TvXdp3GDk"
         ));
-        assert_eq!(byron_addr.network_id().unwrap(), 0b0001);
+        assert_eq!(byron_addr.network_id(), 0b0001);
 
         // round-trip from generic address type and back
         let generic_addr = Address::from_raw_bytes(&byron_addr.to_address().to_bytes()).unwrap();

--- a/chain/rust/src/byron/utils.rs
+++ b/chain/rust/src/byron/utils.rs
@@ -142,7 +142,7 @@ impl AddressContent {
         }
     }
 
-    pub fn network_id(&self) -> Result<u8, ByronAddressError> {
+    pub fn network_id(&self) -> u8 {
         // premise: during the Byron-era, we had one mainnet (764824073) and many many testnets
         // with each testnet getting a different protocol magic
         // in Shelley, this changes so that:
@@ -156,12 +156,9 @@ impl AddressContent {
         let protocol_magic = self.byron_protocol_magic();
         match protocol_magic {
             magic if magic == NetworkInfo::mainnet().protocol_magic() => {
-                Ok(NetworkInfo::mainnet().network_id())
+                NetworkInfo::mainnet().network_id()
             }
-            magic if magic == NetworkInfo::testnet().protocol_magic() => {
-                Ok(NetworkInfo::testnet().network_id())
-            }
-            _ => Err(ByronAddressError::UnknownNetwork(protocol_magic)),
+            _ => NetworkInfo::testnet().network_id(),
         }
     }
 
@@ -460,7 +457,7 @@ mod tests {
             NetworkInfo::mainnet().protocol_magic()
         );
         assert_eq!(
-            addr.content.network_id().unwrap(),
+            addr.content.network_id(),
             NetworkInfo::mainnet().network_id()
         );
 
@@ -474,7 +471,7 @@ mod tests {
             NetworkInfo::testnet().protocol_magic()
         );
         assert_eq!(
-            addr.content.network_id().unwrap(),
+            addr.content.network_id(),
             NetworkInfo::testnet().network_id()
         );
     }

--- a/chain/wasm/src/byron/utils.rs
+++ b/chain/wasm/src/byron/utils.rs
@@ -108,8 +108,8 @@ impl AddressContent {
         self.0.byron_protocol_magic().into()
     }
 
-    pub fn network_id(&self) -> Result<u8, JsError> {
-        self.0.network_id().map_err(Into::into)
+    pub fn network_id(&self) -> u8 {
+        self.0.network_id()
     }
 
     // icarus-style address (Ae2)


### PR DESCRIPTION
Fixes `Byron(UnknownNetwork(ProtocolMagic(1)))` when trying to serialize Byron address from preprod testnet.