### PR TITLE
Fix for coin/deposit merge issue

### DIFF
--- a/chain/rust/src/deposit.rs
+++ b/chain/rust/src/deposit.rs
@@ -25,8 +25,8 @@ pub fn internal_get_implicit_input(
             .try_fold(0u64, |acc, cert| match cert {
                 Certificate::PoolRetirement(_cert) => acc.checked_add(pool_deposit),
                 Certificate::StakeDeregistration(_cert) => acc.checked_add(key_deposit),
-                Certificate::UnregCert(cert) => acc.checked_add(cert.coin),
-                Certificate::UnregDrepCert(cert) => acc.checked_add(cert.coin),
+                Certificate::UnregCert(cert) => acc.checked_add(cert.deposit),
+                Certificate::UnregDrepCert(cert) => acc.checked_add(cert.deposit),
                 // TODO: is this the case?
                 Certificate::ResignCommitteeColdCert(_cert) => acc.checked_add(key_deposit),
                 _ => Some(acc),
@@ -53,11 +53,11 @@ pub fn internal_get_deposit(
             .try_fold(0u64, |acc, cert| match cert {
                 Certificate::PoolRegistration(_cert) => acc.checked_add(pool_deposit),
                 Certificate::StakeRegistration(_cert) => acc.checked_add(key_deposit),
-                Certificate::RegCert(cert) => acc.checked_add(cert.coin),
-                Certificate::StakeRegDelegCert(cert) => acc.checked_add(cert.coin),
-                Certificate::RegDrepCert(cert) => acc.checked_add(cert.coin),
-                Certificate::VoteRegDelegCert(cert) => acc.checked_add(cert.coin),
-                Certificate::StakeVoteRegDelegCert(cert) => acc.checked_add(cert.coin),
+                Certificate::RegCert(cert) => acc.checked_add(cert.deposit),
+                Certificate::StakeRegDelegCert(cert) => acc.checked_add(cert.deposit),
+                Certificate::RegDrepCert(cert) => acc.checked_add(cert.deposit),
+                Certificate::VoteRegDelegCert(cert) => acc.checked_add(cert.deposit),
+                Certificate::StakeVoteRegDelegCert(cert) => acc.checked_add(cert.deposit),
                 _ => Some(acc),
             })
             .ok_or(ArithmeticError::IntegerOverflow)?,


### PR DESCRIPTION
Somehow `coin` ended up here still after #333 despite being changed to `deposit`.