### PR TITLE
Remove wasm-bindgen deps from rust

### DIFF
--- a/chain/rust/Cargo.toml
+++ b/chain/rust/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["cardano"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+used_from_wasm = ["wasm-bindgen"]
+
 [dependencies]
 cml-core = { "path" = "../../core/rust", version = "5.3.1" }
 cml-crypto = { "path" = "../../crypto/rust", version = "5.3.1" }
@@ -32,29 +35,15 @@ fraction = "0.10.0"
 base64 = "0.21.5"
 num-bigint = "0.4.0"
 num-integer = "0.1.45"
-#rand_os = "0.1"
 thiserror = "1.0.37"
 num = "0.4"
 unicode-segmentation = "1.10.1"
-# These can be removed if we make wasm bindings for ALL functionality here.
-# This was not done right now as there is a lot of existing legacy code e.g.
-# for Byron that might need to be used from WASM and might not.
-# We can remove this dependency when that is decided.
-#
-# The other use-case here is enums. Without this two enums would need to be defined
-# despite wasm_bindgen supporting C-style enums (with non-negative values) 100%
-# This could possibly be resolved with macros but maybe not.
 
 # non-wasm
-#[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
-#rand_os = "0.1"
-#noop_proc_macro = "0.3.0"
+noop_proc_macro = { version = "0.3.0", optional = false }
 
 # wasm
-#[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "0.2.87" }
-#rand_os = { version = "0.1", features = ["wasm-bindgen"] }
-#js-sys = "=0.3.59"
+wasm-bindgen = { version = "0.2.87", optional = true }
 
 
 [dev-dependencies]

--- a/chain/rust/src/address.rs
+++ b/chain/rust/src/address.rs
@@ -7,7 +7,9 @@ use schemars::JsonSchema;
 use std::convert::{TryFrom, TryInto};
 use std::io::{BufRead, Write};
 
-// for enums
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use cml_crypto::{Ed25519KeyHash, ScriptHash};

--- a/chain/rust/src/builders/tx_builder.rs
+++ b/chain/rust/src/builders/tx_builder.rs
@@ -41,7 +41,9 @@ use std::convert::TryInto;
 use std::io::{BufRead, Seek, Write};
 use std::ops::DerefMut;
 
-// for enums:
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 /**

--- a/chain/rust/src/byron/mod.rs
+++ b/chain/rust/src/byron/mod.rs
@@ -3,7 +3,6 @@ use noop_proc_macro::wasm_bindgen;
 #[cfg(feature = "used_from_wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-
 use std::io::{BufRead, Write};
 
 use cml_crypto::{chain_crypto::hash::Blake2b224, Bip32PublicKey, PublicKey};

--- a/chain/rust/src/byron/mod.rs
+++ b/chain/rust/src/byron/mod.rs
@@ -1,5 +1,8 @@
-//#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
-//use noop_proc_macro::wasm_bindgen;
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
 
 use std::io::{BufRead, Write};
 
@@ -76,7 +79,7 @@ impl Default for AddrAttributes {
     serde::Serialize,
     schemars::JsonSchema,
 )]
-#[wasm_bindgen::prelude::wasm_bindgen]
+#[wasm_bindgen]
 pub enum ByronAddrType {
     PublicKey = 0,
     Script = 1,

--- a/chain/rust/src/governance/mod.rs
+++ b/chain/rust/src/governance/mod.rs
@@ -4,6 +4,11 @@
 pub mod cbor_encodings;
 pub mod serialization;
 
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
 use crate::address::RewardAccount;
 use crate::assets::Coin;
 use crate::block::ProtocolVersion;
@@ -320,7 +325,7 @@ impl UpdateCommittee {
     serde::Serialize,
     schemars::JsonSchema,
 )]
-#[wasm_bindgen::prelude::wasm_bindgen]
+#[wasm_bindgen]
 pub enum Vote {
     No,
     Yes,

--- a/chain/rust/src/json/metadatums.rs
+++ b/chain/rust/src/json/metadatums.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{

--- a/chain/rust/src/json/plutus_datums.rs
+++ b/chain/rust/src/json/plutus_datums.rs
@@ -6,6 +6,9 @@ use crate::{
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 /// JSON <-> PlutusData conversion schemas.

--- a/chain/rust/src/plutus/mod.rs
+++ b/chain/rust/src/plutus/mod.rs
@@ -5,6 +5,11 @@ pub mod cbor_encodings;
 pub mod serialization;
 pub mod utils;
 
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
 use self::cbor_encodings::{
     LegacyRedeemerEncoding, PlutusV3ScriptEncoding, RedeemerKeyEncoding, RedeemerValEncoding,
 };
@@ -135,7 +140,7 @@ impl ExUnits {
     serde::Serialize,
     schemars::JsonSchema,
 )]
-#[wasm_bindgen::prelude::wasm_bindgen]
+#[wasm_bindgen]
 pub enum Language {
     PlutusV1,
     PlutusV2,
@@ -477,7 +482,7 @@ impl RedeemerKey {
     serde::Serialize,
     schemars::JsonSchema,
 )]
-#[wasm_bindgen::prelude::wasm_bindgen]
+#[wasm_bindgen]
 pub enum RedeemerTag {
     Spend,
     Mint,

--- a/chain/wasm/Cargo.toml
+++ b/chain/wasm/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["cardano"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cml-chain = { path = "../rust", version = "5.3.1" }
+cml-chain = { path = "../rust", version = "5.3.1", features = ["used_from_wasm"] }
 cml-core = { path = "../../core/rust", version = "5.3.1" }
 cml-core-wasm = { path = "../../core/wasm", version = "5.3.1" }
 # TODO: remove this dependency if possible to reduce confusion? maybe pub export necessary things in crypto-wasm?

--- a/cip25/wasm/Cargo.toml
+++ b/cip25/wasm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cbor_event = "2.2.0"
-cml-chain = { path = "../../chain/rust", version = "5.3.1" }
+cml-chain = { path = "../../chain/rust", version = "5.3.1", features = ["used_from_wasm"] }
 cml-chain-wasm = { path = "../../chain/wasm", version = "5.3.1" }
 cml-core = { path = "../../core/rust", version = "5.3.1" }
 cml-core-wasm = { path = "../../core/wasm", version = "5.3.1" }

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -34,26 +34,6 @@ num-integer = "0.1.45"
 thiserror = "1.0.37"
 cfg-if = "1"
 
-# These can be removed if we make wasm bindings for ALL functionality here.
-# This was not done right now as there is a lot of existing legacy code e.g.
-# for Byron that might need to be used from WASM and might not.
-# We can remove this dependency when that is decided.
-#
-# The other use-case here is enums. Without this two enums would need to be defined
-# despite wasm_bindgen supporting C-style enums (with non-negative values) 100%
-# This could possibly be resolved with macros but maybe not.
-
-# non-wasm
-[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
-#rand_os = "0.1"
-noop_proc_macro = "0.3.0"
-
-# wasm
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "0.2.87" }
-#rand_os = { version = "0.1", features = ["wasm-bindgen"] }
-#js-sys = "=0.3.59"
-
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/multi-era/rust/Cargo.toml
+++ b/multi-era/rust/Cargo.toml
@@ -32,7 +32,7 @@ bech32 = "0.7.2"
 hex = "0.4.0"
 
 # non-wasm
-noop_proc_macro = { version = "0.3.0", optional = true }
+noop_proc_macro = { version = "0.3.0" }
 
 # wasm
 wasm-bindgen = { version = "0.2.87", optional = true }

--- a/multi-era/rust/Cargo.toml
+++ b/multi-era/rust/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["cardano"]
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+used_from_wasm = ["wasm-bindgen"]
+
 [dependencies]
 cml-core = { path = "../../core/rust", version = "5.3.1" }
 cml-crypto = { path = "../../crypto/rust", version = "5.3.1" }
@@ -23,8 +26,13 @@ derivative = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.57"
 schemars = "0.8.8"
-wasm-bindgen = { version = "0.2.87" }
 
 # only for declaring hash types
 bech32 = "0.7.2"
 hex = "0.4.0"
+
+# non-wasm
+noop_proc_macro = { version = "0.3.0", optional = true }
+
+# wasm
+wasm-bindgen = { version = "0.2.87", optional = true }

--- a/multi-era/rust/src/allegra/mod.rs
+++ b/multi-era/rust/src/allegra/mod.rs
@@ -5,6 +5,11 @@ pub mod cbor_encodings;
 pub mod serialization;
 pub mod utils;
 
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
 use crate::shelley::{
     GenesisKeyDelegation, ShelleyHeader, ShelleyPoolParams, ShelleyPoolRegistration,
     ShelleyTransactionOutput, ShelleyUpdate,
@@ -259,7 +264,7 @@ impl MIRAction {
     serde::Serialize,
     schemars::JsonSchema,
 )]
-#[wasm_bindgen::prelude::wasm_bindgen]
+#[wasm_bindgen]
 pub enum MIRPot {
     Reserve,
     Treasury,

--- a/multi-era/rust/src/alonzo/mod.rs
+++ b/multi-era/rust/src/alonzo/mod.rs
@@ -5,6 +5,11 @@ pub mod cbor_encodings;
 pub mod serialization;
 pub mod utils;
 
+#[cfg(not(feature = "used_from_wasm"))]
+use noop_proc_macro::wasm_bindgen;
+#[cfg(feature = "used_from_wasm")]
+use wasm_bindgen::prelude::wasm_bindgen;
+
 use crate::allegra::AllegraCertificate;
 use crate::shelley::{ProtocolVersionStruct, ShelleyHeader};
 use cbor_encodings::{
@@ -210,7 +215,7 @@ impl AlonzoRedeemer {
     serde::Serialize,
     schemars::JsonSchema,
 )]
-#[wasm_bindgen::prelude::wasm_bindgen]
+#[wasm_bindgen]
 pub enum AlonzoRedeemerTag {
     Spend,
     Mint,

--- a/multi-era/wasm/Cargo.toml
+++ b/multi-era/wasm/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["cardano"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cml-chain = { path = "../../chain/rust", version = "5.3.1" }
+cml-chain = { path = "../../chain/rust", version = "5.3.1", features = ["used_from_wasm"] }
 cml-chain-wasm = { path = "../../chain/wasm", version = "5.3.1" }
 cml-crypto = { path = "../../crypto/rust", version = "5.3.1" }
 cml-crypto-wasm = { path = "../../crypto/wasm", version = "5.3.1" }
 cml-core = { path = "../../core/rust", version = "5.3.1" }
 cml-core-wasm = { path = "../../core/wasm", version = "5.3.1" }
-cml-multi-era = { path = "../rust", version = "5.3.1" }
+cml-multi-era = { path = "../rust", version = "5.3.1", features = ["used_from_wasm"] }
 cbor_event = "2.4.0"
 hex = "0.4.0"
 linked-hash-map = "0.5.3"


### PR DESCRIPTION
Rust CML crates must use wasm-bindgen for enums as these are used from the WASM CML crates.

Using noop_proc_macro we can replace the wasm_bindgen proc macro with a no-op that does nothing when consumed directly from rust.

This is now locked behind a feature (used_from_wasm) as we can't just use cfg target checks as compiling the wasm crate (not using web-pack) would use the rust target and break.

Crates using cml-chain and cml-multi-era from a wasm crate must specify this feature to activate the wasm_bindgen dependancy instead of the no-op macro.