### PR TITLE
Move Builders to use Map-format Redeemers

### DIFF
--- a/chain/rust/src/builders/redeemer_builder.rs
+++ b/chain/rust/src/builders/redeemer_builder.rs
@@ -5,52 +5,17 @@ use super::{
 };
 use crate::{
     address::RewardAddress,
-    plutus::{ExUnits, LegacyRedeemer, PlutusData, RedeemerTag, Redeemers},
+    plutus::{ExUnits, PlutusData, RedeemerKey, RedeemerTag, RedeemerVal, Redeemers},
     transaction::TransactionInput,
     PolicyId,
 };
+use cml_core::ordered_hash_map::OrderedHashMap;
 use std::{collections::BTreeMap, fmt::Debug};
-
-#[derive(Clone, Copy, PartialOrd, Ord, Debug, PartialEq, Eq, Hash)]
-pub struct RedeemerWitnessKey {
-    tag: RedeemerTag,
-    index: u64,
-}
-
-impl RedeemerWitnessKey {
-    pub fn new(tag: RedeemerTag, index: u64) -> Self {
-        Self { tag, index }
-    }
-}
-
-impl From<&LegacyRedeemer> for RedeemerWitnessKey {
-    fn from(redeemer: &LegacyRedeemer) -> Self {
-        Self {
-            tag: redeemer.tag,
-            index: redeemer.index,
-        }
-    }
-}
-
-/// LegacyRedeemer without the tag of index
-/// This allows builder code to return partial redeemers
-/// and then later have them placed in the right context
-#[derive(Clone, Debug)]
-pub struct UntaggedRedeemer {
-    pub data: PlutusData,
-    pub ex_units: ExUnits,
-}
-
-impl UntaggedRedeemer {
-    pub fn new(data: PlutusData, ex_units: ExUnits) -> Self {
-        Self { data, ex_units }
-    }
-}
 
 #[derive(Clone, Debug)]
 enum UntaggedRedeemerPlaceholder {
     JustData(PlutusData),
-    Full(UntaggedRedeemer),
+    Full(RedeemerVal),
 }
 
 impl UntaggedRedeemerPlaceholder {
@@ -117,46 +82,46 @@ impl RedeemerSetBuilder {
     }
 
     /// note: will override existing value if called twice with the same key
-    pub fn update_ex_units(&mut self, key: RedeemerWitnessKey, ex_units: ExUnits) {
+    pub fn update_ex_units(&mut self, key: RedeemerKey, ex_units: ExUnits) {
         match key.tag {
             RedeemerTag::Spend => {
                 let entry = self.spend.iter_mut().nth(key.index as usize).unwrap().1;
-                *entry = Some(UntaggedRedeemerPlaceholder::Full(UntaggedRedeemer::new(
+                *entry = Some(UntaggedRedeemerPlaceholder::Full(RedeemerVal::new(
                     entry.as_ref().unwrap().data().clone(),
                     ex_units,
                 )));
             }
             RedeemerTag::Mint => {
                 let entry = self.mint.iter_mut().nth(key.index as usize).unwrap().1;
-                *entry = Some(UntaggedRedeemerPlaceholder::Full(UntaggedRedeemer::new(
+                *entry = Some(UntaggedRedeemerPlaceholder::Full(RedeemerVal::new(
                     entry.as_ref().unwrap().data().clone(),
                     ex_units,
                 )));
             }
             RedeemerTag::Cert => {
                 let entry = self.cert.get_mut(key.index as usize).unwrap();
-                *entry = Some(UntaggedRedeemerPlaceholder::Full(UntaggedRedeemer::new(
+                *entry = Some(UntaggedRedeemerPlaceholder::Full(RedeemerVal::new(
                     entry.as_ref().unwrap().data().clone(),
                     ex_units,
                 )));
             }
             RedeemerTag::Reward => {
                 let entry = self.reward.iter_mut().nth(key.index as usize).unwrap().1;
-                *entry = Some(UntaggedRedeemerPlaceholder::Full(UntaggedRedeemer::new(
+                *entry = Some(UntaggedRedeemerPlaceholder::Full(RedeemerVal::new(
                     entry.as_ref().unwrap().data().clone(),
                     ex_units,
                 )));
             }
             RedeemerTag::Proposing => {
                 let entry = self.proposals.get_mut(key.index as usize).unwrap();
-                *entry = Some(UntaggedRedeemerPlaceholder::Full(UntaggedRedeemer::new(
+                *entry = Some(UntaggedRedeemerPlaceholder::Full(RedeemerVal::new(
                     entry.as_ref().unwrap().data().clone(),
                     ex_units,
                 )));
             }
             RedeemerTag::Voting => {
                 let entry = self.votes.get_mut(key.index as usize).unwrap();
-                *entry = Some(UntaggedRedeemerPlaceholder::Full(UntaggedRedeemer::new(
+                *entry = Some(UntaggedRedeemerPlaceholder::Full(RedeemerVal::new(
                     entry.as_ref().unwrap().data().clone(),
                     ex_units,
                 )));
@@ -253,7 +218,7 @@ impl RedeemerSetBuilder {
     }
 
     pub fn build(&self, default_to_dummy_exunits: bool) -> Result<Redeemers, RedeemerBuilderError> {
-        let mut redeemers = Vec::new();
+        let mut redeemers = OrderedHashMap::new();
         // Calling iter on a BTreeMap returns a list of sorted keys
         self.remove_placeholders_and_tag(
             &mut redeemers,
@@ -292,17 +257,17 @@ impl RedeemerSetBuilder {
             default_to_dummy_exunits,
         )?;
 
-        Ok(Redeemers::new_arr_legacy_redeemer(redeemers))
+        Ok(Redeemers::new_map_redeemer_key_to_redeemer_val(redeemers))
     }
 
     fn remove_placeholders_and_tag<'a, K: Debug + Clone>(
         &self,
-        redeemers: &mut Vec<LegacyRedeemer>,
+        redeemers: &mut OrderedHashMap<RedeemerKey, RedeemerVal>,
         tag: RedeemerTag,
         entries: &mut dyn Iterator<Item = (&'a K, &'a Option<UntaggedRedeemerPlaceholder>)>,
         default_to_dummy_exunits: bool,
     ) -> Result<(), RedeemerBuilderError> {
-        let mut result = vec![];
+        let mut untagged_redeemers = vec![];
         for (i, entry) in entries.enumerate() {
             let key = (tag, i, entry.0);
 
@@ -313,7 +278,7 @@ impl RedeemerSetBuilder {
                             MissingExunitError::Key(key.0, key.1, format!("{:?}", key.2)),
                         ))
                     } else {
-                        Ok(Some(UntaggedRedeemer::new(data.clone(), ExUnits::dummy())))
+                        Ok(Some(RedeemerVal::new(data.clone(), ExUnits::dummy())))
                     }
                 }
                 Some(UntaggedRedeemerPlaceholder::Full(untagged_redeemer)) => {
@@ -321,29 +286,25 @@ impl RedeemerSetBuilder {
                 }
                 None => Ok(None),
             }?;
-            result.push(redeemer);
+            untagged_redeemers.push(redeemer);
         }
-        redeemers.append(&mut Self::tag_redeemer(tag, &result));
+        Self::tag_redeemer(redeemers, tag, &untagged_redeemers);
         Ok(())
     }
 
     fn tag_redeemer(
+        redeemers: &mut OrderedHashMap<RedeemerKey, RedeemerVal>,
         tag: RedeemerTag,
-        untagged_redeemers: &[Option<UntaggedRedeemer>],
-    ) -> Vec<LegacyRedeemer> {
-        let mut result = Vec::new();
-
+        untagged_redeemers: &[Option<RedeemerVal>],
+    ) {
         for (index, untagged_redeemer) in untagged_redeemers.iter().enumerate() {
             if let Some(untagged_redeemer) = untagged_redeemer {
-                result.push(LegacyRedeemer::new(
-                    tag,
-                    index as u64,
-                    untagged_redeemer.data.clone(),
-                    untagged_redeemer.ex_units.clone(),
-                ));
+                redeemers.insert(
+                    RedeemerKey::new(tag, index as u64),
+                    untagged_redeemer.clone(),
+                );
             }
         }
-        result
     }
 }
 
@@ -417,7 +378,7 @@ mod tests {
         builder.add_spend(&input_result);
 
         builder.update_ex_units(
-            RedeemerWitnessKey::new(RedeemerTag::Spend, 0),
+            RedeemerKey::new(RedeemerTag::Spend, 0),
             ExUnits::new(10, 10),
         );
 

--- a/chain/rust/src/builders/tx_builder.rs
+++ b/chain/rust/src/builders/tx_builder.rs
@@ -5,7 +5,6 @@ use super::output_builder::{OutputBuilderError, SingleOutputBuilderResult};
 use super::proposal_builder::ProposalBuilderResult;
 use super::redeemer_builder::RedeemerBuilderError;
 use super::redeemer_builder::RedeemerSetBuilder;
-use super::redeemer_builder::RedeemerWitnessKey;
 use super::vote_builder::VoteBuilderResult;
 use super::withdrawal_builder::WithdrawalBuilderResult;
 use super::witness_builder::merge_fake_witness;
@@ -25,8 +24,7 @@ use crate::deposit::{internal_get_deposit, internal_get_implicit_input};
 use crate::fees::LinearFee;
 use crate::governance::{ProposalProcedure, VotingProcedures};
 use crate::min_ada::min_ada_required;
-use crate::plutus::{CostModels, ExUnits, Language};
-use crate::plutus::{PlutusData, Redeemers};
+use crate::plutus::{CostModels, ExUnits, Language, PlutusData, RedeemerKey, Redeemers};
 use crate::transaction::{
     DatumOption, ScriptRef, Transaction, TransactionBody, TransactionInput, TransactionOutput,
     TransactionWitnessSet,
@@ -118,9 +116,11 @@ impl WitnessBuilders {
         let redeemers = self.redeemer_set_builder.build(true)?;
         let mut witness_set_clone = self.witness_set_builder.clone();
         redeemers
-            .to_flat_format()
-            .into_iter()
-            .for_each(|r| witness_set_clone.add_redeemer(r));
+            .to_map_format()
+            .iter()
+            .for_each(|(key, redeemer)| {
+                witness_set_clone.add_redeemer(key.clone(), redeemer.clone())
+            });
 
         if include_fake {
             merge_fake_witness(&mut witness_set_clone, &self.fake_required_witnesses);
@@ -1509,7 +1509,7 @@ impl TransactionBuilder {
     }
 
     /// used to override the exunit values initially provided when adding inputs
-    pub fn set_exunits(&mut self, redeemer: RedeemerWitnessKey, ex_units: ExUnits) {
+    pub fn set_exunits(&mut self, redeemer: RedeemerKey, ex_units: ExUnits) {
         self.witness_builders
             .redeemer_set_builder
             .update_ex_units(redeemer, ex_units);
@@ -1547,7 +1547,7 @@ impl TxRedeemerBuilder {
     }
 
     /// used to override the exunit values initially provided when adding inputs
-    pub fn set_exunits(&mut self, redeemer: RedeemerWitnessKey, ex_units: ExUnits) {
+    pub fn set_exunits(&mut self, redeemer: RedeemerKey, ex_units: ExUnits) {
         self.witness_builders
             .redeemer_set_builder
             .update_ex_units(redeemer, ex_units);
@@ -5368,17 +5368,20 @@ mod tests {
         }
 
         let original_tx_fee = tx_builder.min_fee(false).unwrap();
-        assert_eq!(original_tx_fee, 470421);
+        // 44 more than original as the redeemer format changed to map which uses 1 byte more
+        assert_eq!(original_tx_fee, 470465);
         tx_builder.set_fee(897753);
 
         {
             tx_builder.set_exunits(
-                RedeemerWitnessKey::new(RedeemerTag::Spend, 0),
+                RedeemerKey::new(RedeemerTag::Spend, 0),
                 ExUnits::new(5000000, 2000000000),
             );
         }
         let tx = tx_builder.build(ChangeSelectionAlgo::Default, &Address::from_bech32("addr1q9tzwgthsm4hs8alk5v3rgjn7nf9pldlmnc3nrns6dvct2dqzvgjxvajrmzsvwh9fucmp65gxc6mv3fskurctfyuj5zqc7q30l").unwrap()).unwrap();
-        assert_eq!(hex::encode(tx.body.to_cbor_bytes()), "a700d9010281825820473899cb48414442ea107735f7fc3e020f0293122e9d05e4be6f03ffafde5a0c00018283581d71aba3c2914116298a146af57d8156b1583f183fc05c0aa48ee95bec71821a001c41caa1581c6bec713b08a2d7c64baa3596d200b41b560850919d72e634944f2d52a14f537061636542756442696433303533015820f7f2f57c58b5e4872201ab678928b0d63935e82d022d385e1bad5bfe347e89d8825839015627217786eb781fbfb51911a253f4d250fdbfdcf1198e70d35985a9a013112333b21ec5063ae54f31b0ea883635b64530b70785a49c95041a040228dd021a000db2d907582029ed935cc80249c4de9f3e96fdcea6b7da123a543bbe75fffe9e2c66119e426d0b58205d5863643ea0687f9ca3ea903e9d86d81787373da1ebf196206c31f29608ce9b0dd9010281825820a90a895d07049afc725a0d6a38c6b82218b8d1de60e7bd70ecdd58f1d9e1218b000ed9010281581c1c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c");
+        // original: a700d9010281825820473899cb48414442ea107735f7fc3e020f0293122e9d05e4be6f03ffafde5a0c00018283581d71aba3c2914116298a146af57d8156b1583f183fc05c0aa48ee95bec71821a001c41caa1581c6bec713b08a2d7c64baa3596d200b41b560850919d72e634944f2d52a14f537061636542756442696433303533015820f7f2f57c58b5e4872201ab678928b0d63935e82d022d385e1bad5bfe347e89d8825839015627217786eb781fbfb51911a253f4d250fdbfdcf1198e70d35985a9a013112333b21ec5063ae54f31b0ea883635b64530b70785a49c95041a040228dd021a000db2d907582029ed935cc80249c4de9f3e96fdcea6b7da123a543bbe75fffe9e2c66119e426d0b58205d5863643ea0687f9ca3ea903e9d86d81787373da1ebf196206c31f29608ce9b0dd9010281825820a90a895d07049afc725a0d6a38c6b82218b8d1de60e7bd70ecdd58f1d9e1218b000ed9010281581c1c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c
+        // changed due to redeemer format changing
+        assert_eq!(hex::encode(tx.body.to_cbor_bytes()), "a700d9010281825820473899cb48414442ea107735f7fc3e020f0293122e9d05e4be6f03ffafde5a0c00018283581d71aba3c2914116298a146af57d8156b1583f183fc05c0aa48ee95bec71821a001c41caa1581c6bec713b08a2d7c64baa3596d200b41b560850919d72e634944f2d52a14f537061636542756442696433303533015820f7f2f57c58b5e4872201ab678928b0d63935e82d022d385e1bad5bfe347e89d8825839015627217786eb781fbfb51911a253f4d250fdbfdcf1198e70d35985a9a013112333b21ec5063ae54f31b0ea883635b64530b70785a49c95041a040228dd021a000db2d907582029ed935cc80249c4de9f3e96fdcea6b7da123a543bbe75fffe9e2c66119e426d0b5820ef2bf6654c6bb34514b16edc28ae51df117f9252322735962ea571e2614525d50dd9010281825820a90a895d07049afc725a0d6a38c6b82218b8d1de60e7bd70ecdd58f1d9e1218b000ed9010281581c1c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c");
     }
 
     #[test]
@@ -5532,11 +5535,11 @@ mod tests {
         );
         {
             tx_redeemer_builder.set_exunits(
-                RedeemerWitnessKey::new(RedeemerTag::Spend, 0),
+                RedeemerKey::new(RedeemerTag::Spend, 0),
                 ExUnits::new(5000000, 2000000000),
             );
             tx_builder.set_exunits(
-                RedeemerWitnessKey::new(RedeemerTag::Spend, 0),
+                RedeemerKey::new(RedeemerTag::Spend, 0),
                 ExUnits::new(5000000, 2000000000),
             );
         }
@@ -5548,13 +5551,17 @@ mod tests {
             )
             .unwrap();
         let real_script_hash = signed_tx_builder.body.script_data_hash.as_ref().unwrap();
+        // different than original 5d5863643ea0687f9ca3ea903e9d86d81787373da1ebf196206c31f29608ce9b
+        // because the redeemer format changed which changes the script data hash
         assert_eq!(
             real_script_hash.to_hex(),
-            "5d5863643ea0687f9ca3ea903e9d86d81787373da1ebf196206c31f29608ce9b"
+            "ef2bf6654c6bb34514b16edc28ae51df117f9252322735962ea571e2614525d5"
         );
 
         let tx = &signed_tx_builder.body;
-        assert_eq!(hex::encode(tx.to_cbor_bytes()), "a700d9010281825820473899cb48414442ea107735f7fc3e020f0293122e9d05e4be6f03ffafde5a0c00018283581d71aba3c2914116298a146af57d8156b1583f183fc05c0aa48ee95bec71821a001c41caa1581c6bec713b08a2d7c64baa3596d200b41b560850919d72e634944f2d52a14f537061636542756442696433303533015820f7f2f57c58b5e4872201ab678928b0d63935e82d022d385e1bad5bfe347e89d8825839015627217786eb781fbfb51911a253f4d250fdbfdcf1198e70d35985a9a013112333b21ec5063ae54f31b0ea883635b64530b70785a49c95041a040228dd021a000db2d907582029ed935cc80249c4de9f3e96fdcea6b7da123a543bbe75fffe9e2c66119e426d0b58205d5863643ea0687f9ca3ea903e9d86d81787373da1ebf196206c31f29608ce9b0dd9010281825820a90a895d07049afc725a0d6a38c6b82218b8d1de60e7bd70ecdd58f1d9e1218b000ed9010281581c1c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c");
+        // original: a700d9010281825820473899cb48414442ea107735f7fc3e020f0293122e9d05e4be6f03ffafde5a0c00018283581d71aba3c2914116298a146af57d8156b1583f183fc05c0aa48ee95bec71821a001c41caa1581c6bec713b08a2d7c64baa3596d200b41b560850919d72e634944f2d52a14f537061636542756442696433303533015820f7f2f57c58b5e4872201ab678928b0d63935e82d022d385e1bad5bfe347e89d8825839015627217786eb781fbfb51911a253f4d250fdbfdcf1198e70d35985a9a013112333b21ec5063ae54f31b0ea883635b64530b70785a49c95041a040228dd021a000db2d907582029ed935cc80249c4de9f3e96fdcea6b7da123a543bbe75fffe9e2c66119e426d0b58205d5863643ea0687f9ca3ea903e9d86d81787373da1ebf196206c31f29608ce9b0dd9010281825820a90a895d07049afc725a0d6a38c6b82218b8d1de60e7bd70ecdd58f1d9e1218b000ed9010281581c1c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c
+        // changed due to redeemer format changing
+        assert_eq!(hex::encode(tx.to_cbor_bytes()), "a700d9010281825820473899cb48414442ea107735f7fc3e020f0293122e9d05e4be6f03ffafde5a0c00018283581d71aba3c2914116298a146af57d8156b1583f183fc05c0aa48ee95bec71821a001c41caa1581c6bec713b08a2d7c64baa3596d200b41b560850919d72e634944f2d52a14f537061636542756442696433303533015820f7f2f57c58b5e4872201ab678928b0d63935e82d022d385e1bad5bfe347e89d8825839015627217786eb781fbfb51911a253f4d250fdbfdcf1198e70d35985a9a013112333b21ec5063ae54f31b0ea883635b64530b70785a49c95041a040228dd021a000db2d907582029ed935cc80249c4de9f3e96fdcea6b7da123a543bbe75fffe9e2c66119e426d0b5820ef2bf6654c6bb34514b16edc28ae51df117f9252322735962ea571e2614525d50dd9010281825820a90a895d07049afc725a0d6a38c6b82218b8d1de60e7bd70ecdd58f1d9e1218b000ed9010281581c1c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c");
     }
 
     #[test]
@@ -5708,7 +5715,7 @@ mod tests {
 
         {
             tx_builder.set_exunits(
-                RedeemerWitnessKey::new(RedeemerTag::Spend, 0),
+                RedeemerKey::new(RedeemerTag::Spend, 0),
                 ExUnits::new(5000000, 2000000000),
             );
         }

--- a/chain/rust/src/builders/witness_builder.rs
+++ b/chain/rust/src/builders/witness_builder.rs
@@ -1,4 +1,4 @@
-use linked_hash_map::LinkedHashMap;
+use cml_core::ordered_hash_map::OrderedHashMap;
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::Debug,
@@ -10,7 +10,7 @@ use crate::{
     crypto::{hash::hash_plutus_data, BootstrapWitness, Vkey, Vkeywitness},
     plutus::{
         LegacyRedeemer, PlutusData, PlutusScript, PlutusV1Script, PlutusV2Script, PlutusV3Script,
-        Redeemers,
+        RedeemerKey, RedeemerVal, Redeemers,
     },
     transaction::TransactionWitnessSet,
     NativeScript, RequiredSigners, Script,
@@ -20,7 +20,7 @@ use cml_crypto::{
 };
 
 use super::{
-    redeemer_builder::{MissingExunitError, RedeemerBuilderError, RedeemerWitnessKey},
+    redeemer_builder::{MissingExunitError, RedeemerBuilderError},
     tx_builder::TransactionUnspentOutput,
 };
 
@@ -30,7 +30,7 @@ pub enum WitnessBuilderError {
     MissingWitnesses(RequiredWitnessSet),
     #[error("Missing ExUnit: {0}")]
     MissingExUnit(#[from] MissingExunitError),
-    #[error("LegacyRedeemer build failed: {0}")]
+    #[error("Redeemer build failed: {0}")]
     RedeemBuildFailed(#[from] RedeemerBuilderError),
 }
 
@@ -111,7 +111,7 @@ pub struct RequiredWitnessSet {
     // note: no way to differentiate Plutus script from native script
     pub scripts: BTreeSet<ScriptHash>,
     pub plutus_data: BTreeSet<DatumHash>,
-    pub redeemers: BTreeSet<RedeemerWitnessKey>,
+    pub redeemers: BTreeSet<RedeemerKey>,
     pub script_refs: BTreeSet<ScriptHash>,
 }
 
@@ -167,9 +167,9 @@ impl RequiredWitnessSet {
     }
 
     // pub fn add_redeemer(&mut self, redeemer: &LegacyRedeemer) {
-    //     self.add_redeemer_tag(&RedeemerWitnessKey::new(&redeemer.tag(), &redeemer.index()));
+    //     self.add_redeemer_tag(&RedeemerKey::new(&redeemer.tag(), &redeemer.index()));
     // }
-    pub fn add_redeemer_tag(&mut self, redeemer: RedeemerWitnessKey) {
+    pub fn add_redeemer_tag(&mut self, redeemer: RedeemerKey) {
         self.redeemers.insert(redeemer);
     }
 
@@ -254,8 +254,8 @@ pub struct TransactionWitnessSetBuilder {
     pub vkeys: HashMap<Vkey, Vkeywitness>,
     pub bootstraps: HashMap<Vkey, BootstrapWitness>,
     pub scripts: HashMap<ScriptHash, Script>,
-    pub plutus_data: LinkedHashMap<DatumHash, PlutusData>,
-    pub redeemers: LinkedHashMap<RedeemerWitnessKey, LegacyRedeemer>,
+    pub plutus_data: OrderedHashMap<DatumHash, PlutusData>,
+    pub redeemers: OrderedHashMap<RedeemerKey, RedeemerVal>,
 
     /// witnesses that need to be added for the build function to succeed
     /// this allows checking that witnesses are present at build time (instead of when submitting to a node)
@@ -359,13 +359,15 @@ impl TransactionWitnessSetBuilder {
         self.plutus_data.values().cloned().collect()
     }
 
-    pub fn add_redeemer(&mut self, redeemer: LegacyRedeemer) {
-        self.redeemers
-            .insert(RedeemerWitnessKey::from(&redeemer), redeemer);
+    pub fn add_redeemer(&mut self, key: RedeemerKey, redeemer: RedeemerVal) {
+        self.redeemers.insert(key, redeemer);
     }
 
     pub fn get_redeemer(&self) -> Vec<LegacyRedeemer> {
-        self.redeemers.values().cloned().collect()
+        self.redeemers
+            .iter()
+            .map(|(k, v)| LegacyRedeemer::new(k.tag, k.index, v.data.clone(), v.ex_units.clone()))
+            .collect()
     }
 
     pub fn add_required_wits(&mut self, required_wits: RequiredWitnessSet) {
@@ -409,9 +411,12 @@ impl TransactionWitnessSetBuilder {
             });
         }
         if let Some(redeemers) = wit_set.redeemers {
-            redeemers.to_flat_format().into_iter().for_each(|redeemer| {
-                self.add_redeemer(redeemer);
-            });
+            redeemers
+                .to_map_format()
+                .iter()
+                .for_each(|(key, redeemer)| {
+                    self.add_redeemer(key.clone(), redeemer.clone());
+                });
         }
         if let Some(plutus_datums) = wit_set.plutus_datums {
             plutus_datums.iter().for_each(|plutus_datum| {
@@ -482,8 +487,8 @@ impl TransactionWitnessSetBuilder {
         }
 
         if !self.redeemers.is_empty() {
-            result.redeemers = Some(Redeemers::new_arr_legacy_redeemer(
-                self.redeemers.values().cloned().collect::<Vec<_>>(),
+            result.redeemers = Some(Redeemers::new_map_redeemer_key_to_redeemer_val(
+                self.redeemers,
             ));
         }
 

--- a/chain/wasm/src/builders/redeemer_builder.rs
+++ b/chain/wasm/src/builders/redeemer_builder.rs
@@ -3,52 +3,9 @@ use super::{
     mint_builder::MintBuilderResult, proposal_builder::ProposalBuilderResult,
     vote_builder::VoteBuilderResult, withdrawal_builder::WithdrawalBuilderResult,
 };
-use crate::plutus::{ExUnits, LegacyRedeemer, PlutusData, RedeemerTag, Redeemers};
+use crate::plutus::{ExUnits, RedeemerKey, Redeemers};
 use cml_core_wasm::impl_wasm_conversions;
 use wasm_bindgen::prelude::{wasm_bindgen, JsError};
-
-#[wasm_bindgen]
-#[derive(Clone, Copy, PartialOrd, Ord, Debug, PartialEq, Eq, Hash)]
-pub struct RedeemerWitnessKey(cml_chain::builders::redeemer_builder::RedeemerWitnessKey);
-
-impl_wasm_conversions!(
-    cml_chain::builders::redeemer_builder::RedeemerWitnessKey,
-    RedeemerWitnessKey
-);
-
-#[wasm_bindgen]
-impl RedeemerWitnessKey {
-    pub fn new(tag: RedeemerTag, index: u64) -> Self {
-        cml_chain::builders::redeemer_builder::RedeemerWitnessKey::new(tag, index).into()
-    }
-
-    pub fn from_redeemer(redeemer: &LegacyRedeemer) -> Self {
-        cml_chain::builders::redeemer_builder::RedeemerWitnessKey::from(redeemer.as_ref()).into()
-    }
-}
-
-/// Redeemer without the tag of index
-/// This allows builder code to return partial redeemers
-/// and then later have them placed in the right context
-#[wasm_bindgen]
-#[derive(Clone, Debug)]
-pub struct UntaggedRedeemer(cml_chain::builders::redeemer_builder::UntaggedRedeemer);
-
-impl_wasm_conversions!(
-    cml_chain::builders::redeemer_builder::UntaggedRedeemer,
-    UntaggedRedeemer
-);
-
-#[wasm_bindgen]
-impl UntaggedRedeemer {
-    pub fn new(data: &PlutusData, ex_units: &ExUnits) -> Self {
-        cml_chain::builders::redeemer_builder::UntaggedRedeemer::new(
-            data.clone().into(),
-            ex_units.clone().into(),
-        )
-        .into()
-    }
-}
 
 /// In order to calculate the index from the sorted set, "add_*" methods in this builder
 /// must be called along with the "add_*" methods in transaction builder.
@@ -72,9 +29,9 @@ impl RedeemerSetBuilder {
     }
 
     /// note: will override existing value if called twice with the same key
-    pub fn update_ex_units(&mut self, key: &RedeemerWitnessKey, ex_units: &ExUnits) {
+    pub fn update_ex_units(&mut self, key: &RedeemerKey, ex_units: &ExUnits) {
         self.0
-            .update_ex_units((*key).into(), ex_units.clone().into());
+            .update_ex_units(key.clone().into(), ex_units.clone().into());
     }
 
     pub fn add_spend(&mut self, result: &InputBuilderResult) {

--- a/chain/wasm/src/builders/tx_builder.rs
+++ b/chain/wasm/src/builders/tx_builder.rs
@@ -10,13 +10,12 @@ use crate::{
     builders::{
         certificate_builder::CertificateBuilderResult, input_builder::InputBuilderResult,
         mint_builder::MintBuilderResult, output_builder::SingleOutputBuilderResult,
-        proposal_builder::ProposalBuilderResult, redeemer_builder::RedeemerWitnessKey,
-        vote_builder::VoteBuilderResult, withdrawal_builder::WithdrawalBuilderResult,
-        witness_builder::TransactionWitnessSetBuilder,
+        proposal_builder::ProposalBuilderResult, vote_builder::VoteBuilderResult,
+        withdrawal_builder::WithdrawalBuilderResult, witness_builder::TransactionWitnessSetBuilder,
     },
     crypto::{BootstrapWitness, Vkeywitness},
     fees::LinearFee,
-    plutus::{CostModels, ExUnitPrices, ExUnits, Redeemers},
+    plutus::{CostModels, ExUnitPrices, ExUnits, RedeemerKey, Redeemers},
     transaction::{Transaction, TransactionBody, TransactionInput, TransactionOutput},
     Coin, NetworkId, Slot, Value, Withdrawals,
 };
@@ -359,9 +358,9 @@ impl TransactionBuilder {
     }
 
     /// used to override the exunit values initially provided when adding inputs
-    pub fn set_exunits(&mut self, redeemer: &RedeemerWitnessKey, ex_units: &ExUnits) {
+    pub fn set_exunits(&mut self, redeemer: &RedeemerKey, ex_units: &ExUnits) {
         self.0
-            .set_exunits((*redeemer).into(), ex_units.clone().into())
+            .set_exunits(redeemer.clone().into(), ex_units.clone().into())
     }
 
     /// warning: sum of all parts of a transaction must equal 0. You cannot just set the fee to the min value and forget about it
@@ -408,9 +407,9 @@ impl TxRedeemerBuilder {
     }
 
     /// used to override the exunit values initially provided when adding inputs
-    pub fn set_exunits(&mut self, redeemer: &RedeemerWitnessKey, ex_units: &ExUnits) {
+    pub fn set_exunits(&mut self, redeemer: &RedeemerKey, ex_units: &ExUnits) {
         self.0
-            .set_exunits((*redeemer).into(), ex_units.clone().into())
+            .set_exunits(redeemer.clone().into(), ex_units.clone().into())
     }
 
     /// Transaction body with a dummy values for redeemers & script_data_hash

--- a/chain/wasm/src/builders/witness_builder.rs
+++ b/chain/wasm/src/builders/witness_builder.rs
@@ -2,7 +2,7 @@ use crate::{
     address::RewardAddress,
     byron::ByronAddress,
     crypto::{BootstrapWitness, Vkeywitness},
-    plutus::{utils::PlutusScript, LegacyRedeemer, PlutusData},
+    plutus::{utils::PlutusScript, PlutusData, RedeemerKey, RedeemerVal},
     transaction::TransactionWitnessSet,
     Ed25519KeyHashList, LegacyRedeemerList, NativeScriptList, PlutusDataList, PlutusV1ScriptList,
     PlutusV2ScriptList, Script,
@@ -10,8 +10,6 @@ use crate::{
 use cml_core_wasm::impl_wasm_conversions;
 use cml_crypto_wasm::{DatumHash, Ed25519KeyHash, ScriptHash};
 use wasm_bindgen::prelude::{wasm_bindgen, JsError};
-
-use super::redeemer_builder::RedeemerWitnessKey;
 
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
@@ -126,8 +124,8 @@ impl RequiredWitnessSet {
         self.0.add_plutus_datum_hash(plutus_datum.clone().into());
     }
 
-    pub fn add_redeemer_tag(&mut self, redeemer: &RedeemerWitnessKey) {
-        self.0.add_redeemer_tag((*redeemer).into());
+    pub fn add_redeemer_tag(&mut self, redeemer: &RedeemerKey) {
+        self.0.add_redeemer_tag(redeemer.clone().into());
     }
 
     pub fn add_all(&mut self, requirements: &RequiredWitnessSet) {
@@ -194,8 +192,9 @@ impl TransactionWitnessSetBuilder {
         self.0.get_plutus_datum().into()
     }
 
-    pub fn add_redeemer(&mut self, redeemer: &LegacyRedeemer) {
-        self.0.add_redeemer(redeemer.clone().into());
+    pub fn add_redeemer(&mut self, key: &RedeemerKey, redeemer: &RedeemerVal) {
+        self.0
+            .add_redeemer(key.clone().into(), redeemer.clone().into());
     }
 
     pub fn get_redeemer(&self) -> LegacyRedeemerList {


### PR DESCRIPTION
The upcoming hardfork will switch to only the new map redeemer format. This PR makes that the new default within all the builders.

Fixes #366