### PR TITLE
Move RawBytesEncoding and standardize use

### DIFF
--- a/chain/rust/src/assets/mod.rs
+++ b/chain/rust/src/assets/mod.rs
@@ -12,6 +12,7 @@ use cml_core::error::*;
 
 use std::convert::TryFrom;
 
+/// Use TryFrom<&str> / TryInto<&str> for utf8 text conversion and RawBytesEncoding for direct bytes access
 #[derive(Clone, Debug, derivative::Derivative)]
 #[derivative(Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct AssetName {
@@ -26,10 +27,6 @@ pub struct AssetName {
 }
 
 impl AssetName {
-    pub fn get(&self) -> &Vec<u8> {
-        &self.inner
-    }
-
     pub fn new(inner: Vec<u8>) -> Result<Self, DeserializeError> {
         if inner.len() > 32 {
             return Err(DeserializeError::new(

--- a/chain/rust/src/assets/utils.rs
+++ b/chain/rust/src/assets/utils.rs
@@ -51,7 +51,17 @@ impl<'a> TryInto<&'a str> for &'a AssetName {
     type Error = std::str::Utf8Error;
 
     fn try_into(self) -> Result<&'a str, Self::Error> {
-        std::str::from_utf8(self.get())
+        std::str::from_utf8(self.to_raw_bytes())
+    }
+}
+
+impl RawBytesEncoding for AssetName {
+    fn to_raw_bytes(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Result<Self, DeserializeError> {
+        Self::new(bytes.to_vec())
     }
 }
 
@@ -71,7 +81,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for AssetBundle<T> {
         for (pid, assets) in self.0.iter() {
             let pid_hex = hex::encode(pid.to_raw_bytes());
             for (an, val) in assets.iter() {
-                let an_hex = hex::encode(an.get());
+                let an_hex = hex::encode(an.to_raw_bytes());
                 let an_name = if an_hex.len() > 8 {
                     format!(
                         "{}..{}",

--- a/chain/rust/src/genesis/byron/parse.rs
+++ b/chain/rust/src/genesis/byron/parse.rs
@@ -3,6 +3,7 @@ use base64::{
     Engine,
 };
 use cbor_event::cbor;
+use cml_core::DeserializeError;
 use cml_crypto::{CryptoError, RawBytesEncoding};
 use serde_json;
 use std::collections::BTreeMap;
@@ -29,6 +30,8 @@ pub enum GenesisJSONError {
     Serde(#[from] serde_json::Error),
     #[error("Crypto: {0:?}")]
     CryptoError(#[from] CryptoError),
+    #[error("Deserialize: {0:?}")]
+    DeserializeError(#[from] DeserializeError),
     #[error("Base64: {0:?}")]
     Base64(#[from] base64::DecodeError),
     #[error("ParseInt: {0:?}")]

--- a/chain/rust/src/plutus/mod.rs
+++ b/chain/rust/src/plutus/mod.rs
@@ -244,10 +244,6 @@ pub struct PlutusV1Script {
 }
 
 impl PlutusV1Script {
-    pub fn get(&self) -> &Vec<u8> {
-        &self.inner
-    }
-
     pub fn new(inner: Vec<u8>) -> Self {
         Self {
             inner,
@@ -317,10 +313,6 @@ pub struct PlutusV2Script {
 }
 
 impl PlutusV2Script {
-    pub fn get(&self) -> &Vec<u8> {
-        &self.inner
-    }
-
     pub fn new(inner: Vec<u8>) -> Self {
         Self {
             inner,
@@ -390,10 +382,6 @@ pub struct PlutusV3Script {
 }
 
 impl PlutusV3Script {
-    pub fn get(&self) -> &Vec<u8> {
-        &self.inner
-    }
-
     pub fn new(inner: Vec<u8>) -> Self {
         Self {
             inner,

--- a/chain/rust/src/plutus/utils.rs
+++ b/chain/rust/src/plutus/utils.rs
@@ -452,19 +452,49 @@ impl From<PlutusV3Script> for PlutusScript {
 
 impl PlutusV1Script {
     pub fn hash(&self) -> ScriptHash {
-        hash_script(ScriptHashNamespace::PlutusV1, self.get())
+        hash_script(ScriptHashNamespace::PlutusV1, self.to_raw_bytes())
     }
 }
 
 impl PlutusV2Script {
     pub fn hash(&self) -> ScriptHash {
-        hash_script(ScriptHashNamespace::PlutusV2, self.get())
+        hash_script(ScriptHashNamespace::PlutusV2, self.to_raw_bytes())
     }
 }
 
 impl PlutusV3Script {
     pub fn hash(&self) -> ScriptHash {
-        hash_script(ScriptHashNamespace::PlutusV3, self.get())
+        hash_script(ScriptHashNamespace::PlutusV3, self.to_raw_bytes())
+    }
+}
+
+impl RawBytesEncoding for PlutusV1Script {
+    fn to_raw_bytes(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Result<Self, DeserializeError> {
+        Ok(Self::new(bytes.to_vec()))
+    }
+}
+
+impl RawBytesEncoding for PlutusV2Script {
+    fn to_raw_bytes(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Result<Self, DeserializeError> {
+        Ok(Self::new(bytes.to_vec()))
+    }
+}
+
+impl RawBytesEncoding for PlutusV3Script {
+    fn to_raw_bytes(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Result<Self, DeserializeError> {
+        Ok(Self::new(bytes.to_vec()))
     }
 }
 

--- a/chain/wasm/src/assets/mod.rs
+++ b/chain/wasm/src/assets/mod.rs
@@ -18,10 +18,3 @@ pub struct AssetName(cml_chain::assets::AssetName);
 impl_wasm_cbor_json_api!(AssetName);
 
 impl_wasm_conversions!(cml_chain::assets::AssetName, AssetName);
-
-#[wasm_bindgen]
-impl AssetName {
-    pub fn get(&self) -> Vec<u8> {
-        self.0.get().clone()
-    }
-}

--- a/chain/wasm/src/assets/utils.rs
+++ b/chain/wasm/src/assets/utils.rs
@@ -6,7 +6,9 @@ use std::{
 use crate::{assets::AssetName, AssetNameList, MapAssetNameToNonZeroInt64, PolicyId, PolicyIdList};
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
 
-use cml_core_wasm::{impl_wasm_cbor_json_api, impl_wasm_conversions, impl_wasm_map};
+use cml_core_wasm::{
+    impl_raw_bytes_api, impl_wasm_cbor_json_api, impl_wasm_conversions, impl_wasm_map,
+};
 
 use super::Coin;
 
@@ -25,15 +27,6 @@ impl_wasm_map!(
 
 #[wasm_bindgen]
 impl AssetName {
-    /**
-     * Create an AssetName from raw bytes. 64 byte maximum.
-     */
-    pub fn from_bytes(bytes: Vec<u8>) -> Result<AssetName, JsError> {
-        cml_chain::assets::AssetName::try_from(bytes)
-            .map(Into::into)
-            .map_err(Into::into)
-    }
-
     /**
      * Create an AssetName from utf8 string. 64 byte (not char!) maximum.
      */
@@ -54,6 +47,8 @@ impl AssetName {
             .map_err(Into::into)
     }
 }
+
+impl_raw_bytes_api!(cml_chain::assets::AssetName, AssetName);
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]

--- a/chain/wasm/src/plutus/mod.rs
+++ b/chain/wasm/src/plutus/mod.rs
@@ -224,13 +224,6 @@ impl_wasm_cbor_json_api!(PlutusV1Script);
 
 impl_wasm_conversions!(cml_chain::plutus::PlutusV1Script, PlutusV1Script);
 
-#[wasm_bindgen]
-impl PlutusV1Script {
-    pub fn get(&self) -> Vec<u8> {
-        self.0.get().clone()
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PlutusV2Script(cml_chain::plutus::PlutusV2Script);
@@ -239,13 +232,6 @@ impl_wasm_cbor_json_api!(PlutusV2Script);
 
 impl_wasm_conversions!(cml_chain::plutus::PlutusV2Script, PlutusV2Script);
 
-#[wasm_bindgen]
-impl PlutusV2Script {
-    pub fn get(&self) -> Vec<u8> {
-        self.0.get().clone()
-    }
-}
-
 #[derive(Clone, Debug)]
 #[wasm_bindgen]
 pub struct PlutusV3Script(cml_chain::plutus::PlutusV3Script);
@@ -253,13 +239,6 @@ pub struct PlutusV3Script(cml_chain::plutus::PlutusV3Script);
 impl_wasm_cbor_json_api!(PlutusV3Script);
 
 impl_wasm_conversions!(cml_chain::plutus::PlutusV3Script, PlutusV3Script);
-
-#[wasm_bindgen]
-impl PlutusV3Script {
-    pub fn get(&self) -> Vec<u8> {
-        self.0.get().clone()
-    }
-}
 
 #[derive(Clone, Debug)]
 #[wasm_bindgen]

--- a/chain/wasm/src/plutus/utils.rs
+++ b/chain/wasm/src/plutus/utils.rs
@@ -3,7 +3,9 @@ use crate::{
     LegacyRedeemerList, PlutusDataList,
 };
 use cml_chain::plutus::Language;
-use cml_core_wasm::{impl_wasm_cbor_api, impl_wasm_cbor_json_api, impl_wasm_conversions};
+use cml_core_wasm::{
+    impl_raw_bytes_api, impl_wasm_cbor_api, impl_wasm_cbor_json_api, impl_wasm_conversions,
+};
 use cml_crypto_wasm::ScriptHash;
 use wasm_bindgen::prelude::{wasm_bindgen, JsError, JsValue};
 
@@ -151,6 +153,19 @@ impl PlutusV2Script {
         self.0.hash().into()
     }
 }
+
+#[wasm_bindgen]
+impl PlutusV3Script {
+    pub fn hash(&self) -> ScriptHash {
+        self.0.hash().into()
+    }
+}
+
+impl_raw_bytes_api!(cml_chain::plutus::PlutusV1Script, PlutusV1Script);
+
+impl_raw_bytes_api!(cml_chain::plutus::PlutusV2Script, PlutusV2Script);
+
+impl_raw_bytes_api!(cml_chain::plutus::PlutusV3Script, PlutusV3Script);
 
 #[wasm_bindgen]
 impl Redeemers {

--- a/core/rust/src/serialization.rs
+++ b/core/rust/src/serialization.rs
@@ -288,3 +288,24 @@ impl<T: Deserialize> FromBytes for T {
         Self::deserialize(&mut raw).map_err(Into::into)
     }
 }
+pub trait RawBytesEncoding {
+    fn to_raw_bytes(&self) -> &[u8];
+
+    fn from_raw_bytes(bytes: &[u8]) -> Result<Self, DeserializeError>
+    where
+        Self: Sized;
+
+    fn to_raw_hex(&self) -> String {
+        hex::encode(self.to_raw_bytes())
+    }
+
+    fn from_raw_hex(hex_str: &str) -> Result<Self, DeserializeError>
+    where
+        Self: Sized,
+    {
+        let bytes = hex::decode(hex_str).map_err(|e| {
+            DeserializeError::from(DeserializeFailure::InvalidStructure(Box::new(e)))
+        })?;
+        Self::from_raw_bytes(bytes.as_ref())
+    }
+}

--- a/core/wasm/src/lib.rs
+++ b/core/wasm/src/lib.rs
@@ -2,6 +2,9 @@ use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 use cml_core::serialization::{Deserialize, Serialize};
 
+// re-export to make macros easier to use
+pub use cml_core::serialization::RawBytesEncoding;
+
 #[macro_use]
 pub mod wasm_wrappers;
 

--- a/core/wasm/src/wasm_wrappers.rs
+++ b/core/wasm/src/wasm_wrappers.rs
@@ -550,3 +550,46 @@ macro_rules! impl_wasm_json_api {
         }
     };
 }
+
+#[macro_export]
+macro_rules! impl_raw_bytes_api {
+    ($rust:ty, $wasm:ident) => {
+        #[wasm_bindgen]
+        impl $wasm {
+            /**
+             * Direct raw bytes without any CBOR structure
+             */
+            pub fn to_raw_bytes(&self) -> Vec<u8> {
+                use cml_core_wasm::RawBytesEncoding;
+                self.0.to_raw_bytes().to_vec()
+            }
+
+            /**
+             * Parse from the direct raw bytes, without any CBOR structure
+             */
+            pub fn from_raw_bytes(bytes: &[u8]) -> Result<$wasm, wasm_bindgen::JsError> {
+                use cml_core_wasm::RawBytesEncoding;
+                <$rust>::from_raw_bytes(bytes).map(Self).map_err(Into::into)
+            }
+
+            /**
+             * Direct raw bytes without any CBOR structure, as a hex-encoded string
+             */
+            pub fn to_hex(&self) -> String {
+                use cml_core_wasm::RawBytesEncoding;
+                self.0.to_raw_hex()
+            }
+
+            /**
+             * Parse from a hex string of the direct raw bytes, without any CBOR structure
+             */
+            pub fn from_hex(input: &str) -> Result<$wasm, wasm_bindgen::JsError> {
+                use cml_core_wasm::RawBytesEncoding;
+                <$rust>::from_raw_hex(input)
+                    .map(Into::into)
+                    .map(Self)
+                    .map_err(Into::into)
+            }
+        }
+    };
+}

--- a/crypto/wasm/Cargo.toml
+++ b/crypto/wasm/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["cardano"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+cml-core-wasm = { path = "../../core/wasm", version = "5.3.1" }
 cml-crypto = { path = "../rust", version = "5.3.1" }
 cbor_event = "2.2.0"
 wasm-bindgen = { version = "0.2.87" }

--- a/crypto/wasm/src/lib.rs
+++ b/crypto/wasm/src/lib.rs
@@ -333,38 +333,19 @@ macro_rules! impl_signature {
 
         #[wasm_bindgen]
         impl $name {
-            pub fn to_raw_bytes(&self) -> Vec<u8> {
-                self.0.to_raw_bytes().to_vec()
-            }
-
             pub fn to_bech32(&self) -> String {
                 self.0.to_bech32()
             }
 
-            pub fn to_hex(&self) -> String {
-                self.0.to_raw_hex()
-            }
-
-            pub fn from_bech32(bech32_str: &str) -> Result<$name, JsError> {
+            pub fn from_bech32(bech32_str: &str) -> Result<$name, wasm_bindgen::JsError> {
                 cml_crypto::$name::from_bech32(bech32_str)
                     .map(Into::into)
                     .map(Self)
                     .map_err(Into::into)
             }
-
-            pub fn from_hex(input: &str) -> Result<$name, JsError> {
-                cml_crypto::$name::from_raw_hex(input)
-                    .map(Into::into)
-                    .map(Self)
-                    .map_err(Into::into)
-            }
-
-            pub fn from_raw_bytes(bytes: &[u8]) -> Result<$name, JsError> {
-                cml_crypto::$name::from_raw_bytes(bytes)
-                    .map(Self)
-                    .map_err(Into::into)
-            }
         }
+
+        cml_core_wasm::impl_raw_bytes_api!(cml_crypto::$name, $name);
 
         impl From<cml_crypto::$name> for $name {
             fn from(inner: cml_crypto::$name) -> Self {
@@ -397,11 +378,6 @@ macro_rules! impl_hash_type_ext {
 
         #[wasm_bindgen::prelude::wasm_bindgen]
         impl $wasm_name {
-            pub fn to_raw_bytes(&self) -> Vec<u8> {
-                use cml_crypto::RawBytesEncoding;
-                self.0.to_raw_bytes().to_vec()
-            }
-
             pub fn to_bech32(
                 &self,
                 prefix: &str,
@@ -409,32 +385,11 @@ macro_rules! impl_hash_type_ext {
                 self.0.to_bech32(prefix).map_err(Into::into)
             }
 
-            pub fn to_hex(&self) -> String {
-                use cml_crypto::RawBytesEncoding;
-                self.0.to_raw_hex()
-            }
-
             pub fn from_bech32(
                 bech32_str: &str,
             ) -> Result<$wasm_name, wasm_bindgen::prelude::JsError> {
                 <$rust_name>::from_bech32(bech32_str)
                     .map(Into::into)
-                    .map(Self)
-                    .map_err(Into::into)
-            }
-
-            pub fn from_hex(input: &str) -> Result<$wasm_name, wasm_bindgen::prelude::JsError> {
-                use cml_crypto::RawBytesEncoding;
-                <$rust_name>::from_raw_hex(input)
-                    .map(Self)
-                    .map_err(Into::into)
-            }
-
-            pub fn from_raw_bytes(
-                bytes: &[u8],
-            ) -> Result<$wasm_name, wasm_bindgen::prelude::JsError> {
-                use cml_crypto::RawBytesEncoding;
-                <$rust_name>::from_raw_bytes(bytes)
                     .map(Self)
                     .map_err(Into::into)
             }
@@ -457,6 +412,8 @@ macro_rules! impl_hash_type_ext {
                 &self.0
             }
         }
+
+        cml_core_wasm::impl_raw_bytes_api!($rust_name, $wasm_name);
     };
 }
 

--- a/multi-era/rust/src/babbage/utils.rs
+++ b/multi-era/rust/src/babbage/utils.rs
@@ -194,7 +194,8 @@ impl Serialize for BabbageMint {
                 .map(|(i, _)| i)
                 .collect::<Vec<usize>>();
             if force_canonical {
-                inner_key_order.sort_by(|i, j| assets[*i].0.get().cmp(assets[*j].0.get()));
+                inner_key_order
+                    .sort_by(|i, j| assets[*i].0.to_raw_bytes().cmp(assets[*j].0.to_raw_bytes()));
             }
 
             for (j, (asset_name, coin)) in inner_key_order.into_iter().zip(assets.iter()) {

--- a/specs/conway/assets.cddl
+++ b/specs/conway/assets.cddl
@@ -4,7 +4,7 @@ coin = uint
 ; but possibly it could be its own type with bounds checking (!=0)
 positive_coin = coin
 
-asset_name = bytes .size (0..32)
+asset_name = bytes .size (0..32) ; @doc Use TryFrom<&str> / TryInto<&str> for utf8 text conversion and RawBytesEncoding for direct bytes access
 
 ; these two are technically hand-written but we keep them here so that other code can
 ; continue thinking they're maps and handle them like so (encoding details, etc)


### PR DESCRIPTION
Fixes #334

Moves RawBytesEncoding to cml_core::serialization as there is nothing specific about crypto with it, and it can be used in many other places (Asset names, plutus scripts, etc).

Add wasm macros for declaring the RawBytesEncoding API automatically using the rust type's trait impl

Add missing hash() to PlutusV3Script

Document AssetName on how to convert to/from using utf8 traits in rust

Use dcSpark/cddl-codegen#240 to remove confusing `get()` (what is it getting?) functions on some wrapper types. These are replaced with `RawBytesEncoding` to standardize use with the rest of CML