### PR TITLE
Update JSON Schemas

### DIFF
--- a/chain/rust/src/byron/mod.rs
+++ b/chain/rust/src/byron/mod.rs
@@ -115,18 +115,7 @@ impl AddressContent {
     }
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    serde::Deserialize,
-    serde::Serialize,
-    schemars::JsonSchema,
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ByronAddress {
     pub content: AddressContent,
     pub crc: Crc32,

--- a/chain/rust/src/byron/utils.rs
+++ b/chain/rust/src/byron/utils.rs
@@ -290,6 +290,42 @@ pub fn make_icarus_bootstrap_witness(
     BootstrapWitness::new(vkey, signature, chain_code, addr.content.addr_attributes).unwrap()
 }
 
+impl serde::Serialize for ByronAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_base58())
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for ByronAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let base58 = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        Self::from_base58(&base58).map_err(|_e| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&base58),
+                &"base58 byron address string",
+            )
+        })
+    }
+}
+
+impl schemars::JsonSchema for ByronAddress {
+    fn schema_name() -> String {
+        String::from("ByronAddress")
+    }
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ByronAddress;

--- a/chain/rust/src/certs/mod.rs
+++ b/chain/rust/src/certs/mod.rs
@@ -332,10 +332,9 @@ impl DRep {
     }
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(Clone, Debug)]
 pub struct DnsName {
     pub inner: String,
-    #[serde(skip)]
     pub encodings: Option<DnsNameEncoding>,
 }
 
@@ -370,12 +369,46 @@ impl TryFrom<String> for DnsName {
     }
 }
 
+impl serde::Serialize for DnsName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DnsName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let inner = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        Self::new(inner.clone()).map_err(|_e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Str(&inner), &"invalid DnsName")
+        })
+    }
+}
+
+impl schemars::JsonSchema for DnsName {
+    fn schema_name() -> String {
+        String::from("DnsName")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
+    }
+}
+
 pub type DrepCredential = Credential;
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(Clone, Debug)]
 pub struct Ipv4 {
     pub inner: Vec<u8>,
-    #[serde(skip)]
     pub encodings: Option<Ipv4Encoding>,
 }
 
@@ -416,10 +449,9 @@ impl From<Ipv4> for Vec<u8> {
     }
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(Clone, Debug)]
 pub struct Ipv6 {
     pub inner: Vec<u8>,
-    #[serde(skip)]
     pub encodings: Option<Ipv6Encoding>,
 }
 
@@ -873,10 +905,9 @@ impl UpdateDrepCert {
     }
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[derive(Clone, Debug)]
 pub struct Url {
     pub inner: String,
-    #[serde(skip)]
     pub encodings: Option<UrlEncoding>,
 }
 
@@ -908,6 +939,41 @@ impl TryFrom<String> for Url {
 
     fn try_from(inner: String) -> Result<Self, Self::Error> {
         Url::new(inner)
+    }
+}
+
+impl serde::Serialize for Url {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Url {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let inner = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        Self::new(inner.clone()).map_err(|_e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Str(&inner), &"invalid Url")
+        })
+    }
+}
+
+impl schemars::JsonSchema for Url {
+    fn schema_name() -> String {
+        String::from("Url")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
     }
 }
 

--- a/chain/rust/src/certs/utils.rs
+++ b/chain/rust/src/certs/utils.rs
@@ -1,4 +1,7 @@
-use super::StakeCredential;
+use std::str::FromStr;
+
+use super::{Ipv4, Ipv6, StakeCredential};
+use cml_core::DeserializeError;
 use cml_crypto::RawBytesEncoding;
 
 impl StakeCredential {
@@ -8,5 +11,135 @@ impl StakeCredential {
             Self::PubKey { hash, .. } => hash.to_raw_bytes(),
             Self::Script { hash, .. } => hash.to_raw_bytes(),
         }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IPStringParsingError {
+    #[error("Invalid IP Address String, expected period-separated bytes e.g. 0.0.0.0")]
+    StringFormat,
+    #[error("Deserializing from bytes: {0:?}")]
+    DeserializeError(DeserializeError),
+}
+
+impl std::fmt::Display for Ipv4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.inner
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join(".")
+        )
+    }
+}
+
+impl FromStr for Ipv4 {
+    type Err = IPStringParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.split('.')
+            .map(FromStr::from_str)
+            .collect::<Result<Vec<u8>, _>>()
+            .map_err(|_e| IPStringParsingError::StringFormat)
+            .and_then(|bytes| Self::new(bytes).map_err(IPStringParsingError::DeserializeError))
+    }
+}
+
+impl serde::Serialize for Ipv4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Ipv4 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(|_e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Str(&s), &"invalid ipv4 address")
+        })
+    }
+}
+
+impl schemars::JsonSchema for Ipv4 {
+    fn schema_name() -> String {
+        String::from("Ipv4")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
+    }
+}
+
+impl std::fmt::Display for Ipv6 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.inner
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<String>>()
+                .join(".")
+        )
+    }
+}
+
+impl FromStr for Ipv6 {
+    type Err = IPStringParsingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.split('.')
+            .map(FromStr::from_str)
+            .collect::<Result<Vec<u8>, _>>()
+            .map_err(|_e| IPStringParsingError::StringFormat)
+            .and_then(|bytes| Self::new(bytes).map_err(IPStringParsingError::DeserializeError))
+    }
+}
+
+impl serde::Serialize for Ipv6 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Ipv6 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        Self::from_str(&s).map_err(|_e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Str(&s), &"invalid ipv6 address")
+        })
+    }
+}
+
+impl schemars::JsonSchema for Ipv6 {
+    fn schema_name() -> String {
+        String::from("Ipv6")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
     }
 }

--- a/chain/rust/src/plutus/mod.rs
+++ b/chain/rust/src/plutus/mod.rs
@@ -175,13 +175,10 @@ impl PlutusData {
     }
 }
 
-#[derive(
-    Clone, Debug, derivative::Derivative, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
-)]
+#[derive(Clone, Debug, derivative::Derivative)]
 #[derivative(Hash, PartialEq, Eq)]
 pub struct PlutusV1Script {
     pub inner: Vec<u8>,
-    #[serde(skip)]
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub encodings: Option<PlutusV1ScriptEncoding>,
 }
@@ -211,13 +208,45 @@ impl From<PlutusV1Script> for Vec<u8> {
     }
 }
 
-#[derive(
-    Clone, Debug, derivative::Derivative, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
-)]
+impl serde::Serialize for PlutusV1Script {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&hex::encode(self.inner.clone()))
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PlutusV1Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        hex::decode(&s).map(PlutusV1Script::new).map_err(|_e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Str(&s), &"invalid hex bytes")
+        })
+    }
+}
+
+impl schemars::JsonSchema for PlutusV1Script {
+    fn schema_name() -> String {
+        String::from("PlutusV1Script")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
+    }
+}
+
+#[derive(Clone, Debug, derivative::Derivative)]
 #[derivative(Hash, PartialEq, Eq)]
 pub struct PlutusV2Script {
     pub inner: Vec<u8>,
-    #[serde(skip)]
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub encodings: Option<PlutusV2ScriptEncoding>,
 }
@@ -246,13 +275,46 @@ impl From<PlutusV2Script> for Vec<u8> {
         wrapper.inner
     }
 }
-#[derive(
-    Clone, Debug, derivative::Derivative, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
-)]
+
+impl serde::Serialize for PlutusV2Script {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&hex::encode(self.inner.clone()))
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PlutusV2Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        hex::decode(&s).map(PlutusV2Script::new).map_err(|_e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Str(&s), &"invalid hex bytes")
+        })
+    }
+}
+
+impl schemars::JsonSchema for PlutusV2Script {
+    fn schema_name() -> String {
+        String::from("PlutusV2Script")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
+    }
+}
+
+#[derive(Clone, Debug, derivative::Derivative)]
 #[derivative(Hash, PartialEq, Eq)]
 pub struct PlutusV3Script {
     pub inner: Vec<u8>,
-    #[serde(skip)]
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub encodings: Option<PlutusV3ScriptEncoding>,
 }
@@ -279,6 +341,41 @@ impl From<Vec<u8>> for PlutusV3Script {
 impl From<PlutusV3Script> for Vec<u8> {
     fn from(wrapper: PlutusV3Script) -> Self {
         wrapper.inner
+    }
+}
+
+impl serde::Serialize for PlutusV3Script {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&hex::encode(self.inner.clone()))
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PlutusV3Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        hex::decode(&s).map(PlutusV3Script::new).map_err(|_e| {
+            serde::de::Error::invalid_value(serde::de::Unexpected::Str(&s), &"invalid hex bytes")
+        })
+    }
+}
+
+impl schemars::JsonSchema for PlutusV3Script {
+    fn schema_name() -> String {
+        String::from("PlutusV3Script")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        String::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        String::is_referenceable()
     }
 }
 

--- a/chain/wasm/src/certs/utils.rs
+++ b/chain/wasm/src/certs/utils.rs
@@ -1,10 +1,34 @@
 use wasm_bindgen::prelude::wasm_bindgen;
-use super::StakeCredential;
+use super::{Ipv4, Ipv6, StakeCredential};
 
 #[wasm_bindgen]
 impl StakeCredential {
     // we don't implement RawBytesEncoding as from_raw_bytes() would be unable to distinguish
     pub fn to_raw_bytes(&self) -> Vec<u8> {
         self.0.to_raw_bytes().into()
+    }
+}
+
+#[wasm_bindgen]
+impl Ipv4 {
+    pub fn to_str(&self) -> String {
+        self.0.to_string()
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Ipv4, JsError> {
+        cml_chain::certs::Ipv4::from_str(s).map(Into::into).map_err(Into::into)
+    }
+}
+
+#[wasm_bindgen]
+impl Ipv6 {
+    pub fn to_str(&self) -> String {
+        self.0.to_string()
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Ipv6, JsError> {
+        cml_chain::certs::Ipv6::from_str(s).map(Into::into).map_err(Into::into)
     }
 }

--- a/specs/conway/certs.cddl
+++ b/specs/conway/certs.cddl
@@ -87,8 +87,8 @@ pool_params = ( operator:       ed25519_key_hash
               , pool_metadata:  pool_metadata / null
               )
 
-ipv4 = bytes .size 4
-ipv6 = bytes .size 16
+ipv4 = bytes .size 4 ; @custom_json
+ipv6 = bytes .size 16 ; @custom_json
 dns_name = tstr .size (0..64)
 
 single_host_addr = ( tag: 0


### PR DESCRIPTION
Int / Ipv4 / Ipv6 / ByronAddress manually implemented Misc byte wrappers now use hex bytestring included in cddl-codegen update.
All wrappers via said cddl-codegne update now exclude the `{ inner: T }` in favor of just `T` directly. e.g. DnsName / Url even when not bytes

Fixes #286