### PR TITLE
TX hash mismatch for non-canonical TXs

### DIFF
--- a/chain/rust/src/crypto/hash.rs
+++ b/chain/rust/src/crypto/hash.rs
@@ -17,7 +17,7 @@ pub fn hash_auxiliary_data(auxiliary_data: &AuxiliaryData) -> AuxiliaryDataHash 
 }
 
 pub fn hash_transaction(tx_body: &TransactionBody) -> TransactionHash {
-    TransactionHash::from(blake2b256(tx_body.to_canonical_cbor_bytes().as_ref()))
+    TransactionHash::from(blake2b256(tx_body.to_cbor_bytes().as_ref()))
 }
 
 pub fn hash_plutus_data(plutus_data: &PlutusData) -> DatumHash {

--- a/chain/rust/src/transaction/mod.rs
+++ b/chain/rust/src/transaction/mod.rs
@@ -24,8 +24,7 @@ use cbor_encodings::{
     TransactionWitnessSetEncoding,
 };
 use cml_core::ordered_hash_map::OrderedHashMap;
-use cml_core::serialization::{LenEncoding, Serialize, StringEncoding};
-use cml_crypto::blake2b256;
+use cml_core::serialization::{LenEncoding, StringEncoding};
 use std::collections::BTreeMap;
 
 #[derive(
@@ -375,10 +374,6 @@ impl TransactionBody {
             donation: None,
             encodings: None,
         }
-    }
-
-    pub fn hash(&self) -> [u8; 32] {
-        blake2b256(&self.to_cbor_bytes())
     }
 }
 

--- a/chain/rust/src/transaction/utils.rs
+++ b/chain/rust/src/transaction/utils.rs
@@ -6,9 +6,17 @@ use crate::{
     transaction::{DatumOption, ScriptRef, TransactionOutput},
     Value,
 };
-use cml_crypto::{DatumHash, Ed25519KeyHash};
+use cml_crypto::{DatumHash, Ed25519KeyHash, TransactionHash};
 
-use super::{AlonzoFormatTxOut, ConwayFormatTxOut, NativeScript, TransactionWitnessSet};
+use super::{
+    AlonzoFormatTxOut, ConwayFormatTxOut, NativeScript, TransactionBody, TransactionWitnessSet,
+};
+
+impl TransactionBody {
+    pub fn hash(&self) -> TransactionHash {
+        crate::crypto::hash::hash_transaction(self)
+    }
+}
 
 impl TransactionOutput {
     pub fn new(

--- a/multi-era/rust/src/allegra/mod.rs
+++ b/multi-era/rust/src/allegra/mod.rs
@@ -23,9 +23,8 @@ use cml_chain::transaction::{NativeScript, TransactionInput};
 use cml_chain::Withdrawals;
 use cml_chain::{DeltaCoin, LenEncoding, TransactionIndex};
 use cml_core::ordered_hash_map::OrderedHashMap;
-use cml_core::serialization::Serialize;
 use cml_core::Epoch;
-use cml_crypto::{blake2b256, Ed25519KeyHash, GenesisDelegateHash, GenesisHash, VRFKeyHash};
+use cml_crypto::{Ed25519KeyHash, GenesisDelegateHash, GenesisHash, VRFKeyHash};
 use std::collections::BTreeMap;
 
 use self::cbor_encodings::{MoveInstantaneousRewardEncoding, MoveInstantaneousRewardsCertEncoding};
@@ -187,10 +186,6 @@ impl AllegraTransactionBody {
             validity_interval_start: None,
             encodings: None,
         }
-    }
-
-    pub fn hash(&self) -> [u8; 32] {
-        blake2b256(&self.to_cbor_bytes())
     }
 }
 

--- a/multi-era/rust/src/allegra/utils.rs
+++ b/multi-era/rust/src/allegra/utils.rs
@@ -1,6 +1,15 @@
 use cml_chain::{auxdata::AuxiliaryData, transaction::TransactionWitnessSet};
 
-use super::{AllegraAuxiliaryData, AllegraTransactionWitnessSet};
+use super::{AllegraAuxiliaryData, AllegraTransactionBody, AllegraTransactionWitnessSet};
+
+use cml_core::serialization::Serialize;
+use cml_crypto::{blake2b256, TransactionHash};
+
+impl AllegraTransactionBody {
+    pub fn hash(&self) -> TransactionHash {
+        blake2b256(&self.to_cbor_bytes()).into()
+    }
+}
 
 impl From<AllegraAuxiliaryData> for AuxiliaryData {
     fn from(aux: AllegraAuxiliaryData) -> Self {

--- a/multi-era/rust/src/alonzo/mod.rs
+++ b/multi-era/rust/src/alonzo/mod.rs
@@ -24,8 +24,6 @@ use cml_chain::transaction::{AlonzoFormatTxOut, NativeScript, RequiredSigners, T
 use cml_chain::TransactionIndex;
 use cml_chain::{Epoch, NetworkId, Rational, UnitInterval, Withdrawals};
 use cml_core::ordered_hash_map::OrderedHashMap;
-use cml_core::serialization::Serialize;
-use cml_crypto::blake2b256;
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
@@ -258,10 +256,6 @@ impl AlonzoTransactionBody {
             network_id: None,
             encodings: None,
         }
-    }
-
-    pub fn hash(&self) -> [u8; 32] {
-        blake2b256(&self.to_cbor_bytes())
     }
 }
 

--- a/multi-era/rust/src/alonzo/utils.rs
+++ b/multi-era/rust/src/alonzo/utils.rs
@@ -3,7 +3,16 @@ use cml_chain::{
     transaction::TransactionWitnessSet,
 };
 
-use super::{AlonzoAuxiliaryData, AlonzoTransactionWitnessSet};
+use super::{AlonzoAuxiliaryData, AlonzoTransactionBody, AlonzoTransactionWitnessSet};
+
+use cml_core::serialization::Serialize;
+use cml_crypto::{blake2b256, TransactionHash};
+
+impl AlonzoTransactionBody {
+    pub fn hash(&self) -> TransactionHash {
+        blake2b256(&self.to_cbor_bytes()).into()
+    }
+}
 
 impl From<AlonzoAuxiliaryData> for AuxiliaryData {
     fn from(aux: AlonzoAuxiliaryData) -> Self {

--- a/multi-era/rust/src/babbage/mod.rs
+++ b/multi-era/rust/src/babbage/mod.rs
@@ -28,10 +28,9 @@ use cml_chain::transaction::{
 use cml_chain::{Epoch, NetworkId, Rational, UnitInterval, Withdrawals};
 
 use cml_core::ordered_hash_map::OrderedHashMap;
-use cml_core::serialization::{LenEncoding, Serialize};
+use cml_core::serialization::LenEncoding;
 use cml_core::{Int, TransactionIndex};
 
-use cml_crypto::blake2b256;
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
@@ -355,10 +354,6 @@ impl BabbageTransactionBody {
             reference_inputs: None,
             encodings: None,
         }
-    }
-
-    pub fn hash(&self) -> [u8; 32] {
-        blake2b256(&self.to_cbor_bytes())
     }
 }
 

--- a/multi-era/rust/src/babbage/utils.rs
+++ b/multi-era/rust/src/babbage/utils.rs
@@ -4,7 +4,18 @@ use cml_chain::{
     Script,
 };
 
-use super::{BabbageAuxiliaryData, BabbageScript, BabbageTransactionWitnessSet};
+use super::{
+    BabbageAuxiliaryData, BabbageScript, BabbageTransactionBody, BabbageTransactionWitnessSet,
+};
+
+use cml_core::serialization::Serialize;
+use cml_crypto::{blake2b256, TransactionHash};
+
+impl BabbageTransactionBody {
+    pub fn hash(&self) -> TransactionHash {
+        blake2b256(&self.to_cbor_bytes()).into()
+    }
+}
 
 impl From<BabbageScript> for Script {
     fn from(script: BabbageScript) -> Script {

--- a/multi-era/rust/src/byron/transaction/mod.rs
+++ b/multi-era/rust/src/byron/transaction/mod.rs
@@ -2,12 +2,11 @@
 // https://github.com/dcSpark/cddl-codegen
 
 pub mod serialization;
+pub mod utils;
 
 use crate::byron::{Blake2b256, ByronPubKey, ByronSignature, ByronTxId};
 
 use cml_chain::byron::ByronTxOut;
-use cml_core::serialization::ToBytes;
-use cml_crypto::blake2b256;
 use std::collections::BTreeMap;
 
 use super::ByronAny;
@@ -121,10 +120,6 @@ impl ByronTx {
             outputs,
             attrs,
         }
-    }
-
-    pub fn hash(&self) -> [u8; 32] {
-        blake2b256(&self.to_bytes())
     }
 }
 

--- a/multi-era/rust/src/byron/transaction/utils.rs
+++ b/multi-era/rust/src/byron/transaction/utils.rs
@@ -1,0 +1,9 @@
+use super::ByronTx;
+use cml_core::serialization::ToBytes;
+use cml_crypto::{blake2b256, TransactionHash};
+
+impl ByronTx {
+    pub fn hash(&self) -> TransactionHash {
+        blake2b256(&self.to_bytes()).into()
+    }
+}

--- a/multi-era/rust/src/mary/mod.rs
+++ b/multi-era/rust/src/mary/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod cbor_encodings;
 pub mod serialization;
+pub mod utils;
 
 use crate::allegra::{AllegraAuxiliaryData, AllegraCertificate, AllegraTransactionWitnessSet};
 use crate::shelley::{ShelleyHeader, ShelleyUpdate};
@@ -15,8 +16,6 @@ use cml_chain::transaction::TransactionInput;
 use cml_chain::TransactionIndex;
 use cml_chain::Withdrawals;
 use cml_core::ordered_hash_map::OrderedHashMap;
-use cml_core::serialization::Serialize;
-use cml_crypto::blake2b256;
 use std::collections::BTreeMap;
 
 use self::cbor_encodings::MaryTransactionOutputEncoding;
@@ -107,10 +106,6 @@ impl MaryTransactionBody {
             mint: None,
             encodings: None,
         }
-    }
-
-    pub fn hash(&self) -> [u8; 32] {
-        blake2b256(&self.to_cbor_bytes())
     }
 }
 

--- a/multi-era/rust/src/mary/utils.rs
+++ b/multi-era/rust/src/mary/utils.rs
@@ -1,0 +1,9 @@
+use super::MaryTransactionBody;
+use cml_core::serialization::Serialize;
+use cml_crypto::{blake2b256, TransactionHash};
+
+impl MaryTransactionBody {
+    pub fn hash(&self) -> TransactionHash {
+        blake2b256(&self.to_cbor_bytes()).into()
+    }
+}

--- a/multi-era/rust/src/shelley/mod.rs
+++ b/multi-era/rust/src/shelley/mod.rs
@@ -26,9 +26,8 @@ use cml_chain::crypto::{
 use cml_chain::transaction::TransactionInput;
 use cml_chain::{Epoch, LenEncoding, Rational, UnitInterval, Withdrawals};
 use cml_core::ordered_hash_map::OrderedHashMap;
-use cml_core::serialization::Serialize;
 use cml_core::TransactionIndex;
-use cml_crypto::{blake2b256, GenesisDelegateHash, VRFKeyHash};
+use cml_crypto::{GenesisDelegateHash, VRFKeyHash};
 use std::collections::BTreeMap;
 
 use crate::allegra::MIRPot;
@@ -471,10 +470,6 @@ impl ShelleyTransactionBody {
             auxiliary_data_hash: None,
             encodings: None,
         }
-    }
-
-    pub fn hash(&self) -> [u8; 32] {
-        blake2b256(&self.to_cbor_bytes())
     }
 }
 

--- a/multi-era/rust/src/shelley/utils.rs
+++ b/multi-era/rust/src/shelley/utils.rs
@@ -1,6 +1,15 @@
 use cml_chain::transaction::{NativeScript, TransactionWitnessSet};
 
-use super::{MultisigScript, ShelleyTransactionWitnessSet};
+use super::{MultisigScript, ShelleyTransactionBody, ShelleyTransactionWitnessSet};
+
+use cml_core::serialization::Serialize;
+use cml_crypto::{blake2b256, TransactionHash};
+
+impl ShelleyTransactionBody {
+    pub fn hash(&self) -> TransactionHash {
+        blake2b256(&self.to_cbor_bytes()).into()
+    }
+}
 
 impl From<ShelleyTransactionWitnessSet> for TransactionWitnessSet {
     fn from(wits: ShelleyTransactionWitnessSet) -> Self {

--- a/multi-era/rust/src/utils.rs
+++ b/multi-era/rust/src/utils.rs
@@ -782,7 +782,7 @@ impl MultiEraTransactionBody {
         }
     }
 
-    pub fn hash(&self) -> [u8; 32] {
+    pub fn hash(&self) -> TransactionHash {
         match self {
             MultiEraTransactionBody::Byron(tx) => tx.hash(),
             MultiEraTransactionBody::Shelley(tx) => tx.hash(),


### PR DESCRIPTION
This only concerns the free-floating `hash_transaction()`.

Fixes #314

Use `TransactionBody` instead of of [u8; 32] to be consistent with
`hash_transaction()`.

Moves all the functions that were added directly to `mod.rs` in https://github.com/dcSpark/cardano-multiplatform-lib/pull/298 files to
`utils.rs` files where they should be since they aren't auto-generated.