### PR TITLE
CI Fixes + Deserialization regen

### DIFF
--- a/chain/rust/src/byron/serialization.rs
+++ b/chain/rust/src/byron/serialization.rs
@@ -197,7 +197,7 @@ impl Deserialize for AddressContent {
                 .map_err(|e: DeserializeError| e.annotate("addr_attributes"))?;
             let addr_type = (|| -> Result<_, DeserializeError> {
                 let initial_position = raw.as_mut_ref().stream_position().unwrap();
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let public_key_value = raw.unsigned_integer()?;
                     if public_key_value != 0 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -207,15 +207,15 @@ impl Deserialize for AddressContent {
                         .into());
                     }
                     Ok(())
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(()) => return Ok(ByronAddrType::PublicKey),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let script_value = raw.unsigned_integer()?;
                     if script_value != 1 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -225,15 +225,15 @@ impl Deserialize for AddressContent {
                         .into());
                     }
                     Ok(())
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(()) => return Ok(ByronAddrType::Script),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let redeem_value = raw.unsigned_integer()?;
                     if redeem_value != 2 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -243,8 +243,8 @@ impl Deserialize for AddressContent {
                         .into());
                     }
                     Ok(())
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(()) => return Ok(ByronAddrType::Redeem),
                     Err(_) => raw
                         .as_mut_ref()
@@ -419,7 +419,7 @@ impl Deserialize for SpendingData {
             let len = raw.array()?;
             let _read_len = CBORReadLen::from(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 (|| -> Result<_, DeserializeError> {
                     let tag_value = raw.unsigned_integer()?;
                     if tag_value != 0 {
@@ -448,15 +448,15 @@ impl Deserialize for SpendingData {
                     },
                 }
                 Ok(Self::SpendingDataPubKey(pubkey))
-            })(raw)
-            {
+            })(raw);
+            match deser_variant {
                 Ok(variant) => return Ok(variant),
                 Err(_) => raw
                     .as_mut_ref()
                     .seek(SeekFrom::Start(initial_position))
                     .unwrap(),
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 (|| -> Result<_, DeserializeError> {
                     let tag_value = raw.unsigned_integer()?;
                     if tag_value != 1 {
@@ -485,15 +485,15 @@ impl Deserialize for SpendingData {
                     },
                 }
                 Ok(Self::SpendingDataScript(script))
-            })(raw)
-            {
+            })(raw);
+            match deser_variant {
                 Ok(variant) => return Ok(variant),
                 Err(_) => raw
                     .as_mut_ref()
                     .seek(SeekFrom::Start(initial_position))
                     .unwrap(),
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 (|| -> Result<_, DeserializeError> {
                     let tag_value = raw.unsigned_integer()?;
                     if tag_value != 2 {
@@ -522,8 +522,8 @@ impl Deserialize for SpendingData {
                     },
                 }
                 Ok(Self::SpendingDataRedeem(redeem))
-            })(raw)
-            {
+            })(raw);
+            match deser_variant {
                 Ok(variant) => return Ok(variant),
                 Err(_) => raw
                     .as_mut_ref()
@@ -572,7 +572,7 @@ impl Deserialize for StakeDistribution {
             let len = raw.array()?;
             let _read_len = CBORReadLen::from(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 (|| -> Result<_, DeserializeError> {
                     let tag_value = raw.unsigned_integer()?;
                     if tag_value != 0 {
@@ -601,15 +601,15 @@ impl Deserialize for StakeDistribution {
                     },
                 }
                 Ok(Self::SingleKey(stakeholder_id))
-            })(raw)
-            {
+            })(raw);
+            match deser_variant {
                 Ok(variant) => return Ok(variant),
                 Err(_) => raw
                     .as_mut_ref()
                     .seek(SeekFrom::Start(initial_position))
                     .unwrap(),
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 let bootstrap_era_distr_value = raw.unsigned_integer()?;
                 if bootstrap_era_distr_value != 1 {
                     return Err(DeserializeFailure::FixedValueMismatch {
@@ -619,8 +619,8 @@ impl Deserialize for StakeDistribution {
                     .into());
                 }
                 Ok(())
-            })(raw)
-            {
+            })(raw);
+            match deser_variant {
                 Ok(()) => return Ok(StakeDistribution::BootstrapEra),
                 Err(_) => raw
                     .as_mut_ref()

--- a/chain/rust/src/certs/serialization.rs
+++ b/chain/rust/src/certs/serialization.rs
@@ -174,11 +174,22 @@ impl Deserialize for Certificate {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
-            let mut read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            let deser_variant: Result<_, DeserializeError> =
-                StakeRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret = StakeRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_registration) => return Ok(Self::StakeRegistration(stake_registration)),
                 Err(e) => {
@@ -188,8 +199,21 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                StakeDeregistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret =
+                    StakeDeregistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_deregistration) => {
                     return Ok(Self::StakeDeregistration(stake_deregistration))
@@ -201,8 +225,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                StakeDelegation::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = StakeDelegation::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_delegation) => return Ok(Self::StakeDelegation(stake_delegation)),
                 Err(e) => {
@@ -212,8 +248,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                PoolRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(10)?;
+                read_len.finish()?;
+                let ret = PoolRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(pool_registration) => return Ok(Self::PoolRegistration(pool_registration)),
                 Err(e) => {
@@ -223,8 +271,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                PoolRetirement::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = PoolRetirement::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(pool_retirement) => return Ok(Self::PoolRetirement(pool_retirement)),
                 Err(e) => {
@@ -234,8 +294,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                RegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = RegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(reg_cert) => return Ok(Self::RegCert(reg_cert)),
                 Err(e) => {
@@ -245,8 +317,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                UnregCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = UnregCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(unreg_cert) => return Ok(Self::UnregCert(unreg_cert)),
                 Err(e) => {
@@ -256,8 +340,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                VoteDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = VoteDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(vote_deleg_cert) => return Ok(Self::VoteDelegCert(vote_deleg_cert)),
                 Err(e) => {
@@ -267,8 +363,21 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                StakeVoteDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(4)?;
+                read_len.finish()?;
+                let ret =
+                    StakeVoteDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_vote_deleg_cert) => {
                     return Ok(Self::StakeVoteDelegCert(stake_vote_deleg_cert))
@@ -280,8 +389,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                StakeRegDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(4)?;
+                read_len.finish()?;
+                let ret = StakeRegDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_reg_deleg_cert) => {
                     return Ok(Self::StakeRegDelegCert(stake_reg_deleg_cert))
@@ -293,8 +414,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                VoteRegDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(4)?;
+                read_len.finish()?;
+                let ret = VoteRegDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(vote_reg_deleg_cert) => return Ok(Self::VoteRegDelegCert(vote_reg_deleg_cert)),
                 Err(e) => {
@@ -304,8 +437,21 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                StakeVoteRegDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(5)?;
+                read_len.finish()?;
+                let ret =
+                    StakeVoteRegDelegCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_vote_reg_deleg_cert) => {
                     return Ok(Self::StakeVoteRegDelegCert(stake_vote_reg_deleg_cert))
@@ -317,8 +463,21 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                AuthCommitteeHotCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret =
+                    AuthCommitteeHotCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(auth_committee_hot_cert) => {
                     return Ok(Self::AuthCommitteeHotCert(auth_committee_hot_cert))
@@ -330,8 +489,21 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                ResignCommitteeColdCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret =
+                    ResignCommitteeColdCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(resign_committee_cold_cert) => {
                     return Ok(Self::ResignCommitteeColdCert(resign_committee_cold_cert))
@@ -343,8 +515,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                RegDrepCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(4)?;
+                read_len.finish()?;
+                let ret = RegDrepCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(reg_drep_cert) => return Ok(Self::RegDrepCert(reg_drep_cert)),
                 Err(e) => {
@@ -354,8 +538,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                UnregDrepCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = UnregDrepCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(unreg_drep_cert) => return Ok(Self::UnregDrepCert(unreg_drep_cert)),
                 Err(e) => {
@@ -365,8 +561,20 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                UpdateDrepCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = UpdateDrepCert::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(update_drep_cert) => return Ok(Self::UpdateDrepCert(update_drep_cert)),
                 Err(e) => {
@@ -376,13 +584,6 @@ impl Deserialize for Certificate {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "Certificate",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -444,10 +645,12 @@ impl Deserialize for Credential {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
             let len_encoding: LenEncoding = len.into();
-            let _read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 0 {
@@ -482,8 +685,8 @@ impl Deserialize for Credential {
                     tag_encoding,
                     hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("PubKey"));
@@ -492,7 +695,10 @@ impl Deserialize for Credential {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 1 {
@@ -527,8 +733,8 @@ impl Deserialize for Credential {
                     tag_encoding,
                     hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("Script"));
@@ -537,13 +743,6 @@ impl Deserialize for Credential {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "Credential",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -630,10 +829,12 @@ impl Deserialize for DRep {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
             let len_encoding: LenEncoding = len.into();
-            let _read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let index_0_encoding = (|| -> Result<_, DeserializeError> {
                     let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
                     if index_0_value != 0 {
@@ -668,8 +869,8 @@ impl Deserialize for DRep {
                     index_0_encoding,
                     pool_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("Key"));
@@ -678,7 +879,10 @@ impl Deserialize for DRep {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let index_0_encoding = (|| -> Result<_, DeserializeError> {
                     let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
                     if index_0_value != 1 {
@@ -713,8 +917,8 @@ impl Deserialize for DRep {
                     index_0_encoding,
                     script_hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("Script"));
@@ -723,18 +927,29 @@ impl Deserialize for DRep {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                let (i2_value, always_abstain_encoding) = raw.unsigned_integer_sz()?;
-                if i2_value != 2 {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(1)?;
+                read_len.finish()?;
+                let (always_abstain_value, always_abstain_encoding) = raw.unsigned_integer_sz()?;
+                if always_abstain_value != 2 {
                     return Err(DeserializeFailure::FixedValueMismatch {
-                        found: Key::Uint(i2_value),
+                        found: Key::Uint(always_abstain_value),
                         expected: Key::Uint(2),
                     }
                     .into());
                 }
-                Ok(Some(always_abstain_encoding))
-            })(raw)
-            {
+                let ret = Ok(Some(always_abstain_encoding));
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
+            match deser_variant {
                 Ok(always_abstain_encoding) => {
                     return Ok(Self::AlwaysAbstain {
                         always_abstain_encoding,
@@ -748,18 +963,30 @@ impl Deserialize for DRep {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                let (i3_value, always_no_confidence_encoding) = raw.unsigned_integer_sz()?;
-                if i3_value != 3 {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(1)?;
+                read_len.finish()?;
+                let (always_no_confidence_value, always_no_confidence_encoding) =
+                    raw.unsigned_integer_sz()?;
+                if always_no_confidence_value != 3 {
                     return Err(DeserializeFailure::FixedValueMismatch {
-                        found: Key::Uint(i3_value),
+                        found: Key::Uint(always_no_confidence_value),
                         expected: Key::Uint(3),
                     }
                     .into());
                 }
-                Ok(Some(always_no_confidence_encoding))
-            })(raw)
-            {
+                let ret = Ok(Some(always_no_confidence_encoding));
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
+            match deser_variant {
                 Ok(always_no_confidence_encoding) => {
                     return Ok(Self::AlwaysNoConfidence {
                         always_no_confidence_encoding,
@@ -773,13 +1000,6 @@ impl Deserialize for DRep {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "DRep",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -1830,11 +2050,22 @@ impl Deserialize for Relay {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
-            let mut read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            let deser_variant: Result<_, DeserializeError> =
-                SingleHostAddr::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(4)?;
+                read_len.finish()?;
+                let ret = SingleHostAddr::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(single_host_addr) => return Ok(Self::SingleHostAddr(single_host_addr)),
                 Err(e) => {
@@ -1844,8 +2075,20 @@ impl Deserialize for Relay {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                SingleHostName::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = SingleHostName::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(single_host_name) => return Ok(Self::SingleHostName(single_host_name)),
                 Err(e) => {
@@ -1855,8 +2098,20 @@ impl Deserialize for Relay {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                MultiHostName::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret = MultiHostName::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(multi_host_name) => return Ok(Self::MultiHostName(multi_host_name)),
                 Err(e) => {
@@ -1866,13 +2121,6 @@ impl Deserialize for Relay {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "Relay",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),

--- a/chain/rust/src/governance/mod.rs
+++ b/chain/rust/src/governance/mod.rs
@@ -89,7 +89,7 @@ pub enum GovAction {
     NewConstitution(NewConstitution),
     InfoAction {
         #[serde(skip)]
-        i6_encoding: Option<cbor_event::Sz>,
+        info_action_encoding: Option<cbor_event::Sz>,
         #[serde(skip)]
         len_encoding: LenEncoding,
     },
@@ -140,7 +140,7 @@ impl GovAction {
 
     pub fn new_info_action() -> Self {
         Self::InfoAction {
-            i6_encoding: None,
+            info_action_encoding: None,
             len_encoding: LenEncoding::default(),
         }
     }

--- a/chain/rust/src/governance/serialization.rs
+++ b/chain/rust/src/governance/serialization.rs
@@ -328,12 +328,14 @@ impl Serialize for GovAction {
                 new_constitution.serialize(serializer, force_canonical)
             }
             GovAction::InfoAction {
-                i6_encoding,
+                info_action_encoding,
                 len_encoding,
             } => {
                 serializer.write_array_sz(len_encoding.to_len_sz(1, force_canonical))?;
-                serializer
-                    .write_unsigned_integer_sz(6u64, fit_sz(6u64, *i6_encoding, force_canonical))?;
+                serializer.write_unsigned_integer_sz(
+                    6u64,
+                    fit_sz(6u64, *info_action_encoding, force_canonical),
+                )?;
                 len_encoding.end(serializer, force_canonical)?;
                 Ok(serializer)
             }
@@ -346,11 +348,23 @@ impl Deserialize for GovAction {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
             let len_encoding: LenEncoding = len.into();
-            let mut read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            let deser_variant: Result<_, DeserializeError> =
-                ParameterChangeAction::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret =
+                    ParameterChangeAction::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(parameter_change_action) => {
                     return Ok(Self::ParameterChangeAction(parameter_change_action))
@@ -362,8 +376,24 @@ impl Deserialize for GovAction {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                HardForkInitiationAction::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = HardForkInitiationAction::deserialize_as_embedded_group(
+                    raw,
+                    &mut read_len,
+                    len,
+                );
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(hard_fork_initiation_action) => {
                     return Ok(Self::HardForkInitiationAction(hard_fork_initiation_action))
@@ -375,8 +405,24 @@ impl Deserialize for GovAction {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                TreasuryWithdrawalsAction::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret = TreasuryWithdrawalsAction::deserialize_as_embedded_group(
+                    raw,
+                    &mut read_len,
+                    len,
+                );
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(treasury_withdrawals_action) => {
                     return Ok(Self::TreasuryWithdrawalsAction(treasury_withdrawals_action))
@@ -388,8 +434,20 @@ impl Deserialize for GovAction {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                NoConfidence::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret = NoConfidence::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(no_confidence) => return Ok(Self::NoConfidence(no_confidence)),
                 Err(e) => {
@@ -399,8 +457,20 @@ impl Deserialize for GovAction {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                NewCommittee::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(4)?;
+                read_len.finish()?;
+                let ret = NewCommittee::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(new_committee) => return Ok(Self::NewCommittee(new_committee)),
                 Err(e) => {
@@ -410,8 +480,20 @@ impl Deserialize for GovAction {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                NewConstitution::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = NewConstitution::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(new_constitution) => return Ok(Self::NewConstitution(new_constitution)),
                 Err(e) => {
@@ -421,21 +503,32 @@ impl Deserialize for GovAction {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                let (i6_value, i6_encoding) = raw.unsigned_integer_sz()?;
-                if i6_value != 6 {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(1)?;
+                read_len.finish()?;
+                let (info_action_value, info_action_encoding) = raw.unsigned_integer_sz()?;
+                if info_action_value != 6 {
                     return Err(DeserializeFailure::FixedValueMismatch {
-                        found: Key::Uint(i6_value),
+                        found: Key::Uint(info_action_value),
                         expected: Key::Uint(6),
                     }
                     .into());
                 }
-                Ok(Some(i6_encoding))
-            })(raw)
-            {
-                Ok(i6_encoding) => {
+                let ret = Ok(Some(info_action_encoding));
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
+            match deser_variant {
+                Ok(info_action_encoding) => {
                     return Ok(Self::InfoAction {
-                        i6_encoding,
+                        info_action_encoding,
                         len_encoding,
                     })
                 }
@@ -446,13 +539,6 @@ impl Deserialize for GovAction {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "GovAction",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -524,8 +610,8 @@ impl Deserialize for GovActionId {
                 .map_err(|e: DeserializeError| e.annotate("transaction_id"))?;
             let (gov_action_index, gov_action_index_encoding) = raw
                 .unsigned_integer_sz()
-                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(Into::<DeserializeError>::into)
+                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(|e: DeserializeError| e.annotate("gov_action_index"))?;
             match len {
                 cbor_event::LenSz::Len(_, _) => (),
@@ -1185,8 +1271,8 @@ impl Deserialize for ProposalProcedure {
         (|| -> Result<_, DeserializeError> {
             let (deposit, deposit_encoding) = raw
                 .unsigned_integer_sz()
-                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(Into::<DeserializeError>::into)
+                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(|e: DeserializeError| e.annotate("deposit"))?;
             let reward_account = RewardAccount::deserialize(raw)
                 .map_err(|e: DeserializeError| e.annotate("reward_account"))?;
@@ -1505,10 +1591,12 @@ impl Deserialize for Voter {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
             let len_encoding: LenEncoding = len.into();
-            let _read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let index_0_encoding = (|| -> Result<_, DeserializeError> {
                     let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
                     if index_0_value != 0 {
@@ -1543,8 +1631,8 @@ impl Deserialize for Voter {
                     index_0_encoding,
                     ed25519_key_hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("ConstitutionalCommitteeHotKeyHash"));
@@ -1553,7 +1641,10 @@ impl Deserialize for Voter {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let index_0_encoding = (|| -> Result<_, DeserializeError> {
                     let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
                     if index_0_value != 1 {
@@ -1588,8 +1679,8 @@ impl Deserialize for Voter {
                     index_0_encoding,
                     script_hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("ConstitutionalCommitteeHotScriptHash"));
@@ -1598,7 +1689,10 @@ impl Deserialize for Voter {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let index_0_encoding = (|| -> Result<_, DeserializeError> {
                     let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
                     if index_0_value != 2 {
@@ -1633,8 +1727,8 @@ impl Deserialize for Voter {
                     index_0_encoding,
                     ed25519_key_hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("DRepKeyHash"));
@@ -1643,7 +1737,10 @@ impl Deserialize for Voter {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let index_0_encoding = (|| -> Result<_, DeserializeError> {
                     let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
                     if index_0_value != 3 {
@@ -1678,8 +1775,8 @@ impl Deserialize for Voter {
                     index_0_encoding,
                     script_hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("DRepScriptHash"));
@@ -1688,7 +1785,10 @@ impl Deserialize for Voter {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let index_0_encoding = (|| -> Result<_, DeserializeError> {
                     let (index_0_value, index_0_encoding) = raw.unsigned_integer_sz()?;
                     if index_0_value != 4 {
@@ -1723,8 +1823,8 @@ impl Deserialize for Voter {
                     index_0_encoding,
                     ed25519_key_hash_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("StakingPoolKeyHash"));
@@ -1733,13 +1833,6 @@ impl Deserialize for Voter {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "Voter",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -1819,7 +1912,7 @@ impl Deserialize for VotingProcedure {
         (|| -> Result<_, DeserializeError> {
             let (vote, vote_encoding) = (|| -> Result<_, DeserializeError> {
                 let initial_position = raw.as_mut_ref().stream_position().unwrap();
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (no_value, no_encoding) = raw.unsigned_integer_sz()?;
                     if no_value != 0 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -1829,15 +1922,15 @@ impl Deserialize for VotingProcedure {
                         .into());
                     }
                     Ok(Some(no_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(vote_encoding) => return Ok((Vote::No, vote_encoding)),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (yes_value, yes_encoding) = raw.unsigned_integer_sz()?;
                     if yes_value != 1 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -1847,15 +1940,15 @@ impl Deserialize for VotingProcedure {
                         .into());
                     }
                     Ok(Some(yes_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(vote_encoding) => return Ok((Vote::Yes, vote_encoding)),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (abstain_value, abstain_encoding) = raw.unsigned_integer_sz()?;
                     if abstain_value != 2 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -1865,8 +1958,8 @@ impl Deserialize for VotingProcedure {
                         .into());
                     }
                     Ok(Some(abstain_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(vote_encoding) => return Ok((Vote::Abstain, vote_encoding)),
                     Err(_) => raw
                         .as_mut_ref()

--- a/chain/rust/src/json/json_serialize.rs
+++ b/chain/rust/src/json/json_serialize.rs
@@ -123,7 +123,7 @@ impl Display for JsonParseError {
 impl std::error::Error for JsonParseError {}
 
 fn tokenize_string(string: &str) -> Vec<JsonToken> {
-    fn are_we_inside_string(tokens: &Vec<JsonToken>) -> bool {
+    fn are_we_inside_string(tokens: &[JsonToken]) -> bool {
         if tokens.is_empty() {
             return false;
         }

--- a/chain/rust/src/plutus/serialization.rs
+++ b/chain/rust/src/plutus/serialization.rs
@@ -728,7 +728,7 @@ impl Deserialize for Redeemer {
         (|| -> Result<_, DeserializeError> {
             let (tag, tag_encoding) = (|| -> Result<_, DeserializeError> {
                 let initial_position = raw.as_mut_ref().stream_position().unwrap();
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (spend_value, spend_encoding) = raw.unsigned_integer_sz()?;
                     if spend_value != 0 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -738,15 +738,15 @@ impl Deserialize for Redeemer {
                         .into());
                     }
                     Ok(Some(spend_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(tag_encoding) => return Ok((RedeemerTag::Spend, tag_encoding)),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (mint_value, mint_encoding) = raw.unsigned_integer_sz()?;
                     if mint_value != 1 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -756,15 +756,15 @@ impl Deserialize for Redeemer {
                         .into());
                     }
                     Ok(Some(mint_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(tag_encoding) => return Ok((RedeemerTag::Mint, tag_encoding)),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (cert_value, cert_encoding) = raw.unsigned_integer_sz()?;
                     if cert_value != 2 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -774,15 +774,15 @@ impl Deserialize for Redeemer {
                         .into());
                     }
                     Ok(Some(cert_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(tag_encoding) => return Ok((RedeemerTag::Cert, tag_encoding)),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (reward_value, reward_encoding) = raw.unsigned_integer_sz()?;
                     if reward_value != 3 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -792,8 +792,8 @@ impl Deserialize for Redeemer {
                         .into());
                     }
                     Ok(Some(reward_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(tag_encoding) => return Ok((RedeemerTag::Reward, tag_encoding)),
                     Err(_) => raw
                         .as_mut_ref()
@@ -808,8 +808,8 @@ impl Deserialize for Redeemer {
             .map_err(|e| e.annotate("tag"))?;
             let (index, index_encoding) = raw
                 .unsigned_integer_sz()
-                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(Into::<DeserializeError>::into)
+                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(|e: DeserializeError| e.annotate("index"))?;
             let data =
                 PlutusData::deserialize(raw).map_err(|e: DeserializeError| e.annotate("data"))?;

--- a/chain/rust/src/serialization.rs
+++ b/chain/rust/src/serialization.rs
@@ -1794,10 +1794,12 @@ impl Deserialize for Script {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
             let len_encoding: LenEncoding = len.into();
-            let _read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 0 {
@@ -1824,8 +1826,8 @@ impl Deserialize for Script {
                     len_encoding,
                     tag_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("Native"));
@@ -1834,7 +1836,10 @@ impl Deserialize for Script {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 1 {
@@ -1861,8 +1866,8 @@ impl Deserialize for Script {
                     len_encoding,
                     tag_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("PlutusV1"));
@@ -1871,7 +1876,10 @@ impl Deserialize for Script {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 2 {
@@ -1898,8 +1906,8 @@ impl Deserialize for Script {
                     len_encoding,
                     tag_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("PlutusV2"));
@@ -1908,7 +1916,10 @@ impl Deserialize for Script {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 3 {
@@ -1935,8 +1946,8 @@ impl Deserialize for Script {
                     len_encoding,
                     tag_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("PlutusV3"));
@@ -1945,13 +1956,6 @@ impl Deserialize for Script {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "Script",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -2035,13 +2039,13 @@ impl Deserialize for UnitInterval {
         (|| -> Result<_, DeserializeError> {
             let (start, start_encoding) = raw
                 .unsigned_integer_sz()
-                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(Into::<DeserializeError>::into)
+                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(|e: DeserializeError| e.annotate("start"))?;
             let (end, end_encoding) = raw
                 .unsigned_integer_sz()
-                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(Into::<DeserializeError>::into)
+                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(|e: DeserializeError| e.annotate("end"))?;
             match len {
                 cbor_event::LenSz::Len(_, _) => (),

--- a/cip25/rust/src/utils.rs
+++ b/cip25/rust/src/utils.rs
@@ -334,7 +334,7 @@ impl Deserialize for CIP25LabelMetadata {
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
 
             // Try parsing V1
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 let mut label_metadata_v1_table = BTreeMap::new();
                 let mut label_metadata_v1_table_len = 0;
                 let label_metadata_v1_len = raw.map()?;
@@ -425,8 +425,8 @@ impl Deserialize for CIP25LabelMetadata {
                     }
                 }
                 Ok(label_metadata_v1_table)
-            })(raw)
-            {
+            })(raw);
+            match deser_variant {
                 Ok(label_metadata_v1) => {
                     // hand-edit: construct merged type
                     return Ok(Self {
@@ -441,7 +441,7 @@ impl Deserialize for CIP25LabelMetadata {
             };
 
             // Try paring V2
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 let len = raw.map()?;
                 let mut read_len = CBORReadLen::new(match len {
                     cbor_event::Len::Len(n) => cbor_event::LenSz::Len(n, cbor_event::Sz::canonical(n)),
@@ -611,8 +611,8 @@ impl Deserialize for CIP25LabelMetadata {
                 // hand-edit: expression only here, no Self wrapper
                 Ok(data)
             })(raw)
-            .map_err(|e| e.annotate("LabelMetadataV2"))
-            {
+            .map_err(|e| e.annotate("LabelMetadataV2"));
+            match deser_variant {
                 Ok(label_metadata_v2) => {
                     // hand-edit: construct merged type
                     return Ok(Self {

--- a/cip36/rust/src/serialization.rs
+++ b/cip36/rust/src/serialization.rs
@@ -134,7 +134,7 @@ impl Deserialize for CIP36DelegationDistribution {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
         (|| -> Result<_, DeserializeError> {
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 let mut weighted_arr = Vec::new();
                 let len = raw.array_sz()?;
                 let delegations_encoding = len.into();
@@ -149,8 +149,8 @@ impl Deserialize for CIP36DelegationDistribution {
                     weighted_arr.push(CIP36Delegation::deserialize(raw)?);
                 }
                 Ok((weighted_arr, delegations_encoding))
-            })(raw)
-            {
+            })(raw);
+            match deser_variant {
                 Ok((delegations, delegations_encoding)) => {
                     return Ok(Self::Weighted {
                         delegations,

--- a/multi-era/rust/src/allegra/serialization.rs
+++ b/multi-era/rust/src/allegra/serialization.rs
@@ -274,11 +274,22 @@ impl Deserialize for AllegraCertificate {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
-            let mut read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            let deser_variant: Result<_, DeserializeError> =
-                StakeRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret = StakeRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_registration) => return Ok(Self::StakeRegistration(stake_registration)),
                 Err(e) => {
@@ -288,8 +299,21 @@ impl Deserialize for AllegraCertificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                StakeDeregistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret =
+                    StakeDeregistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_deregistration) => {
                     return Ok(Self::StakeDeregistration(stake_deregistration))
@@ -301,8 +325,20 @@ impl Deserialize for AllegraCertificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                StakeDelegation::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = StakeDelegation::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(stake_delegation) => return Ok(Self::StakeDelegation(stake_delegation)),
                 Err(e) => {
@@ -312,8 +348,20 @@ impl Deserialize for AllegraCertificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                PoolRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(10)?;
+                read_len.finish()?;
+                let ret = PoolRegistration::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(pool_registration) => return Ok(Self::PoolRegistration(pool_registration)),
                 Err(e) => {
@@ -323,8 +371,20 @@ impl Deserialize for AllegraCertificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                PoolRetirement::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(3)?;
+                read_len.finish()?;
+                let ret = PoolRetirement::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(pool_retirement) => return Ok(Self::PoolRetirement(pool_retirement)),
                 Err(e) => {
@@ -334,8 +394,21 @@ impl Deserialize for AllegraCertificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                GenesisKeyDelegation::deserialize_as_embedded_group(raw, &mut read_len, len);
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(4)?;
+                read_len.finish()?;
+                let ret =
+                    GenesisKeyDelegation::deserialize_as_embedded_group(raw, &mut read_len, len);
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(genesis_key_delegation) => {
                     return Ok(Self::GenesisKeyDelegation(genesis_key_delegation))
@@ -347,12 +420,24 @@ impl Deserialize for AllegraCertificate {
                         .unwrap();
                 }
             };
-            let deser_variant: Result<_, DeserializeError> =
-                MoveInstantaneousRewardsCert::deserialize_as_embedded_group(
+            let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
+                let ret = MoveInstantaneousRewardsCert::deserialize_as_embedded_group(
                     raw,
                     &mut read_len,
                     len,
                 );
+                match len {
+                    cbor_event::LenSz::Len(_, _) => (),
+                    cbor_event::LenSz::Indefinite => match raw.special()? {
+                        cbor_event::Special::Break => (),
+                        _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                    },
+                }
+                ret
+            })(raw);
             match deser_variant {
                 Ok(move_instantaneous_rewards_cert) => {
                     return Ok(Self::MoveInstantaneousRewardsCert(
@@ -366,13 +451,6 @@ impl Deserialize for AllegraCertificate {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "AllegraCertificate",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -873,7 +951,7 @@ impl Deserialize for AllegraTransactionBody {
                             if fee.is_some() {
                                 return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
                             }
-                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into).map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc))).map_err(|e: DeserializeError| e.annotate("fee"))?;
                             fee = Some(tmp_fee);
                             fee_encoding = tmp_fee_encoding;
                             fee_key_encoding = Some(key_enc);
@@ -885,7 +963,7 @@ impl Deserialize for AllegraTransactionBody {
                             }
                             let (tmp_ttl, tmp_ttl_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("ttl"))?;
                             ttl = Some(tmp_ttl);
                             ttl_encoding = tmp_ttl_encoding;
@@ -976,7 +1054,7 @@ impl Deserialize for AllegraTransactionBody {
                             }
                             let (tmp_validity_interval_start, tmp_validity_interval_start_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("validity_interval_start"))?;
                             validity_interval_start = Some(tmp_validity_interval_start);
                             validity_interval_start_encoding = tmp_validity_interval_start_encoding;
@@ -1512,7 +1590,7 @@ impl Deserialize for MoveInstantaneousReward {
         (|| -> Result<_, DeserializeError> {
             let (pot, pot_encoding) = (|| -> Result<_, DeserializeError> {
                 let initial_position = raw.as_mut_ref().stream_position().unwrap();
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (reserve_value, reserve_encoding) = raw.unsigned_integer_sz()?;
                     if reserve_value != 0 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -1522,15 +1600,15 @@ impl Deserialize for MoveInstantaneousReward {
                         .into());
                     }
                     Ok(Some(reserve_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(pot_encoding) => return Ok((MIRPot::Reserve, pot_encoding)),
                     Err(_) => raw
                         .as_mut_ref()
                         .seek(SeekFrom::Start(initial_position))
                         .unwrap(),
                 };
-                match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                     let (treasury_value, treasury_encoding) = raw.unsigned_integer_sz()?;
                     if treasury_value != 1 {
                         return Err(DeserializeFailure::FixedValueMismatch {
@@ -1540,8 +1618,8 @@ impl Deserialize for MoveInstantaneousReward {
                         .into());
                     }
                     Ok(Some(treasury_encoding))
-                })(raw)
-                {
+                })(raw);
+                match deser_variant {
                     Ok(pot_encoding) => return Ok((MIRPot::Treasury, pot_encoding)),
                     Err(_) => raw
                         .as_mut_ref()

--- a/multi-era/rust/src/alonzo/serialization.rs
+++ b/multi-era/rust/src/alonzo/serialization.rs
@@ -1536,8 +1536,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("minfee_a"))?;
                             minfee_a = Some(tmp_minfee_a);
@@ -1553,8 +1553,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("minfee_b"))?;
                             minfee_b = Some(tmp_minfee_b);
@@ -1570,8 +1570,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_block_body_size"))?;
                             max_block_body_size = Some(tmp_max_block_body_size);
@@ -1587,8 +1587,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_transaction_size"))?;
                             max_transaction_size = Some(tmp_max_transaction_size);
@@ -1604,8 +1604,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_block_header_size"))?;
                             max_block_header_size = Some(tmp_max_block_header_size);
@@ -1621,8 +1621,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("key_deposit"))?;
                             key_deposit = Some(tmp_key_deposit);
@@ -1638,8 +1638,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("pool_deposit"))?;
                             pool_deposit = Some(tmp_pool_deposit);
@@ -1655,8 +1655,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("maximum_epoch"))?;
                             maximum_epoch = Some(tmp_maximum_epoch);
@@ -1672,8 +1672,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("n_opt"))?;
                             n_opt = Some(tmp_n_opt);
@@ -1768,8 +1768,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("min_pool_cost"))?;
                             min_pool_cost = Some(tmp_min_pool_cost);
@@ -1785,8 +1785,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("ada_per_utxo_byte"))?;
                             ada_per_utxo_byte = Some(tmp_ada_per_utxo_byte);
@@ -1856,8 +1856,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_value_size"))?;
                             max_value_size = Some(tmp_max_value_size);
@@ -1873,8 +1873,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("collateral_percentage"))?;
                             collateral_percentage = Some(tmp_collateral_percentage);
@@ -1890,8 +1890,8 @@ impl Deserialize for AlonzoProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_collateral_inputs"))?;
                             max_collateral_inputs = Some(tmp_max_collateral_inputs);
@@ -2765,7 +2765,7 @@ impl Deserialize for AlonzoTransactionBody {
                             if fee.is_some() {
                                 return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
                             }
-                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into).map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc))).map_err(|e: DeserializeError| e.annotate("fee"))?;
                             fee = Some(tmp_fee);
                             fee_encoding = tmp_fee_encoding;
                             fee_key_encoding = Some(key_enc);
@@ -2777,7 +2777,7 @@ impl Deserialize for AlonzoTransactionBody {
                             }
                             let (tmp_ttl, tmp_ttl_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("ttl"))?;
                             ttl = Some(tmp_ttl);
                             ttl_encoding = tmp_ttl_encoding;
@@ -2868,7 +2868,7 @@ impl Deserialize for AlonzoTransactionBody {
                             }
                             let (tmp_validity_interval_start, tmp_validity_interval_start_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("validity_interval_start"))?;
                             validity_interval_start = Some(tmp_validity_interval_start);
                             validity_interval_start_encoding = tmp_validity_interval_start_encoding;
@@ -3762,8 +3762,8 @@ impl Deserialize for AlonzoUpdate {
             .map_err(|e| e.annotate("proposed_protocol_parameter_updates"))?;
             let (epoch, epoch_encoding) = raw
                 .unsigned_integer_sz()
-                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(Into::<DeserializeError>::into)
+                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(|e: DeserializeError| e.annotate("epoch"))?;
             match len {
                 cbor_event::LenSz::Len(_, _) => (),

--- a/multi-era/rust/src/babbage/serialization.rs
+++ b/multi-era/rust/src/babbage/serialization.rs
@@ -1932,8 +1932,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("minfee_a"))?;
                             minfee_a = Some(tmp_minfee_a);
@@ -1949,8 +1949,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("minfee_b"))?;
                             minfee_b = Some(tmp_minfee_b);
@@ -1966,8 +1966,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_block_body_size"))?;
                             max_block_body_size = Some(tmp_max_block_body_size);
@@ -1983,8 +1983,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_transaction_size"))?;
                             max_transaction_size = Some(tmp_max_transaction_size);
@@ -2000,8 +2000,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_block_header_size"))?;
                             max_block_header_size = Some(tmp_max_block_header_size);
@@ -2017,8 +2017,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("key_deposit"))?;
                             key_deposit = Some(tmp_key_deposit);
@@ -2034,8 +2034,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("pool_deposit"))?;
                             pool_deposit = Some(tmp_pool_deposit);
@@ -2051,8 +2051,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("maximum_epoch"))?;
                             maximum_epoch = Some(tmp_maximum_epoch);
@@ -2068,8 +2068,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("n_opt"))?;
                             n_opt = Some(tmp_n_opt);
@@ -2137,8 +2137,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("min_pool_cost"))?;
                             min_pool_cost = Some(tmp_min_pool_cost);
@@ -2154,8 +2154,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("ada_per_utxo_byte"))?;
                             ada_per_utxo_byte = Some(tmp_ada_per_utxo_byte);
@@ -2225,8 +2225,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_value_size"))?;
                             max_value_size = Some(tmp_max_value_size);
@@ -2242,8 +2242,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("collateral_percentage"))?;
                             collateral_percentage = Some(tmp_collateral_percentage);
@@ -2259,8 +2259,8 @@ impl Deserialize for BabbageProtocolParamUpdate {
                                 (|| -> Result<_, DeserializeError> {
                                     read_len.read_elems(1)?;
                                     raw.unsigned_integer_sz()
-                                        .map(|(x, enc)| (x, Some(enc)))
                                         .map_err(Into::<DeserializeError>::into)
+                                        .map(|(x, enc)| (x, Some(enc)))
                                 })()
                                 .map_err(|e| e.annotate("max_collateral_inputs"))?;
                             max_collateral_inputs = Some(tmp_max_collateral_inputs);
@@ -2420,10 +2420,12 @@ impl Deserialize for BabbageScript {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array_sz()?;
             let len_encoding: LenEncoding = len.into();
-            let _read_len = CBORReadLen::new(len);
             let initial_position = raw.as_mut_ref().stream_position().unwrap();
             let mut errs = Vec::new();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 0 {
@@ -2450,8 +2452,8 @@ impl Deserialize for BabbageScript {
                     len_encoding,
                     tag_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("Native"));
@@ -2460,7 +2462,10 @@ impl Deserialize for BabbageScript {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 1 {
@@ -2487,8 +2492,8 @@ impl Deserialize for BabbageScript {
                     len_encoding,
                     tag_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("PlutusV1"));
@@ -2497,7 +2502,10 @@ impl Deserialize for BabbageScript {
                         .unwrap();
                 }
             };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+                let mut read_len = CBORReadLen::new(len);
+                read_len.read_elems(2)?;
+                read_len.finish()?;
                 let tag_encoding = (|| -> Result<_, DeserializeError> {
                     let (tag_value, tag_encoding) = raw.unsigned_integer_sz()?;
                     if tag_value != 2 {
@@ -2524,8 +2532,8 @@ impl Deserialize for BabbageScript {
                     len_encoding,
                     tag_encoding,
                 })
-            })(raw)
-            {
+            })(raw);
+            match variant_deser {
                 Ok(variant) => return Ok(variant),
                 Err(e) => {
                     errs.push(e.annotate("PlutusV2"));
@@ -2534,13 +2542,6 @@ impl Deserialize for BabbageScript {
                         .unwrap();
                 }
             };
-            match len {
-                cbor_event::LenSz::Len(_, _) => (),
-                cbor_event::LenSz::Indefinite => match raw.special()? {
-                    cbor_event::Special::Break => (),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
             Err(DeserializeError::new(
                 "BabbageScript",
                 DeserializeFailure::NoVariantMatchedWithCauses(errs),
@@ -3416,7 +3417,7 @@ impl Deserialize for BabbageTransactionBody {
                             if fee.is_some() {
                                 return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
                             }
-                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into).map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc))).map_err(|e: DeserializeError| e.annotate("fee"))?;
                             fee = Some(tmp_fee);
                             fee_encoding = tmp_fee_encoding;
                             fee_key_encoding = Some(key_enc);
@@ -3428,7 +3429,7 @@ impl Deserialize for BabbageTransactionBody {
                             }
                             let (tmp_ttl, tmp_ttl_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("ttl"))?;
                             ttl = Some(tmp_ttl);
                             ttl_encoding = tmp_ttl_encoding;
@@ -3519,7 +3520,7 @@ impl Deserialize for BabbageTransactionBody {
                             }
                             let (tmp_validity_interval_start, tmp_validity_interval_start_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("validity_interval_start"))?;
                             validity_interval_start = Some(tmp_validity_interval_start);
                             validity_interval_start_encoding = tmp_validity_interval_start_encoding;
@@ -3677,7 +3678,7 @@ impl Deserialize for BabbageTransactionBody {
                             }
                             let (tmp_total_collateral, tmp_total_collateral_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("total_collateral"))?;
                             total_collateral = Some(tmp_total_collateral);
                             total_collateral_encoding = tmp_total_collateral_encoding;
@@ -4568,8 +4569,8 @@ impl Deserialize for BabbageUpdate {
                 .map_err(|e| e.annotate("updates"))?;
             let (epoch, epoch_encoding) = raw
                 .unsigned_integer_sz()
-                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(Into::<DeserializeError>::into)
+                .map(|(x, enc)| (x, Some(enc)))
                 .map_err(|e: DeserializeError| e.annotate("epoch"))?;
             match len {
                 cbor_event::LenSz::Len(_, _) => (),

--- a/multi-era/rust/src/mary/serialization.rs
+++ b/multi-era/rust/src/mary/serialization.rs
@@ -801,7 +801,7 @@ impl Deserialize for MaryTransactionBody {
                             if fee.is_some() {
                                 return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
                             }
-                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into).map_err(|e: DeserializeError| e.annotate("fee"))?;
+                            let (tmp_fee, tmp_fee_encoding) = raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc))).map_err(|e: DeserializeError| e.annotate("fee"))?;
                             fee = Some(tmp_fee);
                             fee_encoding = tmp_fee_encoding;
                             fee_key_encoding = Some(key_enc);
@@ -813,7 +813,7 @@ impl Deserialize for MaryTransactionBody {
                             }
                             let (tmp_ttl, tmp_ttl_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("ttl"))?;
                             ttl = Some(tmp_ttl);
                             ttl_encoding = tmp_ttl_encoding;
@@ -904,7 +904,7 @@ impl Deserialize for MaryTransactionBody {
                             }
                             let (tmp_validity_interval_start, tmp_validity_interval_start_encoding) = (|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                raw.unsigned_integer_sz().map(|(x, enc)| (x, Some(enc))).map_err(Into::<DeserializeError>::into)
+                                raw.unsigned_integer_sz().map_err(Into::<DeserializeError>::into).map(|(x, enc)| (x, Some(enc)))
                             })().map_err(|e| e.annotate("validity_interval_start"))?;
                             validity_interval_start = Some(tmp_validity_interval_start);
                             validity_interval_start_encoding = tmp_validity_interval_start_encoding;

--- a/specs/conway/certs.cddl
+++ b/specs/conway/certs.cddl
@@ -23,15 +23,14 @@ stake_deregistration = (tag: 1, stake_credential)
 stake_delegation = (
     tag: 2,
     stake_credential,
-    ed25519_key_hash ; @name pool
+    pool: ed25519_key_hash
 )
 
 ; POOL
 pool_registration = (tag: 3, pool_params)
-pool_retirement = (tag: 4, ed25519_key_hash, epoch)
 pool_retirement = (
     tag: 4,
-    ed25519_key_hash, ; @name pool
+    pool: ed25519_key_hash,
     epoch
 )
 
@@ -43,10 +42,26 @@ pool_retirement = (
 reg_cert = (tag: 7, stake_credential, coin)
 unreg_cert = (tag: 8, stake_credential, coin)
 vote_deleg_cert = (tag: 9, stake_credential, d_rep)
-stake_vote_deleg_cert = (tag: 10, stake_credential, ed25519_key_hash, d_rep)
-stake_reg_deleg_cert = (tag: 11, stake_credential, ed25519_key_hash, coin)
+stake_vote_deleg_cert = (
+  tag: 10,
+  stake_credential,
+  pool: ed25519_key_hash,
+  d_rep
+)
+stake_reg_deleg_cert = (
+  tag: 11,
+  stake_credential,
+  pool: ed25519_key_hash,
+  coin
+)
 vote_reg_deleg_cert = (tag: 12, stake_credential, d_rep, coin)
-stake_vote_reg_deleg_cert = (tag: 13, stake_credential, ed25519_key_hash, d_rep, coin)
+stake_vote_reg_deleg_cert = (
+  tag: 13,
+  stake_credential,
+  pool: ed25519_key_hash,
+  d_rep,
+  coin
+)
 
 ; GOVCERT
 auth_committee_hot_cert = (14, committee_cold_credential, committee_hot_credential)
@@ -57,7 +72,7 @@ update_drep_cert = (18, drep_credential, anchor / null)
 
 d_rep = [
   ; @name key
-  0, ed25519_key_hash //
+  0, pool: ed25519_key_hash //
   ; @name script
   1, script_hash //
   ; @name always_abstain

--- a/specs/conway/governance.cddl
+++ b/specs/conway/governance.cddl
@@ -13,15 +13,16 @@ proposal_procedure =
   , anchor
   ]
 
-gov_action =
-  [ parameter_change_action
-  // hard_fork_initiation_action
-  // treasury_withdrawals_action
-  // no_confidence
-  // new_committee
-  // new_constitution
-  // 6 ; @name info_action
-  ]
+gov_action = [
+  parameter_change_action //
+  hard_fork_initiation_action //
+  treasury_withdrawals_action //
+  no_confidence //
+  new_committee //
+  new_constitution //
+  ; @name info_action
+  6
+]
 
 parameter_change_action = (tag: 0, gov_action_id / null, protocol_param_update)
 


### PR DESCRIPTION
Regen using Emurgo/cddl-codegen#225 to fix new clippy lint causing several open PRs to fail

This also includes some enum deserialization check improvements introduced in Emurgo/cddl-codegen#217

Also some minor updates to the .cddl spec to fix names in a few places