### PR TITLE
Plutus Datum JSON to use Cardano Node format

### DIFF
--- a/chain/rust/src/auxdata/metadata.rs
+++ b/chain/rust/src/auxdata/metadata.rs
@@ -1,8 +1,9 @@
-use crate::error::{DeserializeError, DeserializeFailure};
-
-use crate::serialization::{fit_sz, Deserialize, LenEncoding, Serialize, StringEncoding};
-use crate::Int;
 use cbor_event::{de::Deserializer, se::Serializer};
+use cml_core::{
+    error::{DeserializeError, DeserializeFailure},
+    serialization::{fit_sz, Deserialize, LenEncoding, Serialize, StringEncoding},
+    Int,
+};
 use derivative::Derivative;
 
 use std::io::{BufRead, Seek, Write};

--- a/chain/rust/src/auxdata/metadata.rs
+++ b/chain/rust/src/auxdata/metadata.rs
@@ -1,3 +1,6 @@
+use crate::json::metadatums::{
+    decode_metadatum_to_json_value, encode_json_value_to_metadatum, MetadataJsonSchema,
+};
 use cbor_event::{de::Deserializer, se::Serializer};
 use cml_core::{
     error::{DeserializeError, DeserializeFailure},
@@ -150,13 +153,10 @@ impl Deserialize for Metadata {
 
 /// Handles the extremely rare (2 total instances on mainnet) edge-case of in
 /// previous generations allowing duplicate metadatum keys.
-#[derive(
-    Clone, Debug, Default, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative,
-)]
+#[derive(Clone, Debug, Default, Derivative)]
 #[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct MetadatumMap {
     pub entries: Vec<(TransactionMetadatum, TransactionMetadatum)>,
-    #[serde(skip)]
     #[derivative(
         PartialEq = "ignore",
         Ord = "ignore",
@@ -274,7 +274,7 @@ impl Deserialize for MetadatumMap {
     }
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, Derivative)]
+#[derive(Clone, Debug, Derivative)]
 #[derivative(
     Eq,
     PartialEq,
@@ -292,7 +292,6 @@ pub enum TransactionMetadatum {
             PartialOrd = "ignore",
             Hash = "ignore"
         )]
-        #[serde(skip)]
         elements_encoding: LenEncoding,
     },
     Int(Int),
@@ -304,7 +303,6 @@ pub enum TransactionMetadatum {
             PartialOrd = "ignore",
             Hash = "ignore"
         )]
-        #[serde(skip)]
         bytes_encoding: StringEncoding,
     },
     Text {
@@ -315,7 +313,6 @@ pub enum TransactionMetadatum {
             PartialOrd = "ignore",
             Hash = "ignore"
         )]
-        #[serde(skip)]
         text_encoding: StringEncoding,
     },
 }
@@ -399,6 +396,51 @@ impl TransactionMetadatum {
             Self::Text { text, .. } => Some(text),
             _ => None,
         }
+    }
+}
+
+impl serde::Serialize for TransactionMetadatum {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let json_value = decode_metadatum_to_json_value(self, MetadataJsonSchema::DetailedSchema)
+            .expect("DetailedSchema can represent everything");
+        serde_json::Value::from(json_value).serialize(serializer)
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for TransactionMetadatum {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let serde_json_value =
+            <serde_json::Value as serde::de::Deserialize>::deserialize(deserializer)?;
+        let json_value = crate::json::json_serialize::Value::from(serde_json_value);
+        encode_json_value_to_metadatum(json_value.clone(), MetadataJsonSchema::DetailedSchema)
+            .map_err(|_e| {
+                serde::de::Error::invalid_value(
+                    (&json_value).into(),
+                    &"invalid tx metadatum (cardano-node JSON format)",
+                )
+            })
+    }
+}
+
+impl schemars::JsonSchema for TransactionMetadatum {
+    fn schema_name() -> String {
+        String::from("TransactionMetadatum")
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::from(schemars::schema::SchemaObject::new_ref(
+            "TransactionMetadatum".to_owned(),
+        ))
+    }
+
+    fn is_referenceable() -> bool {
+        true
     }
 }
 
@@ -556,5 +598,13 @@ mod tests {
         let metadata = encode_arbitrary_bytes_as_metadatum(input_bytes.as_ref());
         let output_bytes = decode_arbitrary_bytes_from_metadatum(&metadata).expect("decode failed");
         assert_eq!(input_bytes, output_bytes);
+    }
+
+    #[test]
+    fn metadatum_default_json() {
+        let json_str = "{\"map\":[{\"k\":{\"list\":[{\"map\":[{\"k\":{\"int\":5},\"v\":{\"int\":-7}},{\"k\":{\"string\":\"hello\"},\"v\":{\"string\":\"world\"}}]},{\"bytes\":\"ff00ff00\"}]},\"v\":{\"int\":5}}]}";
+        let metadatum: TransactionMetadatum = serde_json::from_str(json_str).unwrap();
+        let roundtrip_str = serde_json::to_string(&metadatum).unwrap();
+        assert_eq!(json_str, roundtrip_str);
     }
 }

--- a/chain/rust/src/auxdata/mod.rs
+++ b/chain/rust/src/auxdata/mod.rs
@@ -2,6 +2,7 @@
 // https://github.com/dcSpark/cddl-codegen
 
 pub mod cbor_encodings;
+pub mod metadata;
 pub mod serialization;
 pub mod utils;
 
@@ -9,7 +10,7 @@ use crate::plutus::{PlutusV1Script, PlutusV2Script, PlutusV3Script};
 use crate::transaction::NativeScript;
 use cbor_encodings::{ConwayFormatAuxDataEncoding, ShelleyMaFormatAuxDataEncoding};
 
-pub use cml_core::metadata::*;
+pub use metadata::*;
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub enum AuxiliaryData {

--- a/chain/rust/src/auxdata/utils.rs
+++ b/chain/rust/src/auxdata/utils.rs
@@ -1,4 +1,4 @@
-use cml_core::metadata::Metadata;
+use crate::auxdata::metadata::Metadata;
 
 use crate::{
     plutus::{PlutusV1Script, PlutusV2Script},

--- a/chain/rust/src/builders/tx_builder.rs
+++ b/chain/rust/src/builders/tx_builder.rs
@@ -1876,9 +1876,6 @@ mod tests {
     use std::collections::BTreeMap;
     use std::ops::Deref;
 
-    use cml_core::metadata::{
-        Metadata, MetadatumMap, TransactionMetadatum, TransactionMetadatumLabel,
-    };
     use cml_core::Int;
     use cml_crypto::{
         Bip32PrivateKey, Bip32PublicKey, DatumHash, Deserialize, PrivateKey, RawBytesEncoding,
@@ -1886,6 +1883,7 @@ mod tests {
     };
 
     use crate::address::{Address, BaseAddress, EnterpriseAddress, Pointer, PointerAddress};
+    use crate::auxdata::{Metadata, MetadatumMap, TransactionMetadatum, TransactionMetadatumLabel};
     use crate::builders::witness_builder::{PartialPlutusWitness, PlutusScriptWitness};
     use crate::builders::{
         input_builder::SingleInputBuilder, mint_builder::SingleMintBuilder,

--- a/chain/rust/src/json/metadatums.rs
+++ b/chain/rust/src/json/metadatums.rs
@@ -1,14 +1,12 @@
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{
+    auxdata::{MetadatumMap, TransactionMetadatum},
     json::json_serialize::{JsonParseError, Value as JSONValue},
     utils::BigInteger,
 };
 
-use cml_core::{
-    metadata::{MetadatumMap, TransactionMetadatum},
-    DeserializeError, Int,
-};
+use cml_core::{DeserializeError, Int};
 
 use std::collections::BTreeMap;
 use std::convert::TryFrom;

--- a/chain/rust/src/json/mod.rs
+++ b/chain/rust/src/json/mod.rs
@@ -1,3 +1,3 @@
-mod json_serialize;
+pub(crate) mod json_serialize;
 pub mod metadatums;
 pub mod plutus_datums;

--- a/chain/rust/src/json/plutus_datums.rs
+++ b/chain/rust/src/json/plutus_datums.rs
@@ -333,3 +333,16 @@ pub fn decode_plutus_datum_to_json_value(
         _ => Ok(json_value),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::plutus::PlutusData;
+
+    #[test]
+    fn plutus_datum_json() {
+        let json = "{\"map\":[{\"k\":{\"int\":100},\"v\":{\"list\":[{\"map\":[{\"k\":{\"bytes\":\"78\"},\"v\":{\"bytes\":\"30\"}},{\"k\":{\"bytes\":\"79\"},\"v\":{\"int\":1}}]}]}},{\"k\":{\"bytes\":\"666f6f\"},\"v\":{\"bytes\":\"0000baadf00d0000cafed00d0000deadbeef0000\"}}]}";
+        // let datum = encode_json_str_to_plutus_datum(json, crate::json::plutus_datums::CardanoNodePlutusDatumSchema::DetailedSchema).unwrap();
+        let datum: PlutusData = serde_json::from_str(json).unwrap();
+        assert_eq!(json, serde_json::to_string(&datum).unwrap());
+    }
+}

--- a/chain/rust/src/lib.rs
+++ b/chain/rust/src/lib.rs
@@ -36,7 +36,6 @@ pub use utils::NetworkId;
 
 pub use cml_core::{
     error::{DeserializeError, DeserializeFailure},
-    metadata::{TransactionMetadatum, TransactionMetadatumLabel},
     ordered_hash_map::OrderedHashMap,
     serialization::{Deserialize, LenEncoding, Serialize, StringEncoding},
     CertificateIndex, Epoch, Int, Slot, TransactionIndex,

--- a/chain/rust/src/plutus/mod.rs
+++ b/chain/rust/src/plutus/mod.rs
@@ -105,9 +105,7 @@ pub enum Language {
     PlutusV3,
 }
 
-#[derive(
-    Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, derivative::Derivative,
-)]
+#[derive(Clone, Debug, derivative::Derivative)]
 #[derivative(
     Eq,
     PartialEq,
@@ -126,7 +124,6 @@ pub enum PlutusData {
             PartialOrd = "ignore",
             Hash = "ignore"
         )]
-        #[serde(skip)]
         list_encoding: LenEncoding,
     },
     Integer(BigInteger),
@@ -138,7 +135,6 @@ pub enum PlutusData {
             PartialOrd = "ignore",
             Hash = "ignore"
         )]
-        #[serde(skip)]
         bytes_encoding: StringEncoding,
     },
 }

--- a/chain/rust/src/plutus/utils.rs
+++ b/chain/rust/src/plutus/utils.rs
@@ -33,12 +33,16 @@ impl<'de> serde::de::Deserialize<'de> for PlutusData {
         let serde_json_value =
             <serde_json::Value as serde::de::Deserialize>::deserialize(deserializer)?;
         let json_value = crate::json::json_serialize::Value::from(serde_json_value);
-        println!("json_value: {json_value:?}");
         encode_json_value_to_plutus_datum(
             json_value.clone(),
             CardanoNodePlutusDatumSchema::DetailedSchema,
         )
-        .map_err(|_e| serde::de::Error::invalid_value((&json_value).into(), &"invalid hex bytes"))
+        .map_err(|_e| {
+            serde::de::Error::invalid_value(
+                (&json_value).into(),
+                &"invalid plutus datum (cardano-node JSON format)",
+            )
+        })
     }
 }
 

--- a/chain/rust/src/plutus/utils.rs
+++ b/chain/rust/src/plutus/utils.rs
@@ -1,6 +1,10 @@
 use super::{CostModels, Language, Redeemer};
 use super::{ExUnits, PlutusData, PlutusV1Script, PlutusV2Script, PlutusV3Script};
 use crate::crypto::hash::{hash_script, ScriptHashNamespace};
+use crate::json::plutus_datums::{
+    decode_plutus_datum_to_json_value, encode_json_value_to_plutus_datum,
+    CardanoNodePlutusDatumSchema,
+};
 use cbor_event::de::Deserializer;
 use cbor_event::se::Serializer;
 use cml_core::serialization::*;
@@ -8,6 +12,51 @@ use cml_core::{error::*, Int};
 use cml_crypto::ScriptHash;
 use std::collections::BTreeMap;
 use std::io::{BufRead, Seek, Write};
+
+impl serde::Serialize for PlutusData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let json_value =
+            decode_plutus_datum_to_json_value(self, CardanoNodePlutusDatumSchema::DetailedSchema)
+                .expect("DetailedSchema can represent everything");
+        serde_json::Value::from(json_value).serialize(serializer)
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for PlutusData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let serde_json_value =
+            <serde_json::Value as serde::de::Deserialize>::deserialize(deserializer)?;
+        let json_value = crate::json::json_serialize::Value::from(serde_json_value);
+        println!("json_value: {json_value:?}");
+        encode_json_value_to_plutus_datum(
+            json_value.clone(),
+            CardanoNodePlutusDatumSchema::DetailedSchema,
+        )
+        .map_err(|_e| serde::de::Error::invalid_value((&json_value).into(), &"invalid hex bytes"))
+    }
+}
+
+impl schemars::JsonSchema for PlutusData {
+    fn schema_name() -> String {
+        String::from("PlutusData")
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::from(schemars::schema::SchemaObject::new_ref(
+            "PlutusData".to_owned(),
+        ))
+    }
+
+    fn is_referenceable() -> bool {
+        true
+    }
+}
 
 #[derive(
     Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema, derivative::Derivative,
@@ -434,15 +483,7 @@ pub fn compute_total_ex_units(redeemers: &[Redeemer]) -> Result<ExUnits, Arithme
     Ok(sum)
 }
 
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    serde::Deserialize,
-    serde::Serialize,
-    schemars::JsonSchema,
-    derivative::Derivative,
-)]
+#[derive(Clone, Debug, Default, derivative::Derivative)]
 #[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PlutusMap {
     // possibly duplicates (very rare - only found on testnet)
@@ -453,7 +494,6 @@ pub struct PlutusMap {
         PartialOrd = "ignore",
         Hash = "ignore"
     )]
-    #[serde(skip)]
     pub encoding: LenEncoding,
 }
 

--- a/chain/wasm/json-gen/custom_schemas/PlutusData
+++ b/chain/wasm/json-gen/custom_schemas/PlutusData
@@ -1,0 +1,200 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PlutusData",
+  "oneOf": [
+    { 
+      "type": "object",
+      "required": [
+        "map"
+      ],
+      "properties": {
+        "map": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["k", "v"],
+            "properties": {
+              "k": {
+                "$ref": "#/definitions/PlutusData"
+              },
+              "v": {
+                "$ref": "#/definitions/PlutusData"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "list"
+      ],
+      "properties": {
+        "list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PlutusData"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "int"
+      ],
+      "properties": {
+        "int": {
+          "$ref": "#/definitions/BigInteger"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "bytes"
+      ],
+      "properties": {
+        "bytes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "constructor",
+        "fields"
+      ],
+      "properties": {
+        "constructor": {
+          "type": "number"
+        },
+        "fields": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["k", "v"],
+            "properties": {
+              "k": {
+                "$ref": "#/definitions/PlutusData"
+              },
+              "v": {
+                "$ref": "#/definitions/PlutusData"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "PlutusData": {
+      "oneOf": [
+        { 
+          "type": "object",
+          "required": [
+            "map"
+          ],
+          "properties": {
+            "map": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["k", "v"],
+                "properties": {
+                  "k": {
+                    "$ref": "#/definitions/PlutusData"
+                  },
+                  "v": {
+                    "$ref": "#/definitions/PlutusData"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "list"
+          ],
+          "properties": {
+            "list": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/PlutusData"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "int"
+          ],
+          "properties": {
+            "int": {
+              "$ref": "#/definitions/BigInteger"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "bytes"
+          ],
+          "properties": {
+            "bytes": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "constructor",
+            "fields"
+          ],
+          "properties": {
+            "constructor": {
+              "type": "number"
+            },
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["k", "v"],
+                "properties": {
+                  "k": {
+                    "$ref": "#/definitions/PlutusData"
+                  },
+                  "v": {
+                    "$ref": "#/definitions/PlutusData"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "BigInteger": {
+      "type": "string"
+    }
+  }
+}

--- a/chain/wasm/json-gen/custom_schemas/TransactionMetadatum
+++ b/chain/wasm/json-gen/custom_schemas/TransactionMetadatum
@@ -1,0 +1,166 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TransactionMetadatum",
+  "oneOf": [
+    { 
+      "type": "object",
+      "required": [
+        "map"
+      ],
+      "properties": {
+        "map": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["k", "v"],
+            "properties": {
+              "k": {
+                "$ref": "#/definitions/TransactionMetadatum"
+              },
+              "v": {
+                "$ref": "#/definitions/TransactionMetadatum"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "list"
+      ],
+      "properties": {
+        "list": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TransactionMetadatum"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "int"
+      ],
+      "properties": {
+        "int": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "bytes"
+      ],
+      "properties": {
+        "bytes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "string"
+      ],
+      "properties": {
+        "string": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "TransactionMetadatum": {
+      "oneOf": [
+        { 
+          "type": "object",
+          "required": [
+            "map"
+          ],
+          "properties": {
+            "map": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["k", "v"],
+                "properties": {
+                  "k": {
+                    "$ref": "#/definitions/TransactionMetadatum"
+                  },
+                  "v": {
+                    "$ref": "#/definitions/TransactionMetadatum"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "list"
+          ],
+          "properties": {
+            "list": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TransactionMetadatum"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "int"
+          ],
+          "properties": {
+            "int": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "bytes"
+          ],
+          "properties": {
+            "bytes": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "string"
+          ],
+          "properties": {
+            "string": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "BigInteger": {
+      "type": "string"
+    }
+  }
+}

--- a/chain/wasm/json-gen/src/lib.rs
+++ b/chain/wasm/json-gen/src/lib.rs
@@ -15,6 +15,29 @@ pub fn export_schemas() {
     if !schema_path.exists() {
         std::fs::create_dir(schema_path).unwrap();
     }
+    // copy over custom ones
+    for custom_schema in std::fs::read_dir(
+        std::path::Path::new("..")
+            .join("..")
+            .join("..")
+            .join("chain")
+            .join("wasm")
+            .join("json-gen")
+            .join("custom_schemas"),
+    )
+    .unwrap()
+    {
+        let old_path = custom_schema.unwrap().path();
+        //if let Some("json") = old_path.extension().and_then(|p| p.to_str()) {
+        let new_path = std::path::Path::new("schemas").join(old_path.file_name().unwrap());
+        println!(
+            "MOVING: {}\nTO: {}",
+            old_path.as_os_str().to_str().unwrap(),
+            new_path.as_os_str().to_str().unwrap()
+        );
+        std::fs::copy(old_path, new_path).unwrap();
+        //}
+    }
     // address
     gen_json_schema!(cml_chain::address::Address);
     gen_json_schema!(cml_chain::address::RewardAccount);
@@ -93,12 +116,12 @@ pub fn export_schemas() {
     gen_json_schema!(cml_chain::Value);
     gen_json_schema!(cml_chain::crypto::Vkeywitness);
     // plutus
-    gen_json_schema!(cml_chain::plutus::ConstrPlutusData);
+    //gen_json_schema!(cml_chain::plutus::ConstrPlutusData);
     gen_json_schema!(cml_chain::plutus::CostModels);
     gen_json_schema!(cml_chain::plutus::ExUnitPrices);
     gen_json_schema!(cml_chain::plutus::ExUnits);
-    gen_json_schema!(cml_chain::plutus::PlutusData);
-    gen_json_schema!(cml_chain::plutus::PlutusMap);
+    //gen_json_schema!(cml_chain::plutus::PlutusData);
+    //gen_json_schema!(cml_chain::plutus::PlutusMap);
     gen_json_schema!(cml_chain::plutus::PlutusV1Script);
     gen_json_schema!(cml_chain::plutus::PlutusV2Script);
     gen_json_schema!(cml_chain::plutus::Redeemer);

--- a/chain/wasm/json-gen/src/lib.rs
+++ b/chain/wasm/json-gen/src/lib.rs
@@ -46,9 +46,7 @@ pub fn export_schemas() {
     gen_json_schema!(cml_chain::assets::Value);
     // auxdata
     gen_json_schema!(cml_chain::auxdata::AuxiliaryData);
-    gen_json_schema!(cml_chain::auxdata::TransactionMetadatum);
     gen_json_schema!(cml_chain::auxdata::Metadata);
-    gen_json_schema!(cml_chain::auxdata::MetadatumMap);
     // block
     gen_json_schema!(cml_chain::block::Block);
     gen_json_schema!(cml_chain::block::Header);

--- a/chain/wasm/src/auxdata/metadata.rs
+++ b/chain/wasm/src/auxdata/metadata.rs
@@ -9,17 +9,17 @@ use wasm_bindgen::{
     JsError,
 };
 
-use cml_core::metadata as core;
+use cml_core::serialization::{Deserialize, Serialize};
 
-use super::*;
+use cml_core_wasm::{impl_wasm_conversions, impl_wasm_list, Int};
 
-pub use cml_core::metadata::TransactionMetadatumLabel;
+pub use cml_chain::auxdata::TransactionMetadatumLabel;
 
-impl_wasm_conversions!(core::MetadatumMap, MetadatumMap);
+impl_wasm_conversions!(cml_chain::auxdata::MetadatumMap, MetadatumMap);
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
-pub struct MetadatumList(Vec<core::TransactionMetadatum>);
+pub struct MetadatumList(Vec<cml_chain::auxdata::TransactionMetadatum>);
 
 #[wasm_bindgen]
 impl MetadatumList {
@@ -40,13 +40,13 @@ impl MetadatumList {
     }
 }
 
-impl From<Vec<core::TransactionMetadatum>> for MetadatumList {
-    fn from(native: Vec<core::TransactionMetadatum>) -> Self {
+impl From<Vec<cml_chain::auxdata::TransactionMetadatum>> for MetadatumList {
+    fn from(native: Vec<cml_chain::auxdata::TransactionMetadatum>) -> Self {
         Self(native)
     }
 }
 
-impl From<MetadatumList> for Vec<core::TransactionMetadatum> {
+impl From<MetadatumList> for Vec<cml_chain::auxdata::TransactionMetadatum> {
     fn from(wrapper: MetadatumList) -> Self {
         wrapper.0
     }
@@ -89,12 +89,12 @@ impl From<TransactionMetadatumLabels> for Vec<TransactionMetadatumLabel> {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
-pub struct MetadatumMap(core::MetadatumMap);
+pub struct MetadatumMap(cml_chain::auxdata::MetadatumMap);
 
 #[wasm_bindgen]
 impl MetadatumMap {
     pub fn new() -> Self {
-        Self(core::MetadatumMap::new())
+        Self(cml_chain::auxdata::MetadatumMap::new())
     }
 
     pub fn len(&self) -> usize {
@@ -132,21 +132,21 @@ impl MetadatumMap {
 }
 
 impl_wasm_list!(
-    core::TransactionMetadatum,
+    cml_chain::auxdata::TransactionMetadatum,
     TransactionMetadatum,
     TransactionMetadatumList
 );
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
-pub struct Metadata(core::Metadata);
+pub struct Metadata(cml_chain::auxdata::Metadata);
 
-impl_wasm_conversions!(core::Metadata, Metadata);
+impl_wasm_conversions!(cml_chain::auxdata::Metadata, Metadata);
 
 #[wasm_bindgen]
 impl Metadata {
     pub fn new() -> Self {
-        Self(core::Metadata::new())
+        Self(cml_chain::auxdata::Metadata::new())
     }
 
     /// How many metadatum labels there are.
@@ -178,8 +178,8 @@ impl Metadata {
     }
 }
 
-impl AsMut<core::Metadata> for Metadata {
-    fn as_mut(&mut self) -> &mut core::Metadata {
+impl AsMut<cml_chain::auxdata::Metadata> for Metadata {
+    fn as_mut(&mut self) -> &mut cml_chain::auxdata::Metadata {
         &mut self.0
     }
 }
@@ -195,7 +195,7 @@ pub enum TransactionMetadatumKind {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
-pub struct TransactionMetadatum(core::TransactionMetadatum);
+pub struct TransactionMetadatum(cml_chain::auxdata::TransactionMetadatum);
 
 #[wasm_bindgen]
 impl TransactionMetadatum {
@@ -226,91 +226,99 @@ impl TransactionMetadatum {
     }
 
     pub fn new_map(map: &MetadatumMap) -> Self {
-        Self(core::TransactionMetadatum::new_map(map.clone().into()))
+        Self(cml_chain::auxdata::TransactionMetadatum::new_map(
+            map.clone().into(),
+        ))
     }
 
     pub fn new_list(elements: &MetadatumList) -> Self {
-        Self(core::TransactionMetadatum::new_list(
+        Self(cml_chain::auxdata::TransactionMetadatum::new_list(
             elements.clone().into(),
         ))
     }
 
     pub fn new_int(int: &Int) -> Self {
-        Self(core::TransactionMetadatum::new_int(int.clone().into()))
+        Self(cml_chain::auxdata::TransactionMetadatum::new_int(
+            int.clone().into(),
+        ))
     }
 
     pub fn new_bytes(bytes: Vec<u8>) -> Result<TransactionMetadatum, JsError> {
-        core::TransactionMetadatum::new_bytes(bytes)
+        cml_chain::auxdata::TransactionMetadatum::new_bytes(bytes)
             .map(Into::into)
             .map_err(Into::into)
     }
 
     pub fn new_text(text: String) -> Result<TransactionMetadatum, JsError> {
-        core::TransactionMetadatum::new_text(text)
+        cml_chain::auxdata::TransactionMetadatum::new_text(text)
             .map(Into::into)
             .map_err(Into::into)
     }
 
     pub fn kind(&self) -> TransactionMetadatumKind {
         match &self.0 {
-            core::TransactionMetadatum::Map { .. } => TransactionMetadatumKind::Map,
-            core::TransactionMetadatum::List { .. } => TransactionMetadatumKind::List,
-            core::TransactionMetadatum::Int(_) => TransactionMetadatumKind::Int,
-            core::TransactionMetadatum::Bytes { .. } => TransactionMetadatumKind::Bytes,
-            core::TransactionMetadatum::Text { .. } => TransactionMetadatumKind::Text,
+            cml_chain::auxdata::TransactionMetadatum::Map { .. } => TransactionMetadatumKind::Map,
+            cml_chain::auxdata::TransactionMetadatum::List { .. } => TransactionMetadatumKind::List,
+            cml_chain::auxdata::TransactionMetadatum::Int(_) => TransactionMetadatumKind::Int,
+            cml_chain::auxdata::TransactionMetadatum::Bytes { .. } => {
+                TransactionMetadatumKind::Bytes
+            }
+            cml_chain::auxdata::TransactionMetadatum::Text { .. } => TransactionMetadatumKind::Text,
         }
     }
 
     pub fn as_map(&self) -> Option<MetadatumMap> {
         match &self.0 {
-            core::TransactionMetadatum::Map(map) => Some(map.clone().into()),
+            cml_chain::auxdata::TransactionMetadatum::Map(map) => Some(map.clone().into()),
             _ => None,
         }
     }
 
     pub fn as_list(&self) -> Option<MetadatumList> {
         match &self.0 {
-            core::TransactionMetadatum::List { elements, .. } => Some(elements.clone().into()),
+            cml_chain::auxdata::TransactionMetadatum::List { elements, .. } => {
+                Some(elements.clone().into())
+            }
             _ => None,
         }
     }
 
     pub fn as_int(&self) -> Option<Int> {
         match &self.0 {
-            core::TransactionMetadatum::Int(int) => Some(int.clone().into()),
+            cml_chain::auxdata::TransactionMetadatum::Int(int) => Some(int.clone().into()),
             _ => None,
         }
     }
 
     pub fn as_bytes(&self) -> Option<Vec<u8>> {
         match &self.0 {
-            core::TransactionMetadatum::Bytes { bytes, .. } => Some(bytes.clone()),
+            cml_chain::auxdata::TransactionMetadatum::Bytes { bytes, .. } => Some(bytes.clone()),
             _ => None,
         }
     }
 
     pub fn as_text(&self) -> Option<String> {
         match &self.0 {
-            core::TransactionMetadatum::Text { text, .. } => Some(text.clone()),
+            cml_chain::auxdata::TransactionMetadatum::Text { text, .. } => Some(text.clone()),
             _ => None,
         }
     }
 }
 
-impl From<core::TransactionMetadatum> for TransactionMetadatum {
-    fn from(native: core::TransactionMetadatum) -> Self {
+impl From<cml_chain::auxdata::TransactionMetadatum> for TransactionMetadatum {
+    fn from(native: cml_chain::auxdata::TransactionMetadatum) -> Self {
         Self(native)
     }
 }
 
-impl From<TransactionMetadatum> for core::TransactionMetadatum {
+impl From<TransactionMetadatum> for cml_chain::auxdata::TransactionMetadatum {
     fn from(wasm: TransactionMetadatum) -> Self {
         wasm.0
     }
 }
 
-impl AsRef<core::TransactionMetadatum> for TransactionMetadatum {
-    fn as_ref(&self) -> &core::TransactionMetadatum {
+impl AsRef<cml_chain::auxdata::TransactionMetadatum> for TransactionMetadatum {
+    fn as_ref(&self) -> &cml_chain::auxdata::TransactionMetadatum {
         &self.0
     }
 }
@@ -318,11 +326,11 @@ impl AsRef<core::TransactionMetadatum> for TransactionMetadatum {
 /// encodes arbitrary bytes into chunks of 64 bytes (the limit for bytes) as a list to be valid Metadata
 #[wasm_bindgen]
 pub fn encode_arbitrary_bytes_as_metadatum(bytes: &[u8]) -> TransactionMetadatum {
-    cml_core::metadata::encode_arbitrary_bytes_as_metadatum(bytes).into()
+    cml_chain::auxdata::encode_arbitrary_bytes_as_metadatum(bytes).into()
 }
 
 /// decodes from chunks of bytes in a list to a byte vector if that is the metadata format, otherwise returns None
 #[wasm_bindgen]
 pub fn decode_arbitrary_bytes_from_metadatum(metadata: &TransactionMetadatum) -> Option<Vec<u8>> {
-    cml_core::metadata::decode_arbitrary_bytes_from_metadatum(metadata.as_ref())
+    cml_chain::auxdata::decode_arbitrary_bytes_from_metadatum(metadata.as_ref())
 }

--- a/chain/wasm/src/auxdata/mod.rs
+++ b/chain/wasm/src/auxdata/mod.rs
@@ -2,9 +2,13 @@
 // https://github.com/dcSpark/cddl-codegen
 
 use super::{NativeScriptList, PlutusV1ScriptList, PlutusV2ScriptList, PlutusV3ScriptList};
-pub use cml_core_wasm::metadata::{Metadata, TransactionMetadatum, TransactionMetadatumLabel};
 use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
+
+pub mod metadata;
+pub mod utils;
+
+pub use metadata::*;
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]

--- a/chain/wasm/src/auxdata/utils.rs
+++ b/chain/wasm/src/auxdata/utils.rs
@@ -1,8 +1,7 @@
-use cml_core_wasm::metadata::Metadata;
-use wasm_bindgen::prelude::wasm_bindgen;
 use crate::{NativeScriptList, PlutusV1ScriptList, PlutusV2ScriptList};
+use wasm_bindgen::prelude::wasm_bindgen;
 
-use super::AuxiliaryData;
+use super::{AuxiliaryData, Metadata};
 
 #[wasm_bindgen]
 impl AuxiliaryData {

--- a/chain/wasm/src/json/metadatums.rs
+++ b/chain/wasm/src/json/metadatums.rs
@@ -1,5 +1,5 @@
+use crate::auxdata::TransactionMetadatum;
 pub use cml_chain::json::metadatums::MetadataJsonSchema;
-use cml_core_wasm::metadata::TransactionMetadatum;
 use wasm_bindgen::prelude::{wasm_bindgen, JsError};
 
 /// Converts JSON to Metadata according to MetadataJsonSchema

--- a/chain/wasm/src/lib.rs
+++ b/chain/wasm/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 
 use ::wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
-use cml_core_wasm::metadata::TransactionMetadatumList;
+use auxdata::TransactionMetadatumList;
 use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions, impl_wasm_list};
 
 pub use cml_core_wasm::Int;

--- a/chain/wasm/src/plutus/utils.rs
+++ b/chain/wasm/src/plutus/utils.rs
@@ -1,6 +1,6 @@
 use crate::{plutus::PlutusData, PlutusDataList, RedeemerList};
 use cml_chain::plutus::Language;
-use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
+use cml_core_wasm::{impl_wasm_cbor_api, impl_wasm_cbor_json_api, impl_wasm_conversions};
 use cml_crypto_wasm::ScriptHash;
 use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
 
@@ -38,7 +38,7 @@ pub struct PlutusMap(cml_chain::plutus::PlutusMap);
 
 impl_wasm_conversions!(cml_chain::plutus::PlutusMap, PlutusMap);
 
-impl_wasm_cbor_json_api!(PlutusMap);
+impl_wasm_cbor_api!(PlutusMap);
 
 #[wasm_bindgen]
 impl PlutusMap {

--- a/cip25/rust/src/serialization.rs
+++ b/cip25/rust/src/serialization.rs
@@ -80,7 +80,7 @@ impl Deserialize for CIP25FilesDetails {
                             read_len.read_elems(1)?;
                             // we still need to read the data to move on to the CBOR after it
                             let _other_metadatum =
-                                cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                         }
                     },
                     CBORType::Special => match len {
@@ -97,9 +97,9 @@ impl Deserialize for CIP25FilesDetails {
                         read_len.read_elems(1)?;
                         // we still need to read the data to move on to the CBOR after it
                         let _other_key =
-                            cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                            cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                         let _other_value =
-                            cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                            cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                     }
                 }
                 read += 1;
@@ -185,7 +185,7 @@ impl Deserialize for CIP25Metadata {
                             read_len.read_elems(1)?;
                             // we still need to read the data to move on to the CBOR after it
                             let _other_metadatum =
-                                cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                         }
                     },
                     CBORType::Special => match len {
@@ -362,7 +362,7 @@ impl Deserialize for CIP25MetadataDetails {
                             read_len.read_elems(1)?;
                             // we still need to read the data to move on to the CBOR after it
                             let _other_metadatum =
-                                cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                         }
                     },
                     CBORType::Special => match len {
@@ -379,9 +379,9 @@ impl Deserialize for CIP25MetadataDetails {
                         read_len.read_elems(1)?;
                         // we still need to read the data to move on to the CBOR after it
                         let _other_key =
-                            cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                            cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                         let _other_value =
-                            cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                            cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                     }
                 }
                 read += 1;

--- a/cip25/rust/src/utils.rs
+++ b/cip25/rust/src/utils.rs
@@ -1,12 +1,12 @@
 use std::{collections::BTreeMap, convert::TryFrom, string::FromUtf8Error};
 
 use cbor_event::{de::Deserializer, se::Serializer};
-pub use cml_chain::{assets::AssetName, PolicyId};
-pub use cml_core::{
-    error::*,
-    metadata::{Metadata, TransactionMetadatum},
-    serialization::*,
+pub use cml_chain::{
+    assets::AssetName,
+    auxdata::{Metadata, TransactionMetadatum},
+    PolicyId,
 };
+pub use cml_core::{error::*, serialization::*};
 use cml_crypto::RawBytesEncoding;
 use std::io::{BufRead, Seek, SeekFrom, Write};
 
@@ -387,11 +387,11 @@ impl Deserialize for CIP25LabelMetadata {
                                     _other_type => {
                                         // we still need to read the data to move on to the CBOR after it
                                         let _other_key =
-                                            cml_core::metadata::TransactionMetadatum::deserialize(
+                                            cml_chain::auxdata::TransactionMetadatum::deserialize(
                                                 raw,
                                             )?;
                                         let _other_value =
-                                            cml_core::metadata::TransactionMetadatum::deserialize(
+                                            cml_chain::auxdata::TransactionMetadatum::deserialize(
                                                 raw,
                                             )?;
                                         label_metadata_v1_value_table_len += 1;
@@ -417,9 +417,9 @@ impl Deserialize for CIP25LabelMetadata {
                         _other_type => {
                             // we still need to read the data to move on to the CBOR after it
                             let _other_key =
-                                cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                             let _other_value =
-                                cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                             label_metadata_v1_table_len += 1;
                         }
                     }
@@ -512,8 +512,8 @@ impl Deserialize for CIP25LabelMetadata {
                                                             },
                                                             _other_type => {
                                                                 // we still need to read the data to move on to the CBOR after it
-                                                                let _other_key = cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
-                                                                let _other_value = cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                                                let _other_key = cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
+                                                                let _other_value = cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                                                                 data_value_table_len += 1;
                                                             },
                                                         }
@@ -536,8 +536,8 @@ impl Deserialize for CIP25LabelMetadata {
                                                 },
                                                 _other_type => {
                                                     // we still need to read the data to move on to the CBOR after it
-                                                    let _other_key = cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
-                                                    let _other_value = cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                                    let _other_key = cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
+                                                    let _other_value = cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                                                     data_table_len += 1;
                                                 },
                                             }
@@ -571,7 +571,7 @@ impl Deserialize for CIP25LabelMetadata {
                                 // CIP-25 allows permissive parsing
                                 read_len.read_elems(1)?;
                                 // we still need to read the data to move on to the CBOR after it
-                                let _other_metadatum = cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                                let _other_metadatum = cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                             }
                         },
                         cbor_event::Type::Special => match len {
@@ -587,8 +587,8 @@ impl Deserialize for CIP25LabelMetadata {
                             // CIP-25 allows permissive parsing
                             read_len.read_elems(1)?;
                             // we still need to read the data to move on to the CBOR after it
-                            let _other_key = cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
-                            let _other_value = cml_core::metadata::TransactionMetadatum::deserialize(raw)?;
+                            let _other_key = cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
+                            let _other_value = cml_chain::auxdata::TransactionMetadatum::deserialize(raw)?;
                         }
                     }
                     read += 1;

--- a/cip25/wasm/src/utils.rs
+++ b/cip25/wasm/src/utils.rs
@@ -1,13 +1,14 @@
-use cml_chain_wasm::{assets::AssetName, PolicyId};
+use cml_chain_wasm::{
+    assets::AssetName,
+    auxdata::{Metadata, TransactionMetadatum},
+    PolicyId,
+};
 
 use crate::*;
 
 use wasm_bindgen::prelude::JsError;
 
-use cml_core_wasm::{
-    impl_wasm_json_api,
-    metadata::{Metadata, TransactionMetadatum},
-};
+use cml_core_wasm::impl_wasm_json_api;
 
 #[wasm_bindgen]
 impl CIP25Metadata {

--- a/cip36/rust/src/lib.rs
+++ b/cip36/rust/src/lib.rs
@@ -5,12 +5,11 @@
 
 pub use cml_core::{
     error::{DeserializeError, DeserializeFailure},
-    metadata::Metadata,
     ordered_hash_map::OrderedHashMap,
     serialization::{Deserialize, LenEncoding, Serialize, StringEncoding},
 };
 
-pub use cml_chain::{address::Address, NetworkId};
+pub use cml_chain::{address::Address, auxdata::Metadata, NetworkId};
 
 use std::convert::From;
 

--- a/cip36/rust/src/utils.rs
+++ b/cip36/rust/src/utils.rs
@@ -4,12 +4,15 @@ use crate::error::CIP36Error;
 
 pub use cml_core::{
     error::{DeserializeError, DeserializeFailure},
-    metadata::{Metadata, TransactionMetadatum},
     ordered_hash_map::OrderedHashMap,
     serialization::{Deserialize, LenEncoding, Serialize, StringEncoding},
 };
 
-pub use cml_chain::{address::Address, NetworkId};
+pub use cml_chain::{
+    address::Address,
+    auxdata::{Metadata, TransactionMetadatum},
+    NetworkId,
+};
 
 use std::convert::From;
 

--- a/cip36/wasm/Cargo.toml
+++ b/cip36/wasm/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 cml-cip36 = { path = "../rust", version = "5.1.0" }
 cml-crypto = { path = "../../crypto/rust", version = "5.1.0" }
 cml-crypto-wasm = { path = "../../crypto/wasm", version = "5.1.0" }
+cml-chain = { path = "../../chain/rust", version = "5.1.0" }
 cml-chain-wasm = { path = "../../chain/wasm", version = "5.1.0" }
 cml-core = { path = "../../core/rust", version = "5.1.0" }
 cml-core-wasm = { path = "../../core/wasm", version = "5.1.0" }

--- a/cip36/wasm/src/utils.rs
+++ b/cip36/wasm/src/utils.rs
@@ -4,7 +4,7 @@ pub use cml_core::{
     serialization::{Deserialize, LenEncoding, Serialize, StringEncoding},
 };
 
-pub use cml_core_wasm::metadata::{Metadata, TransactionMetadatum};
+pub use cml_chain_wasm::auxdata::{Metadata, TransactionMetadatum};
 
 pub use cml_chain_wasm::{address::Address, NetworkId};
 use wasm_bindgen::JsError;
@@ -51,7 +51,7 @@ impl CIP36DeregistrationCbor {
     }
 
     pub fn try_into_metadata(&self) -> Result<Metadata, JsError> {
-        TryInto::<cml_core::metadata::Metadata>::try_into(&self.0)
+        TryInto::<cml_chain::auxdata::Metadata>::try_into(&self.0)
             .map(Into::into)
             .map_err(Into::into)
     }
@@ -154,7 +154,7 @@ impl CIP36RegistrationCbor {
     }
 
     pub fn try_into_metadata(&self) -> Result<Metadata, JsError> {
-        TryInto::<cml_core::metadata::Metadata>::try_into(&self.0)
+        TryInto::<cml_chain::auxdata::Metadata>::try_into(&self.0)
             .map(Into::into)
             .map_err(Into::into)
     }

--- a/core/rust/src/lib.rs
+++ b/core/rust/src/lib.rs
@@ -13,7 +13,6 @@
 pub use error::*;
 
 pub mod error;
-pub mod metadata;
 pub mod network;
 pub mod ordered_hash_map;
 pub mod serialization;

--- a/core/wasm/src/lib.rs
+++ b/core/wasm/src/lib.rs
@@ -2,7 +2,6 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 use cml_core::serialization::{Deserialize, Serialize};
 
-pub mod metadata;
 #[macro_use]
 pub mod wasm_wrappers;
 

--- a/multi-era/wasm/src/babbage/mod.rs
+++ b/multi-era/wasm/src/babbage/mod.rs
@@ -13,14 +13,14 @@ use cml_chain_wasm::block::Header;
 use cml_chain_wasm::crypto::{AuxiliaryDataHash, GenesisHash, ScriptDataHash};
 use cml_chain_wasm::plutus::{ExUnitPrices, ExUnits, PlutusV1Script, PlutusV2Script};
 use cml_chain_wasm::transaction::{AlonzoFormatTxOut, DatumOption, NativeScript, RequiredSigners};
+use cml_chain_wasm::{auxdata::Metadata, Epoch, Rational, UnitInterval, Withdrawals};
 use cml_chain_wasm::{
     BootstrapWitnessList, IntList, NativeScriptList, NetworkId, PlutusDataList, PlutusV1ScriptList,
     PlutusV2ScriptList, RedeemerList, TransactionInputList, VkeywitnessList,
 };
-use cml_chain_wasm::{Epoch, Rational, UnitInterval, Withdrawals};
 use cml_core::ordered_hash_map::OrderedHashMap;
 use cml_core::TransactionIndex;
-use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions, metadata::Metadata};
+use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions};
 use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
 
 #[derive(Clone, Debug)]

--- a/multi-era/wasm/src/lib.rs
+++ b/multi-era/wasm/src/lib.rs
@@ -161,9 +161,9 @@ impl_wasm_map!(
 
 impl_wasm_map!(
     cml_chain::TransactionIndex,
-    cml_core::metadata::Metadata,
+    cml_chain::auxdata::Metadata,
     TransactionIndex,
-    cml_core_wasm::metadata::Metadata,
+    cml_chain_wasm::auxdata::Metadata,
     Vec<TransactionIndex>,
     MapTransactionIndexToMetadata,
     true,

--- a/scripts/run-json2ts.js
+++ b/scripts/run-json2ts.js
@@ -3,7 +3,12 @@ const json2ts = require('json-schema-to-typescript');
 const path = require('path');
 
 const schemasDir = path.join('json-gen', 'schemas');
-const schemaFiles = fs.readdirSync(schemasDir).filter(file => path.extname(file) === '.json');
+// we don't filter .json anymore to get around not being able to name the custom ones .json
+// Note: the reason we can't seem to be able to do that is if we use e.g.:
+//      schemars::schema::Schema::from(schemars::schema::SchemaObject::new_ref("PlutusData".to_owned()))
+// it will not be able to find it as PlutusData.json, and if we add .json to the above
+// it will not have the correct name.
+const schemaFiles = fs.readdirSync(schemasDir)/*.filter(file => path.extname(file) === '.json')*/;
 
 function replaceRef(obj) {
   if (obj['$ref'] != null && typeof obj['$ref'] === 'string' && obj['$ref'].startsWith('#/definitions/')) {


### PR DESCRIPTION
To replace the redundant auto-generated plutus datum JSON format with a standardized one even when used from within other structures.