### PR TITLE
wasm-bindgen: upgrade to 0.2.87 and remove serde-deserialize feature

### DIFF
--- a/chain/rust/Cargo.toml
+++ b/chain/rust/Cargo.toml
@@ -52,7 +52,7 @@ unicode-segmentation = "1.10.1"
 
 # wasm
 #[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }
 #rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 #js-sys = "=0.3.59"
 

--- a/chain/rust/Cargo.toml
+++ b/chain/rust/Cargo.toml
@@ -52,7 +52,7 @@ unicode-segmentation = "1.10.1"
 
 # wasm
 #[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }
 #rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 #js-sys = "=0.3.59"
 

--- a/chain/wasm/Cargo.toml
+++ b/chain/wasm/Cargo.toml
@@ -22,7 +22,7 @@ cml-crypto = { path = "../../crypto/rust", version = "5.3.1" }
 cml-crypto-wasm = { path = "../../crypto/wasm", version = "5.3.1" }
 cbor_event = "2.4.0"
 hex = "0.4.0"
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"

--- a/chain/wasm/Cargo.toml
+++ b/chain/wasm/Cargo.toml
@@ -22,7 +22,7 @@ cml-crypto = { path = "../../crypto/rust", version = "5.3.1" }
 cml-crypto-wasm = { path = "../../crypto/wasm", version = "5.3.1" }
 cbor_event = "2.4.0"
 hex = "0.4.0"
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"

--- a/cip25/rust/Cargo.toml
+++ b/cip25/rust/Cargo.toml
@@ -24,4 +24,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.37"
 # for enums
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }

--- a/cip25/rust/Cargo.toml
+++ b/cip25/rust/Cargo.toml
@@ -24,4 +24,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.37"
 # for enums
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }

--- a/cip25/wasm/Cargo.toml
+++ b/cip25/wasm/Cargo.toml
@@ -24,4 +24,4 @@ hex = "0.4.0"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }

--- a/cip25/wasm/Cargo.toml
+++ b/cip25/wasm/Cargo.toml
@@ -24,4 +24,4 @@ hex = "0.4.0"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }

--- a/cip36/wasm/Cargo.toml
+++ b/cip36/wasm/Cargo.toml
@@ -23,7 +23,7 @@ cml-core = { path = "../../core/rust", version = "5.3.1" }
 cml-core-wasm = { path = "../../core/wasm", version = "5.3.1" }
 cbor_event = "2.2.0"
 hex = "0.4.0"
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"

--- a/cip36/wasm/Cargo.toml
+++ b/cip36/wasm/Cargo.toml
@@ -23,7 +23,7 @@ cml-core = { path = "../../core/rust", version = "5.3.1" }
 cml-core-wasm = { path = "../../core/wasm", version = "5.3.1" }
 cbor_event = "2.2.0"
 hex = "0.4.0"
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"

--- a/cml/wasm/Cargo.toml
+++ b/cml/wasm/Cargo.toml
@@ -23,4 +23,4 @@ hex = "0.4.0"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"
-wasm-bindgen = { version = "0.2", features=["serde-serialize"] }
+wasm-bindgen = { version = "0.2" }

--- a/cml/wasm/Cargo.toml
+++ b/cml/wasm/Cargo.toml
@@ -23,4 +23,4 @@ hex = "0.4.0"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = { version = "=0.2.87" }

--- a/cml/wasm/Cargo.toml
+++ b/cml/wasm/Cargo.toml
@@ -23,4 +23,4 @@ hex = "0.4.0"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -50,7 +50,7 @@ cfg-if = "1"
 
 # wasm
 #[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }
 #rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 #js-sys = "=0.3.59"
 

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -24,7 +24,7 @@ schemars = "0.8.8"
 bech32 = "0.7.2"
 hex = "0.4.0"
 itertools = "0.10.1"
-getrandom = { version = "0.2.3", features = ["js"] }
+getrandom = { version = "0.2.3" }
 rand = "0.8.5"
 fraction = "0.10.0"
 base64 = "0.13"
@@ -50,7 +50,7 @@ cfg-if = "1"
 
 # wasm
 #[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }
 #rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 #js-sys = "=0.3.59"
 

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -24,7 +24,7 @@ schemars = "0.8.8"
 bech32 = "0.7.2"
 hex = "0.4.0"
 itertools = "0.10.1"
-getrandom = { version = "0.2.3" }
+getrandom = { version = "0.2.3", features = ["js"] }
 rand = "0.8.5"
 fraction = "0.10.0"
 base64 = "0.13"

--- a/core/wasm/Cargo.toml
+++ b/core/wasm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 cml-core = { path = "../rust", version = "5.3.1" }
 cbor_event = "2.2.0"
 hex = "0.4.0"
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"

--- a/core/wasm/Cargo.toml
+++ b/core/wasm/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 cml-core = { path = "../rust", version = "5.3.1" }
 cbor_event = "2.2.0"
 hex = "0.4.0"
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"

--- a/crypto/wasm/Cargo.toml
+++ b/crypto/wasm/Cargo.toml
@@ -16,6 +16,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 cml-crypto = { path = "../rust", version = "5.3.1" }
 cbor_event = "2.2.0"
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"

--- a/crypto/wasm/Cargo.toml
+++ b/crypto/wasm/Cargo.toml
@@ -16,6 +16,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 cml-crypto = { path = "../rust", version = "5.3.1" }
 cbor_event = "2.2.0"
-wasm-bindgen = { version = "=0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.87" }
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"

--- a/multi-era/rust/Cargo.toml
+++ b/multi-era/rust/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 schemars = "0.8.8"
-wasm-bindgen = { version = "0.2", features=["serde-serialize"] }
+wasm-bindgen = { version = "0.2" }
 
 # only for declaring hash types
 bech32 = "0.7.2"

--- a/multi-era/rust/Cargo.toml
+++ b/multi-era/rust/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 schemars = "0.8.8"
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = { version = "=0.2.87" }
 
 # only for declaring hash types
 bech32 = "0.7.2"

--- a/multi-era/rust/Cargo.toml
+++ b/multi-era/rust/Cargo.toml
@@ -23,7 +23,7 @@ derivative = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 schemars = "0.8.8"
-wasm-bindgen = { version = "=0.2.87" }
+wasm-bindgen = { version = "0.2.87" }
 
 # only for declaring hash types
 bech32 = "0.7.2"

--- a/multi-era/wasm/Cargo.toml
+++ b/multi-era/wasm/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4.0"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"
-wasm-bindgen = { version = "0.2", features=["serde-serialize"] }
+wasm-bindgen = { version = "0.2" }
 # not actual multi-era dependencies but we re-export these for the wasm builds
 cml-cip25-wasm = { path = "../../cip25/wasm", version = "5.3.1" }
 cml-cip36-wasm = { path = "../../cip36/wasm", version = "5.3.1" }

--- a/multi-era/wasm/Cargo.toml
+++ b/multi-era/wasm/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4.0"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
 serde-wasm-bindgen = "0.4.5"
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = { version = "0.2.87" }
 # not actual multi-era dependencies but we re-export these for the wasm builds
 cml-cip25-wasm = { path = "../../cip25/wasm", version = "5.3.1" }
 cml-cip36-wasm = { path = "../../cip36/wasm", version = "5.3.1" }


### PR DESCRIPTION
Removes the deprecated serde-serialize feature (which seems unused, but I'm not a 100% sure). Also upgrades the wasm-bindgen version. I'm actually not sure if the version pinning is needed for some reason, but this is the minimum version I needed to add this as a dependency in the milkomeda bridge.